### PR TITLE
feat(tool): openai_chat MCP tool + OpenAI client

### DIFF
--- a/lib/openai-client.ts
+++ b/lib/openai-client.ts
@@ -1,2 +1,18 @@
-// Implemented in #4 (openai SDK singleton).
-export {};
+// OpenAI SDK singleton (#4).
+//
+// One client instance per Vercel worker (cold start), reused across every
+// request handled by `lib/tools/openai-chat.ts`. Constructor reads from the
+// validated `env` module — never directly from `process.env` (CLAUDE.md §4 /
+// plan §2).
+//
+// `timeout` is per-request and applies to non-streaming calls; streaming
+// calls additionally pass `maxRetries: 0` at the call site to prevent
+// mid-stream replays from emitting duplicated text (CLAUDE.md §4).
+
+import OpenAI from "openai";
+import { env } from "./env.js";
+
+export const openai = new OpenAI({
+  apiKey: env.OPENAI_API_KEY,
+  timeout: env.REQUEST_TIMEOUT_MS,
+});

--- a/lib/tools/openai-chat.ts
+++ b/lib/tools/openai-chat.ts
@@ -136,9 +136,17 @@ function mapOpenAIError(err: unknown): MappedError {
 // --- handler --------------------------------------------------------------
 
 export async function openaiChatHandler(
-  input: OpenaiChatInput,
+  rawInput: unknown,
   extra: { signal?: AbortSignal } = {},
 ): Promise<OpenaiChatResult> {
+  // Defensive validation. In production the mcp-handler runtime parses
+  // the request against `inputSchema` before invoking the handler, but we
+  // re-parse here so the handler is also safe to call directly (tests and
+  // any future direct-call paths). zod errors propagate to the caller —
+  // they are not caught and re-mapped to `bad_request`, because schema
+  // violations are caller bugs, not upstream errors.
+  const input: OpenaiChatInput = inputSchema.parse(rawInput);
+
   // Local AbortController so we can both observe the caller's signal and
   // reuse the abort path inside the iterator if needed in the future.
   const ac = new AbortController();

--- a/lib/tools/openai-chat.ts
+++ b/lib/tools/openai-chat.ts
@@ -1,2 +1,227 @@
-// Implemented in #4 (openai_chat tool handler + zod schema).
-export {};
+// openai_chat MCP tool handler (#4).
+//
+// v1 single tool per ARCHITECTURE.md §3-§4. Steps the handler performs:
+//   1. zod-validate input (.strict, allowlist refine, max_tokens clamp)
+//   2. wire AbortController to extra.signal so MCP cancellation propagates
+//   3. call openai.chat.completions.create({ stream: true,
+//        stream_options: { include_usage: true } }, { signal, maxRetries: 0 })
+//   4. accumulate delta.content, capture finish_reason and usage
+//   5. return CallToolResult-shaped object with safe metadata only
+//
+// CLAUDE.md §4 invariants:
+//   • streaming MUST set maxRetries: 0 (no mid-stream replay → no duplicates)
+//   • error results MUST NEVER echo the raw upstream body / prompt / headers
+//   • the only token-comparison rule (=== forbidden) lives in lib/auth.ts
+//     and is unrelated here — surfaced via comment for completeness only
+
+import OpenAI from "openai";
+import { z } from "zod";
+import { env } from "../env.js";
+import { openai } from "../openai-client.js";
+
+// --- input schema ---------------------------------------------------------
+
+const inputSchema = z
+  .object({
+    model: z.string().refine((m) => env.MODEL_ALLOWLIST.includes(m), {
+      message: "model not in allowlist",
+    }),
+    messages: z
+      .array(
+        z.object({
+          role: z.enum(["system", "user", "assistant"]),
+          content: z.string(),
+        }),
+      )
+      .min(1),
+    temperature: z.number().min(0).max(2).optional(),
+    // Silently clamp to env.MAX_OUTPUT_TOKENS_CEILING (transform, not throw).
+    // The pre-transform schema enforces int-positive; the post-transform
+    // value is `number | undefined` (undefined when caller omitted it).
+    max_tokens: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .transform((n) => (n === undefined ? undefined : Math.min(n, env.MAX_OUTPUT_TOKENS_CEILING))),
+    top_p: z.number().min(0).max(1).optional(),
+    stop: z.union([z.string(), z.array(z.string())]).optional(),
+  })
+  .strict();
+
+export type OpenaiChatInput = z.infer<typeof inputSchema>;
+
+// --- result shape ---------------------------------------------------------
+
+export type OpenaiUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+export type OpenaiChatStructured = {
+  model: string;
+  // Optional fields: under tsconfig `exactOptionalPropertyTypes` the result
+  // builder MUST omit these keys entirely when unset (rather than assigning
+  // `undefined`). The "?:" markers below describe exactly that contract.
+  usage?: OpenaiUsage;
+  finish_reason?: string;
+  code?: string;
+  retryAfter?: number;
+};
+
+export type OpenaiChatResult = {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: OpenaiChatStructured;
+  isError: boolean;
+};
+
+// --- error mapping --------------------------------------------------------
+
+type MappedError = {
+  code: string;
+  message: string;
+  retryAfter?: number;
+};
+
+function mapOpenAIError(err: unknown): MappedError {
+  if (err instanceof OpenAI.APIError) {
+    const status = err.status;
+
+    if (status === 401 || status === 403) {
+      return { code: "auth", message: "Authentication failed" };
+    }
+
+    if (status === 429) {
+      const headerVal = err.headers?.get?.("retry-after") ?? "";
+      const parsed = Number(headerVal);
+      const retryAfter = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+      return retryAfter !== undefined
+        ? { code: "rate_limited", message: "Rate limited by upstream", retryAfter }
+        : { code: "rate_limited", message: "Rate limited by upstream" };
+    }
+
+    if (status === 400) {
+      // `code` is on APIError itself (string | null | undefined per the SDK
+      // d.ts). It surfaces the OpenAI error body's `error.code` field for
+      // 400-class errors (context_length_exceeded, content_filter, ...).
+      const apiCode = err.code;
+      if (apiCode === "context_length_exceeded") {
+        return { code: "context_length", message: "Context length exceeded" };
+      }
+      if (apiCode === "content_filter" || /content policy|safety/i.test(err.message)) {
+        return { code: "content_policy", message: "Content policy rejected" };
+      }
+      return { code: "bad_request", message: "Bad request" };
+    }
+
+    if (typeof status === "number" && status >= 500) {
+      return { code: "upstream_error", message: "Upstream server error" };
+    }
+
+    if (status === undefined) {
+      // APIConnectionError / APIUserAbortError have status: undefined.
+      return { code: "upstream_error", message: "Network or connection error" };
+    }
+
+    // Other 4xx — fall through.
+    return { code: "bad_request", message: "Bad request" };
+  }
+
+  // Non-APIError: network failure thrown outside the SDK retry path, or any
+  // other unexpected throwable. Map to generic upstream_error.
+  return { code: "upstream_error", message: "Network or unknown error" };
+}
+
+// --- handler --------------------------------------------------------------
+
+export async function openaiChatHandler(
+  input: OpenaiChatInput,
+  extra: { signal?: AbortSignal } = {},
+): Promise<OpenaiChatResult> {
+  // Local AbortController so we can both observe the caller's signal and
+  // reuse the abort path inside the iterator if needed in the future.
+  const ac = new AbortController();
+  if (extra.signal) {
+    if (extra.signal.aborted) {
+      ac.abort();
+    } else {
+      extra.signal.addEventListener("abort", () => ac.abort(), { once: true });
+    }
+  }
+
+  try {
+    // Build the request body without spreading-undefined for optional keys
+    // — the OpenAI SDK types are `number | null` (not `| undefined`) under
+    // tsconfig `exactOptionalPropertyTypes`. We omit each optional key when
+    // the caller did not supply it, rather than passing `undefined`.
+    const stream = await openai.chat.completions.create(
+      {
+        model: input.model,
+        messages: input.messages,
+        ...(input.temperature !== undefined ? { temperature: input.temperature } : {}),
+        ...(input.max_tokens !== undefined ? { max_tokens: input.max_tokens } : {}),
+        ...(input.top_p !== undefined ? { top_p: input.top_p } : {}),
+        ...(input.stop !== undefined ? { stop: input.stop } : {}),
+        stream: true,
+        stream_options: { include_usage: true },
+      },
+      { signal: ac.signal, maxRetries: 0 },
+    );
+
+    let accumulated = "";
+    let usage: OpenaiUsage | undefined;
+    let finishReason: string | undefined;
+
+    for await (const chunk of stream) {
+      const choice = chunk.choices?.[0];
+      const delta = choice?.delta?.content;
+      if (delta) accumulated += delta;
+      const fr = choice?.finish_reason;
+      if (fr) finishReason = fr;
+      if (chunk.usage) {
+        usage = {
+          prompt_tokens: chunk.usage.prompt_tokens,
+          completion_tokens: chunk.usage.completion_tokens,
+          total_tokens: chunk.usage.total_tokens,
+        };
+      }
+    }
+
+    // Build structuredContent without injecting `undefined` for optional
+    // keys (exactOptionalPropertyTypes). Spread the optional fields only
+    // when defined.
+    const structuredContent: OpenaiChatStructured = {
+      model: input.model,
+      ...(usage !== undefined ? { usage } : {}),
+      ...(finishReason !== undefined ? { finish_reason: finishReason } : {}),
+    };
+
+    return {
+      content: [{ type: "text", text: accumulated }],
+      structuredContent,
+      isError: false,
+    };
+  } catch (err) {
+    const mapped = mapOpenAIError(err);
+    const structuredContent: OpenaiChatStructured = {
+      model: input.model,
+      code: mapped.code,
+      ...(mapped.retryAfter !== undefined ? { retryAfter: mapped.retryAfter } : {}),
+    };
+    return {
+      content: [{ type: "text", text: mapped.message }],
+      structuredContent,
+      isError: true,
+    };
+  }
+}
+
+// --- tool descriptor ------------------------------------------------------
+
+export const openaiChatTool = {
+  name: "openai_chat",
+  description: "Invoke OpenAI Chat Completions and return the accumulated assistant message.",
+  inputSchema,
+  handler: openaiChatHandler,
+} as const;

--- a/tests/unit/openai-chat.test.ts
+++ b/tests/unit/openai-chat.test.ts
@@ -1,0 +1,662 @@
+// Unit tests for `lib/tools/openai-chat.ts` — covers all 25 behaviors from
+// plan §6 (B1-B25). Single file; 5 describe blocks per the plan layout.
+//
+// Test infrastructure:
+//   • MSW (`setupServer`) intercepts POST https://api.openai.com/v1/chat/completions
+//     so the openai SDK code path is exercised end-to-end without ever making
+//     a real network request. The SDK module itself is NEVER mocked — that is
+//     the SDK-upgrade-detection contract (CLAUDE.md §7).
+//   • SSE responses are emitted as `text/event-stream` ReadableStreams so the
+//     SDK's async-iterator path runs exactly as it would against OpenAI proper.
+//   • `tests/setup-env.ts` (workspace setupFiles) seeds OPENAI_API_KEY +
+//     RELAY_AUTH_TOKEN BEFORE `lib/env.ts` parses, so MODEL_ALLOWLIST and
+//     MAX_OUTPUT_TOKENS_CEILING fall back to defaults (4096 ceiling).
+//
+// Secret-leakage guard (B25): `assertNoSecretLeak(result)` MUST be called on
+// every result to assert that neither OPENAI_API_KEY nor RELAY_AUTH_TOKEN
+// appears anywhere in the returned object. CLAUDE.md §4 forbids echoing
+// secrets into tool output / logs.
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../lib/env.js";
+import type {
+  openaiChatHandler as OpenaiChatHandlerType,
+  OpenaiChatResult,
+  openaiChatTool as OpenaiChatToolType,
+} from "../../lib/tools/openai-chat.js";
+
+// --- shared MSW server lifecycle -----------------------------------------
+//
+// IMPORTANT: the openai SDK captures a `fetch` reference at construction
+// time inside `lib/openai-client.ts`'s module-level `new OpenAI({...})`.
+// If `setupServer().listen()` runs AFTER that capture, MSW's interceptor
+// patches `globalThis.fetch` but the SDK still holds the unpatched
+// reference — so requests bypass MSW and hit the real api.openai.com,
+// returning a real 401 (because the test API key is fake) and breaking
+// the entire test file.
+//
+// Fix: MSW listens FIRST in beforeAll, then the handler + client modules
+// are dynamically imported. By the time `new OpenAI({...})` runs and
+// captures fetch, MSW has already monkey-patched globalThis.fetch.
+const server = setupServer();
+let openaiChatHandler: typeof OpenaiChatHandlerType;
+let openaiChatTool: typeof OpenaiChatToolType;
+
+beforeAll(async () => {
+  server.listen({ onUnhandledRequest: "error" });
+  // Dynamic import AFTER MSW is listening so the SDK constructor captures
+  // the MSW-patched fetch reference. Otherwise every test in this file
+  // hits the real api.openai.com and surfaces real 401 errors.
+  const mod = await import("../../lib/tools/openai-chat.js");
+  openaiChatHandler = mod.openaiChatHandler;
+  openaiChatTool = mod.openaiChatTool;
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// --- helpers --------------------------------------------------------------
+
+const ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
+/**
+ * Build a `text/event-stream` body from a list of pre-stringified JSON chunks.
+ * Each chunk becomes one `data: <json>\n\n` SSE event, and a terminal
+ * `data: [DONE]\n\n` is appended. The OpenAI SDK's streaming iterator
+ * recognizes this exact framing.
+ */
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(`data: ${chunks[i]}\n\n`));
+        i++;
+      } else {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      }
+    },
+  });
+}
+
+function sseResponse(chunks: string[]) {
+  return new HttpResponse(sseStream(chunks), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/**
+ * Pretty-print a result and assert that neither OPENAI_API_KEY nor
+ * RELAY_AUTH_TOKEN appears anywhere in it. Plan §6 B25.
+ */
+function assertNoSecretLeak(result: OpenaiChatResult | unknown): void {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain(env.OPENAI_API_KEY);
+  expect(serialized).not.toContain(env.RELAY_AUTH_TOKEN);
+}
+
+const VALID_MODEL = "gpt-4o-mini";
+const VALID_MESSAGES = [{ role: "user" as const, content: "say hi" }];
+
+// `openaiChatHandler` accepts `unknown` and validates via zod internally,
+// so tests can pass arbitrary shapes without TS casts. Negative cases
+// rely on `inputSchema.parse()` throwing inside the handler (the throw
+// propagates because schema-violation is a CALLER bug, not an upstream
+// error — see the handler comment for rationale).
+
+// =========================================================================
+// A: Input Validation (B1-B6)
+// =========================================================================
+
+describe("openai_chat — input validation (.strict, types, ranges)", () => {
+  // B1
+  it("D1: rejects when `model` is missing", async () => {
+    await expect(openaiChatHandler({ messages: VALID_MESSAGES })).rejects.toThrow();
+  });
+
+  // B2
+  it("D2: rejects when `messages` is missing", async () => {
+    await expect(openaiChatHandler({ model: VALID_MODEL })).rejects.toThrow();
+  });
+
+  // B3
+  it("D3: rejects when `messages` is empty", async () => {
+    await expect(openaiChatHandler({ model: VALID_MODEL, messages: [] })).rejects.toThrow();
+  });
+
+  // B4
+  it("D4: rejects `temperature` above 2", async () => {
+    await expect(
+      openaiChatHandler({
+        model: VALID_MODEL,
+        messages: VALID_MESSAGES,
+        temperature: 3,
+      }),
+    ).rejects.toThrow();
+  });
+
+  // B5
+  it("D5: rejects `top_p` above 1", async () => {
+    await expect(
+      openaiChatHandler({
+        model: VALID_MODEL,
+        messages: VALID_MESSAGES,
+        top_p: 2,
+      }),
+    ).rejects.toThrow();
+  });
+
+  // B6 — `.strict()` rejects unknown keys (e.g. callers attempting to pass
+  // through `tools: [...]` which is explicitly NOT in v1 scope).
+  it("D6: rejects unknown extra keys (strict schema)", async () => {
+    await expect(
+      openaiChatHandler({
+        model: VALID_MODEL,
+        messages: VALID_MESSAGES,
+        unknownKey: "x",
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+// =========================================================================
+// B: Allowlist + Clamp (B7-B10)
+// =========================================================================
+
+describe("openai_chat — allowlist + max_tokens clamp", () => {
+  // B7
+  it("P1: accepts a model in env.MODEL_ALLOWLIST", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          JSON.stringify({
+            choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+          }),
+        ]),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL, // "gpt-4o-mini" is in DEFAULT_MODEL_ALLOWLIST
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(false);
+    assertNoSecretLeak(result);
+  });
+
+  // B8
+  it("D1: rejects a model NOT in env.MODEL_ALLOWLIST", async () => {
+    await expect(
+      openaiChatHandler({
+        model: "gpt-9999-not-real",
+        messages: VALID_MESSAGES,
+      }),
+    ).rejects.toThrow(/not in allowlist|not in/i);
+  });
+
+  // B9 — clamp under: passes through unchanged.
+  it("P1: passes max_tokens unchanged when ≤ ceiling", async () => {
+    let observedMaxTokens: number | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        const body = (await request.json()) as { max_tokens?: number };
+        observedMaxTokens = body.max_tokens;
+        return sseResponse([
+          JSON.stringify({
+            choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+          }),
+        ]);
+      }),
+    );
+    await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+      max_tokens: 100, // well under the 4096 default ceiling
+    });
+    expect(observedMaxTokens).toBe(100);
+  });
+
+  // B10 — clamp over: silently capped to env.MAX_OUTPUT_TOKENS_CEILING (no throw).
+  it("N1: silently clamps max_tokens to ceiling when over", async () => {
+    let observedMaxTokens: number | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        const body = (await request.json()) as { max_tokens?: number };
+        observedMaxTokens = body.max_tokens;
+        return sseResponse([
+          JSON.stringify({
+            choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+          }),
+        ]);
+      }),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+      max_tokens: 999_999,
+    });
+    expect(result.isError).toBe(false); // not rejected
+    expect(observedMaxTokens).toBe(env.MAX_OUTPUT_TOKENS_CEILING);
+  });
+});
+
+// =========================================================================
+// C: Streaming (B11-B15)
+// =========================================================================
+
+describe("openai_chat — streaming accumulation, usage, finish_reason, tool_calls, maxRetries", () => {
+  // B11 — concatenates delta.content from all chunks
+  // B12 — last chunk's `usage` populates structuredContent
+  // B13 — last chunk's `finish_reason` populates structuredContent
+  it("P1: accumulates delta.content across chunks and captures usage + finish_reason", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          JSON.stringify({ choices: [{ delta: { content: "Hello" } }] }),
+          JSON.stringify({ choices: [{ delta: { content: " " } }] }),
+          JSON.stringify({
+            choices: [{ delta: { content: "world" }, finish_reason: "stop" }],
+          }),
+          // OpenAI emits a separate trailing chunk with `usage` when
+          // `stream_options: { include_usage: true }` is set; it has no
+          // `choices`. We model that here.
+          JSON.stringify({
+            choices: [],
+            usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+          }),
+        ]),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("Hello world");
+    expect(result.structuredContent.usage).toEqual({
+      prompt_tokens: 4,
+      completion_tokens: 2,
+      total_tokens: 6,
+    });
+    expect(result.structuredContent.finish_reason).toBe("stop");
+    expect(result.structuredContent.model).toBe(VALID_MODEL);
+    assertNoSecretLeak(result);
+  });
+
+  // B14 — finish_reason "tool_calls" is surfaced; the text payload may be
+  // empty and we do NOT serialize tool calls (out of v1 scope).
+  it("N1: surfaces finish_reason 'tool_calls' without serializing tool calls", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          // OpenAI sends incremental tool_calls in delta.tool_calls but no
+          // delta.content. The handler ignores tool_calls and returns empty
+          // text with the finish_reason surfaced.
+          JSON.stringify({
+            choices: [
+              {
+                delta: {
+                  tool_calls: [{ index: 0, function: { name: "lookup" } }],
+                },
+              },
+            ],
+          }),
+          JSON.stringify({
+            choices: [{ delta: {}, finish_reason: "tool_calls" }],
+          }),
+        ]),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("");
+    expect(result.structuredContent.finish_reason).toBe("tool_calls");
+    assertNoSecretLeak(result);
+  });
+
+  // B15 — maxRetries: 0 verified by counting upstream calls on a 500.
+  // Default SDK maxRetries is 2 → 3 calls total. We assert exactly 1 call
+  // — proving the streaming call site overrode to maxRetries: 0.
+  it("D1: streaming call performs exactly one upstream request on 5xx (maxRetries: 0)", async () => {
+    let callCount = 0;
+    server.use(
+      http.post(ENDPOINT, () => {
+        callCount++;
+        return new HttpResponse("upstream blew up", { status: 500 });
+      }),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    expect(callCount).toBe(1);
+    assertNoSecretLeak(result);
+  });
+});
+
+// =========================================================================
+// D: Abort Propagation (B16)
+// =========================================================================
+
+describe("openai_chat — abort propagation", () => {
+  // B16a: signal already aborted before the handler runs → handler short-
+  // circuits the SDK call. The SDK throws APIUserAbortError, which maps to
+  // upstream_error per plan OQ-5.
+  it("D1: short-circuits when extra.signal is already aborted", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          JSON.stringify({
+            choices: [{ delta: { content: "x" }, finish_reason: "stop" }],
+          }),
+        ]),
+      ),
+    );
+    const ac = new AbortController();
+    ac.abort();
+    const result = await openaiChatHandler(
+      { model: VALID_MODEL, messages: VALID_MESSAGES },
+      { signal: ac.signal },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    assertNoSecretLeak(result);
+  });
+
+  // B16b: deferred abort during the stream → handler's listener fires on
+  // the local AbortController and the SDK iteration ends in error.
+  it("D2: aborts mid-stream when extra.signal is aborted after start", async () => {
+    server.use(
+      // A handler that never resolves its body — it returns a stream that
+      // pushes a single chunk and then waits forever. The abort below
+      // terminates the iteration before the close event.
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                const enc = new TextEncoder();
+                controller.enqueue(
+                  enc.encode(
+                    `data: ${JSON.stringify({
+                      choices: [{ delta: { content: "partial" } }],
+                    })}\n\n`,
+                  ),
+                );
+                // intentionally do not close — caller's abort must terminate
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      ),
+    );
+    const ac = new AbortController();
+    const promise = openaiChatHandler(
+      { model: VALID_MODEL, messages: VALID_MESSAGES },
+      { signal: ac.signal },
+    );
+    // Give the SDK a microtask to begin streaming, then abort.
+    await Promise.resolve();
+    ac.abort();
+    const result = await promise;
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    assertNoSecretLeak(result);
+  });
+});
+
+// =========================================================================
+// E: Error Mapping + Secret Guard (B17-B25)
+// =========================================================================
+
+describe("openai_chat — error mapping (auth, rate_limited, context_length, content_policy, upstream_error, bad_request)", () => {
+  // B17 — 401 → auth
+  it("D1: maps upstream 401 to code: 'auth'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "no key" } }), {
+            status: 401,
+          }),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("auth");
+    expect(result.content[0]?.text).toBe("Authentication failed");
+    assertNoSecretLeak(result);
+  });
+
+  // B18 — 403 → auth (same code; permission-denied also maps here)
+  it("D2: maps upstream 403 to code: 'auth'", async () => {
+    server.use(
+      http.post(ENDPOINT, () => new HttpResponse(JSON.stringify({ error: {} }), { status: 403 })),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("auth");
+    assertNoSecretLeak(result);
+  });
+
+  // B19 — 429 + retry-after header → rate_limited + retryAfter
+  it("D3: maps upstream 429 to code: 'rate_limited' with retryAfter from header", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "slow down" } }), {
+            status: 429,
+            headers: { "retry-after": "30" },
+          }),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("rate_limited");
+    expect(result.structuredContent.retryAfter).toBe(30);
+    assertNoSecretLeak(result);
+  });
+
+  // B19b — 429 without retry-after header → rate_limited but retryAfter omitted.
+  // (Confirms exactOptionalPropertyTypes contract: undefined fields are
+  // omitted from structuredContent rather than serialized as `"retryAfter":undefined`.)
+  it("N1: 429 without retry-after omits retryAfter from structuredContent", async () => {
+    server.use(
+      http.post(ENDPOINT, () => new HttpResponse(JSON.stringify({ error: {} }), { status: 429 })),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("rate_limited");
+    expect(result.structuredContent.retryAfter).toBeUndefined();
+    expect("retryAfter" in result.structuredContent).toBe(false);
+    assertNoSecretLeak(result);
+  });
+
+  // B20 — 400 with code "context_length_exceeded" → context_length
+  it("D4: maps 400 context_length_exceeded to code: 'context_length'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              error: {
+                code: "context_length_exceeded",
+                message: "you sent too many tokens",
+              },
+            }),
+            { status: 400 },
+          ),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("context_length");
+    assertNoSecretLeak(result);
+  });
+
+  // B21 — 400 with code "content_filter" → content_policy
+  it("D5: maps 400 content_filter to code: 'content_policy'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              error: { code: "content_filter", message: "blocked by safety" },
+            }),
+            { status: 400 },
+          ),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("content_policy");
+    assertNoSecretLeak(result);
+  });
+
+  // B22 — 500 → upstream_error
+  it("D6: maps 500 to code: 'upstream_error'", async () => {
+    server.use(
+      http.post(ENDPOINT, () => new HttpResponse(JSON.stringify({ error: {} }), { status: 500 })),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    assertNoSecretLeak(result);
+  });
+
+  // B23 — network failure (fetch error) → upstream_error
+  it("D7: maps a fetch-level network failure to code: 'upstream_error'", async () => {
+    server.use(http.post(ENDPOINT, () => HttpResponse.error()));
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    assertNoSecretLeak(result);
+  });
+
+  // B24 — other 4xx (422) → bad_request
+  it("D8: maps an unrecognized 4xx (422) to code: 'bad_request'", async () => {
+    server.use(
+      http.post(ENDPOINT, () => new HttpResponse(JSON.stringify({ error: {} }), { status: 422 })),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("bad_request");
+    assertNoSecretLeak(result);
+  });
+
+  // B24b — 400 with no recognizable code → bad_request (the fall-through
+  // branch inside the 400 arm).
+  it("D9: maps a generic 400 (no special code) to code: 'bad_request'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "nope" } }), {
+            status: 400,
+          }),
+      ),
+    );
+    const result = await openaiChatHandler({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("bad_request");
+    assertNoSecretLeak(result);
+  });
+
+  // B25 — secret-leakage guard: assert that EVERY error path's serialized
+  // result excludes both env secrets. This is also asserted in each branch
+  // above via assertNoSecretLeak(); this aggregate check is a belt-and-
+  // suspenders guarantee that no future branch escapes the guard.
+  it("D10: no error result echoes OPENAI_API_KEY or RELAY_AUTH_TOKEN", async () => {
+    const errorScenarios: Array<() => HttpResponse<string>> = [
+      () =>
+        new HttpResponse(JSON.stringify({ error: { message: env.OPENAI_API_KEY } }), {
+          status: 401,
+        }),
+      () =>
+        new HttpResponse(JSON.stringify({ error: { message: env.OPENAI_API_KEY } }), {
+          status: 500,
+        }),
+      () =>
+        new HttpResponse(
+          JSON.stringify({
+            error: {
+              code: "context_length_exceeded",
+              message: env.OPENAI_API_KEY,
+            },
+          }),
+          { status: 400 },
+        ),
+    ];
+    for (const responseFactory of errorScenarios) {
+      server.resetHandlers();
+      server.use(http.post(ENDPOINT, () => responseFactory()));
+      const result = await openaiChatHandler({
+        model: VALID_MODEL,
+        messages: VALID_MESSAGES,
+      });
+      expect(result.isError).toBe(true);
+      assertNoSecretLeak(result);
+    }
+  });
+});
+
+// =========================================================================
+// F: Tool descriptor surface
+// =========================================================================
+
+describe("openai_chat — exported tool descriptor", () => {
+  it("P1: exports a descriptor with name, description, inputSchema, and handler", () => {
+    expect(openaiChatTool.name).toBe("openai_chat");
+    expect(typeof openaiChatTool.description).toBe("string");
+    expect(openaiChatTool.description.length).toBeGreaterThan(0);
+    // inputSchema is the same zod schema the handler uses internally; we
+    // assert by parsing a known-good input through it.
+    const parsed = openaiChatTool.inputSchema.safeParse({
+      model: VALID_MODEL,
+      messages: VALID_MESSAGES,
+    });
+    expect(parsed.success).toBe(true);
+    expect(openaiChatTool.handler).toBe(openaiChatHandler);
+  });
+});


### PR DESCRIPTION
Closes #4

Implements the v1 single MCP tool (openai_chat) and the OpenAI SDK singleton it depends on per the plan in #4.

## Phases (committed)
1. `6c36fcd` — `feat(openai-client): add OpenAI SDK singleton (lib/openai-client.ts)`
2. `7331893` — `feat(tool): add openai_chat MCP tool handler (lib/tools/openai-chat.ts)`
3. `2c5d250` — `test(openai-chat): add unit tests (validation, allowlist, clamp, errors, streaming, abort)`

## Verification
All 7 verify commands pass — see gate:build comment for the table. **60 unit tests passing** (22 env + 11 auth + 27 openai-chat).