### PR TITLE
feat(env): zod-validated environment loader (lib/env.ts)

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,2 +1,59 @@
-// Implemented in #2 (zod-validated env loader).
-export {};
+// Zod-validated environment loader (#2).
+//
+// Single point of entry for configuration. Every `lib/*` consumer that needs
+// an env var imports from this module — no `process.env` access elsewhere.
+// Validation runs once at module load (Vercel cold start) so misconfiguration
+// fails fast at boot, not mid-request.
+//
+// CLAUDE.md §4: error messages MUST never echo any env var value. Failure
+// messages are built strictly from `issue.path` + `issue.message` text.
+
+import { z } from "zod";
+
+const DEFAULT_MODEL_ALLOWLIST = ["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1"] as const;
+
+const csvList = (defaults: readonly string[]) =>
+  z
+    .string()
+    .optional()
+    .default(defaults.join(","))
+    .transform((csv) =>
+      csv
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+    .refine((arr) => arr.length > 0, "must contain at least one entry");
+
+const envSchema = z.object({
+  OPENAI_API_KEY: z.string().min(1),
+  RELAY_AUTH_TOKEN: z
+    .string()
+    .refine((s) => Buffer.byteLength(s, "utf8") >= 32, "must be at least 32 bytes"),
+  MODEL_ALLOWLIST: csvList(DEFAULT_MODEL_ALLOWLIST),
+  MAX_OUTPUT_TOKENS_CEILING: z.coerce.number().int().positive().default(4096),
+  REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().default(60_000),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+// Permissive env-shaped input. We deliberately do NOT type this as
+// `NodeJS.ProcessEnv` because `next/types/global.d.ts` augments that
+// interface with a required `NODE_ENV` key — `parseEnv` doesn't consume
+// `NODE_ENV` and forcing tests to set it would be noise. `process.env`
+// itself satisfies this signature, so the module-level call below still
+// type-checks against the real Node process env.
+export type EnvSource = Record<string, string | undefined>;
+
+export function parseEnv(source: EnvSource): Env {
+  const result = envSchema.safeParse(source);
+  if (result.success) return result.data;
+  // Redacted error: only path + message text from each zod issue. Never include
+  // `issue.input` / `issue.received` / any value-derived strings (CLAUDE.md §4).
+  const failures = result.error.issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ");
+  throw new Error(`Invalid environment: ${failures}`);
+}
+
+export const env: Env = parseEnv(process.env);

--- a/tests/setup-env.ts
+++ b/tests/setup-env.ts
@@ -1,0 +1,4 @@
+// Seeds process.env with minimal valid values BEFORE lib/env.ts loads in tests.
+// `??=` so an externally provided value (CI secret) is not overwritten.
+process.env.OPENAI_API_KEY ??= "test-openai-api-key";
+process.env.RELAY_AUTH_TOKEN ??= "x".repeat(32);

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { type EnvSource, parseEnv } from "../../lib/env.js";
+
+// A minimal-valid input — every behavior test starts from this and overrides
+// the one or two keys it cares about. Avoids re-declaring boilerplate per case.
+const minimalValid = {
+  OPENAI_API_KEY: "test-openai-api-key",
+  RELAY_AUTH_TOKEN: "x".repeat(32),
+} satisfies EnvSource;
+
+const expectThrow = (input: EnvSource): Error => {
+  let thrown: unknown;
+  try {
+    parseEnv(input);
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  return thrown as Error;
+};
+
+describe("parseEnv — required keys", () => {
+  // B1: OPENAI_API_KEY missing
+  it("throws when OPENAI_API_KEY is missing", () => {
+    const err = expectThrow({ RELAY_AUTH_TOKEN: "x".repeat(32) });
+    expect(err.message).toContain("OPENAI_API_KEY");
+  });
+
+  // B2: RELAY_AUTH_TOKEN missing
+  it("throws when RELAY_AUTH_TOKEN is missing", () => {
+    const err = expectThrow({ OPENAI_API_KEY: "k" });
+    expect(err.message).toContain("RELAY_AUTH_TOKEN");
+  });
+
+  // B3: empty OPENAI_API_KEY
+  it("throws when OPENAI_API_KEY is empty string", () => {
+    const err = expectThrow({ OPENAI_API_KEY: "", RELAY_AUTH_TOKEN: "x".repeat(32) });
+    expect(err.message).toContain("OPENAI_API_KEY");
+  });
+
+  // B4: RELAY_AUTH_TOKEN under 32 bytes
+  it("throws when RELAY_AUTH_TOKEN is 31 bytes (one byte under the floor)", () => {
+    const err = expectThrow({ OPENAI_API_KEY: "k", RELAY_AUTH_TOKEN: "x".repeat(31) });
+    expect(err.message).toContain("RELAY_AUTH_TOKEN");
+    expect(err.message).toContain("at least 32 bytes");
+  });
+
+  // B5: RELAY_AUTH_TOKEN exactly 32 bytes
+  it("accepts RELAY_AUTH_TOKEN at exactly 32 bytes", () => {
+    const env = parseEnv({ OPENAI_API_KEY: "k", RELAY_AUTH_TOKEN: "x".repeat(32) });
+    expect(env.RELAY_AUTH_TOKEN).toBe("x".repeat(32));
+  });
+
+  // B6: RELAY_AUTH_TOKEN multibyte — 8 chars × 4 bytes/char = 32 UTF-8 bytes
+  it("measures RELAY_AUTH_TOKEN length in bytes, not characters", () => {
+    const multibyte = "🦊".repeat(8); // 8 chars, 32 UTF-8 bytes
+    expect(multibyte.length).toBe(16); // JS char-length is surrogate-pair-counted (16)
+    expect(Buffer.byteLength(multibyte, "utf8")).toBe(32);
+    const env = parseEnv({ OPENAI_API_KEY: "k", RELAY_AUTH_TOKEN: multibyte });
+    expect(env.RELAY_AUTH_TOKEN).toBe(multibyte);
+  });
+});
+
+describe("parseEnv — defaults", () => {
+  // B7: MODEL_ALLOWLIST default
+  it("applies the default 4-model allowlist when MODEL_ALLOWLIST is undefined", () => {
+    const env = parseEnv(minimalValid);
+    expect(env.MODEL_ALLOWLIST).toEqual(["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1"]);
+  });
+
+  // B10: MAX_OUTPUT_TOKENS_CEILING default
+  it("defaults MAX_OUTPUT_TOKENS_CEILING to 4096 when undefined", () => {
+    const env = parseEnv(minimalValid);
+    expect(env.MAX_OUTPUT_TOKENS_CEILING).toBe(4096);
+  });
+
+  // B16: REQUEST_TIMEOUT_MS default
+  it("defaults REQUEST_TIMEOUT_MS to 60000 when undefined", () => {
+    const env = parseEnv(minimalValid);
+    expect(env.REQUEST_TIMEOUT_MS).toBe(60_000);
+  });
+});
+
+describe("parseEnv — MODEL_ALLOWLIST CSV", () => {
+  // B8: trim whitespace around entries
+  it("trims whitespace around each CSV entry", () => {
+    const env = parseEnv({ ...minimalValid, MODEL_ALLOWLIST: "a , b , c" });
+    expect(env.MODEL_ALLOWLIST).toEqual(["a", "b", "c"]);
+  });
+
+  // B9: filter empty entries (consecutive commas, trailing comma)
+  it("filters empty entries in the CSV (consecutive and trailing commas)", () => {
+    const env = parseEnv({ ...minimalValid, MODEL_ALLOWLIST: "a,,c," });
+    expect(env.MODEL_ALLOWLIST).toEqual(["a", "c"]);
+  });
+
+  // OQ-2: explicit empty string → zero-length list → throws
+  it("refuses an explicit empty MODEL_ALLOWLIST (OQ-2: zero-length list)", () => {
+    const err = expectThrow({ ...minimalValid, MODEL_ALLOWLIST: "" });
+    expect(err.message).toContain("MODEL_ALLOWLIST");
+    expect(err.message).toContain("at least one entry");
+  });
+
+  // OQ-2 cont.: only commas/whitespace → also zero-length → throws
+  it("refuses MODEL_ALLOWLIST that contains only commas and whitespace", () => {
+    const err = expectThrow({ ...minimalValid, MODEL_ALLOWLIST: " , , " });
+    expect(err.message).toContain("MODEL_ALLOWLIST");
+    expect(err.message).toContain("at least one entry");
+  });
+});
+
+describe("parseEnv — numeric coercion", () => {
+  // B11: numeric string coerced to number
+  it("coerces a numeric string MAX_OUTPUT_TOKENS_CEILING to a number", () => {
+    const env = parseEnv({ ...minimalValid, MAX_OUTPUT_TOKENS_CEILING: "8192" });
+    expect(env.MAX_OUTPUT_TOKENS_CEILING).toBe(8192);
+    expect(typeof env.MAX_OUTPUT_TOKENS_CEILING).toBe("number");
+  });
+
+  // B12: zero rejected (positive int requirement)
+  it("rejects MAX_OUTPUT_TOKENS_CEILING = 0", () => {
+    const err = expectThrow({ ...minimalValid, MAX_OUTPUT_TOKENS_CEILING: "0" });
+    expect(err.message).toContain("MAX_OUTPUT_TOKENS_CEILING");
+  });
+
+  // B13: negative rejected
+  it("rejects negative MAX_OUTPUT_TOKENS_CEILING", () => {
+    const err = expectThrow({ ...minimalValid, MAX_OUTPUT_TOKENS_CEILING: "-1" });
+    expect(err.message).toContain("MAX_OUTPUT_TOKENS_CEILING");
+  });
+
+  // B14: non-integer rejected (.int() refinement)
+  it("rejects non-integer MAX_OUTPUT_TOKENS_CEILING", () => {
+    const err = expectThrow({ ...minimalValid, MAX_OUTPUT_TOKENS_CEILING: "1.5" });
+    expect(err.message).toContain("MAX_OUTPUT_TOKENS_CEILING");
+  });
+
+  // B15: non-numeric rejected (z.coerce.number returns NaN, then .int() fails)
+  it("rejects non-numeric MAX_OUTPUT_TOKENS_CEILING", () => {
+    const err = expectThrow({ ...minimalValid, MAX_OUTPUT_TOKENS_CEILING: "abc" });
+    expect(err.message).toContain("MAX_OUTPUT_TOKENS_CEILING");
+  });
+
+  // Same coverage spot-check for REQUEST_TIMEOUT_MS — same schema branch
+  it("coerces and accepts a numeric string REQUEST_TIMEOUT_MS", () => {
+    const env = parseEnv({ ...minimalValid, REQUEST_TIMEOUT_MS: "30000" });
+    expect(env.REQUEST_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+describe("parseEnv — secret redaction", () => {
+  // B17: input value sentinel never appears in error message
+  it("does not echo input values in error messages (sentinel not leaked)", () => {
+    const sentinel = "secret-leak-marker-xyz-1234567890";
+    const err = expectThrow({
+      OPENAI_API_KEY: sentinel,
+      // RELAY_AUTH_TOKEN missing on purpose → triggers an error path that
+      // could leak OPENAI_API_KEY's value if zod's `received`/`input` were
+      // included in the formatted message.
+    });
+    expect(err.message).not.toContain(sentinel);
+    // Defense in depth: also check for substrings of the sentinel.
+    expect(err.message).not.toContain("secret-leak-marker");
+    expect(err.message).not.toContain("1234567890");
+  });
+
+  // B18: failing key path IS included in error message
+  it("includes the failing key path in the error message", () => {
+    const sentinel = "another-secret-zzz";
+    const err = expectThrow({
+      OPENAI_API_KEY: sentinel,
+      // RELAY_AUTH_TOKEN missing.
+    });
+    expect(err.message).toContain("RELAY_AUTH_TOKEN");
+    // Sanity: the prefix is present so consumers can grep for it.
+    expect(err.message).toContain("Invalid environment");
+  });
+
+  // Belt-and-suspenders: the same sentinel-leak guarantee for the other
+  // secret-class env var (RELAY_AUTH_TOKEN) — failing input value must not
+  // appear in the message even when its own validation triggers the error.
+  it("does not echo RELAY_AUTH_TOKEN value when it fails its own length check", () => {
+    // 31 ASCII bytes — one byte under the floor, triggers the byte-length
+    // refinement. The sentinel substring is something we can grep for in the
+    // error message to prove the value is not leaked.
+    const sentinel = "short-secret-leak-marker-abcdef"; // 31 bytes
+    expect(Buffer.byteLength(sentinel, "utf8")).toBe(31);
+    const err = expectThrow({ OPENAI_API_KEY: "k", RELAY_AUTH_TOKEN: sentinel });
+    expect(err.message).not.toContain(sentinel);
+    expect(err.message).not.toContain("short-secret-leak-marker");
+    expect(err.message).toContain("RELAY_AUTH_TOKEN");
+    expect(err.message).toContain("at least 32 bytes");
+  });
+});

--- a/tests/unit/scaffold.test.ts
+++ b/tests/unit/scaffold.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "vitest";
-
-describe("scaffold smoke — vitest is wired", () => {
-  it("runs a trivial assertion", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -3,12 +3,17 @@ import { defineWorkspace } from "vitest/config";
 // Vitest 2 uses the workspace API (Vitest 3's `projects` is unavailable on
 // the `^2` line pinned in ARCHITECTURE.md §6 / plan OQ-5). The two named
 // projects below back `pnpm test:unit` and `pnpm test:integration`.
+//
+// `setupFiles` registers `tests/setup-env.ts` in BOTH projects so that any
+// test that transitively imports `lib/env.ts` has minimal valid `process.env`
+// values seeded before module-level `parseEnv(process.env)` runs (per OQ-5).
 export default defineWorkspace([
   {
     test: {
       name: "unit",
       include: ["tests/unit/**/*.test.ts"],
       environment: "node",
+      setupFiles: ["./tests/setup-env.ts"],
     },
   },
   {
@@ -16,6 +21,7 @@ export default defineWorkspace([
       name: "integration",
       include: ["tests/integration/**/*.test.ts"],
       environment: "node",
+      setupFiles: ["./tests/setup-env.ts"],
     },
   },
 ]);


### PR DESCRIPTION
Closes #2

Implements the v1 zod-validated env loader per the plan in #2.

## Phases (committed)
1. `a08ea00` — `feat(env): add zod-validated environment loader (lib/env.ts)`
2. `a801668` — `test(env): add unit tests for parseEnv (defaults, CSV, coercion, redaction)`

## Verification
All 7 verify commands pass — see gate:build comment for the table and `$STATE_DIR/build.log` for per-command output. **22 unit tests passing** (≥ 18 required by plan §6 behavior inventory).

## Pattern established
`lib/env.ts` exports `parseEnv` (pure) + `env` (module-level constant) + `Env` (type) — sets the template for #3 (auth) and #4 (openai-client + openai-chat) to follow.