### PR TITLE
feat(route): MCP route handler + integration tests

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -1,12 +1,49 @@
+// MCP route entry point (#5).
+//
+// Single route per ARCHITECTURE.md §5 / CLAUDE.md §5. The Next.js dynamic
+// `[transport]` segment lets `mcp-handler` route by transport type (Streamable
+// HTTP for v1; SSE deprecated upstream).
+//
+// Wiring layers, outermost first:
+//   1. `withMcpAuth(handler, verifyToken, { required: true, requiredScopes })`
+//      — Bearer-token gate. Unauthenticated requests get 401 +
+//        `WWW-Authenticate: Bearer ...` + a `/.well-known/oauth-protected-resource`
+//        discovery URL pointer. Authenticated requests reach the inner handler.
+//   2. `createMcpHandler((server) => server.tool(...))` — registers exactly one
+//      tool: `openai_chat` (v1 scope). Routes JSON-RPC `tools/list` and
+//      `tools/call` internally.
+//
+// CLAUDE.md §9 invariants enforced here:
+//   • `withMcpAuth` wrapper is applied — without it, the route would accept
+//     unauthenticated traffic.
+//   • `export const maxDuration = 300` — defense in depth with vercel.json,
+//     so the route does not silently fall back to the dashboard default.
+//   • `export const runtime = "nodejs"` — Edge runtime would hit the 25s TTFB
+//     cap and break streaming chat completions.
+
+import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import { verifyToken } from "../../../lib/auth.js";
+import { openaiChatTool } from "../../../lib/tools/openai-chat.js";
+
+const handler = createMcpHandler((server) => {
+  // `server.tool(name, description, paramsSchema, cb)` — the schema parameter
+  // is the Zod RawShape (i.e. `inputSchema.shape`), not the full Zod object.
+  // mcp-handler reconstructs the schema internally; passing the shape is the
+  // documented signature in @modelcontextprotocol/sdk's McpServer.
+  server.tool(
+    openaiChatTool.name,
+    openaiChatTool.description,
+    openaiChatTool.inputSchema.shape,
+    (args, extra) => openaiChatTool.handler(args, extra),
+  );
+});
+
+const wrapped = withMcpAuth(handler, verifyToken, {
+  required: true,
+  requiredScopes: ["openai:chat"],
+});
+
 export const runtime = "nodejs";
 export const maxDuration = 300;
 
-const placeholder = (): Response =>
-  new Response(JSON.stringify({ error: "not_implemented", message: "Wired in #5" }), {
-    status: 501,
-    headers: { "content-type": "application/json" },
-  });
-
-export const GET = placeholder;
-export const POST = placeholder;
-export const DELETE = placeholder;
+export { wrapped as GET, wrapped as POST, wrapped as DELETE };

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -25,18 +25,31 @@ import { createMcpHandler, withMcpAuth } from "mcp-handler";
 import { verifyToken } from "../../../lib/auth.js";
 import { openaiChatTool } from "../../../lib/tools/openai-chat.js";
 
-const handler = createMcpHandler((server) => {
-  // `server.tool(name, description, paramsSchema, cb)` — the schema parameter
-  // is the Zod RawShape (i.e. `inputSchema.shape`), not the full Zod object.
-  // mcp-handler reconstructs the schema internally; passing the shape is the
-  // documented signature in @modelcontextprotocol/sdk's McpServer.
-  server.tool(
-    openaiChatTool.name,
-    openaiChatTool.description,
-    openaiChatTool.inputSchema.shape,
-    (args, extra) => openaiChatTool.handler(args, extra),
-  );
-});
+const handler = createMcpHandler(
+  (server) => {
+    // `server.tool(name, description, paramsSchema, cb)` — the schema
+    // parameter is the Zod RawShape (i.e. `inputSchema.shape`), not the full
+    // Zod object. mcp-handler reconstructs the schema internally; passing
+    // the shape is the documented signature in @modelcontextprotocol/sdk's
+    // McpServer.
+    server.tool(
+      openaiChatTool.name,
+      openaiChatTool.description,
+      openaiChatTool.inputSchema.shape,
+      (args, extra) => openaiChatTool.handler(args, extra),
+    );
+  },
+  {},
+  {
+    // Our route is `app/api/[transport]/route.ts` so Next maps the URL
+    // pathname to `/api/<transport>` (e.g. `/api/mcp`). Without `basePath`,
+    // mcp-handler compares against `/mcp` only and rejects every request
+    // with "url not matched". Setting `basePath: "/api"` derives
+    // `/api/mcp`, `/api/sse`, and `/api/message` — matching what Next.js
+    // serves.
+    basePath: "/api",
+  },
+);
 
 const wrapped = withMcpAuth(handler, verifyToken, {
   required: true,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -15,12 +15,14 @@
 // tokens this tradeoff is acceptable (plan §2, OQ-1).
 
 import { timingSafeEqual } from "node:crypto";
+import type { AuthInfo as SdkAuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { env } from "./env.js";
 
-export type AuthInfo = {
-  clientId: string;
-  scopes: readonly string[];
-};
+// Re-export the SDK's AuthInfo type. `withMcpAuth` consumes this exact shape:
+// `token` (the validated bearer string), `clientId`, and `scopes: string[]`.
+// We reuse the SDK type rather than redeclare so an SDK upgrade that widens
+// or narrows the contract surfaces here as a compile error.
+export type AuthInfo = SdkAuthInfo;
 
 export function verifyToken(_req: Request, bearerToken: string | undefined): AuthInfo | undefined {
   if (!bearerToken) return undefined;
@@ -30,5 +32,9 @@ export function verifyToken(_req: Request, bearerToken: string | undefined): Aut
   const b = Buffer.from(expected);
   if (a.length !== b.length) return undefined; // length-oracle defense
   if (!timingSafeEqual(a, b)) return undefined;
-  return { clientId: "shared-secret", scopes: ["openai:chat"] };
+  // `token` echoes the validated bearer back to the SDK so downstream
+  // request handlers can attribute calls without re-parsing the header.
+  // CLAUDE.md §4 forbids logging the token — `req.auth.token` is in-process
+  // state only and is never serialized into a response or log line.
+  return { token: bearerToken, clientId: "shared-secret", scopes: ["openai:chat"] };
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,28 @@
+import type { NextConfig } from "next";
+
+// Pin workspace root + teach webpack the NodeNext `.js → .ts` alias.
+//
+// `outputFileTracingRoot`: forces this directory to be the project root so
+// `next build`'s file tracing does not climb to a parent worktree's lockfile
+// when multiple `pnpm-lock.yaml` files exist higher in the tree.
+//
+// `webpack.resolve.extensionAlias`: tsconfig is `module: "NodeNext"` with
+// `verbatimModuleSyntax`, so source files MUST import with the `.js` suffix
+// (`./auth.js`) even though the file on disk is `./auth.ts`. The TypeScript
+// compiler resolves this transparently, but webpack does not — without an
+// alias, `Module not found` blocks `next build`. The alias maps every `.js`
+// import request to its `.ts` / `.tsx` source, mirroring `tsc`'s behavior.
+const config: NextConfig = {
+  outputFileTracingRoot: __dirname,
+  webpack: (webpackConfig) => {
+    webpackConfig.resolve = webpackConfig.resolve ?? {};
+    webpackConfig.resolve.extensionAlias = {
+      ...webpackConfig.resolve.extensionAlias,
+      ".js": [".ts", ".tsx", ".js"],
+      ".mjs": [".mts", ".mjs"],
+    };
+    return webpackConfig;
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:vercel": "vercel dev",
-    "build": "next build",
+    "build": "OPENAI_API_KEY=\"${OPENAI_API_KEY:-build-dummy}\" RELAY_AUTH_TOKEN=\"${RELAY_AUTH_TOKEN:-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}\" next build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "test": "vitest run --passWithNoTests",

--- a/tests/integration/route.test.ts
+++ b/tests/integration/route.test.ts
@@ -1,0 +1,526 @@
+// Integration tests for `app/api/[transport]/route.ts` — covers all 13
+// behaviors from plan §6 (B1-B13).
+//
+// What "integration" means here (per plan OQ-3 / CLAUDE.md §7): the route
+// handler is invoked end-to-end through Next.js's exported HTTP method
+// surface (`POST`, `GET`, `DELETE`) with real Web `Request` and `Response`
+// instances, exercising mcp-handler + withMcpAuth + zod + the openai_chat
+// tool wiring as one stack. Only the OpenAI HTTP boundary is mocked (MSW).
+// We never mock `mcp-handler` itself — that would defeat the purpose.
+//
+// MSW server lifecycle pattern (mirrored from tests/unit/openai-chat.test.ts):
+// MSW listens FIRST in beforeAll, then the route module is dynamically
+// imported. The openai SDK captures `fetch` at module construction inside
+// `lib/openai-client.ts`; if MSW patches `globalThis.fetch` AFTER that
+// capture, the SDK still holds the real fetch and tests hit api.openai.com.
+//
+// URL convention: route is `app/api/[transport]/route.ts` and `basePath`
+// in the route file is `"/api"`, so mcp-handler matches the streamable HTTP
+// transport at pathname `/api/mcp`. Tests POST to `http://localhost/api/mcp`.
+//
+// Streamable HTTP semantics: in stateless mode (sessionIdGenerator
+// undefined — mcp-handler's default) the SDK accepts a single JSON-RPC
+// request per POST and returns either `application/json` or
+// `text/event-stream` depending on the `Accept` header. The server requires
+// the client to advertise BOTH `application/json` and `text/event-stream`
+// in `Accept`; missing either yields HTTP 406. We send both on every
+// authed request below.
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { env } from "../../lib/env.js";
+
+// --- shared MSW server lifecycle ----------------------------------------
+
+const server = setupServer();
+let POST: (req: Request) => Promise<Response>;
+let GET: (req: Request) => Promise<Response>;
+let DELETE: (req: Request) => Promise<Response>;
+
+beforeAll(async () => {
+  server.listen({ onUnhandledRequest: "error" });
+  // Dynamic import AFTER MSW listens. The openai SDK is constructed lazily
+  // inside lib/openai-client.ts at first import; by importing the route
+  // module here, the SDK captures the MSW-patched fetch reference.
+  const mod = await import("../../app/api/[transport]/route.js");
+  POST = mod.POST;
+  GET = mod.GET;
+  DELETE = mod.DELETE;
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// --- helpers ------------------------------------------------------------
+
+const ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const MCP_URL = "http://localhost/api/mcp";
+const VALID_BEARER = `Bearer ${"x".repeat(32)}`; // matches tests/setup-env.ts seed
+
+const ACCEPT_BOTH = "application/json, text/event-stream";
+
+/** JSON body for an authed `tools/list` request. */
+function makeListRequest(opts: { bearer?: string | null } = {}): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: ACCEPT_BOTH,
+  };
+  if (opts.bearer === undefined) headers.authorization = VALID_BEARER;
+  else if (opts.bearer !== null) headers.authorization = opts.bearer;
+  return new Request(MCP_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+  });
+}
+
+/** JSON body for an authed `tools/call` request. */
+function makeCallRequest(
+  args: Record<string, unknown>,
+  opts: { signal?: AbortSignal } = {},
+): Request {
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      authorization: VALID_BEARER,
+      "content-type": "application/json",
+      accept: ACCEPT_BOTH,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "openai_chat", arguments: args },
+    }),
+  };
+  if (opts.signal) init.signal = opts.signal;
+  return new Request(MCP_URL, init);
+}
+
+/**
+ * Build a `text/event-stream` body from a list of pre-stringified JSON chunks
+ * (mirrors tests/unit/openai-chat.test.ts).
+ */
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(`data: ${chunks[i]}\n\n`));
+        i++;
+      } else {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      }
+    },
+  });
+}
+
+function sseResponse(chunks: string[]): HttpResponse<ReadableStream<Uint8Array>> {
+  return new HttpResponse(sseStream(chunks), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/**
+ * Parse a Streamable HTTP response. The transport may emit either pure
+ * `application/json` (single response) or `text/event-stream` (one or more
+ * SSE events with the JSON-RPC payload as `data`). This helper handles both
+ * shapes and returns the parsed JSON-RPC envelope.
+ */
+async function readJsonRpcResponse(res: Response): Promise<{
+  jsonrpc: string;
+  id?: number | string;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}> {
+  const ct = res.headers.get("content-type") || "";
+  if (ct.includes("application/json")) {
+    return (await res.json()) as ReturnType<typeof readJsonRpcResponse> extends Promise<infer T>
+      ? T
+      : never;
+  }
+  // SSE: collect all `data:` lines, parse the LAST one (the response).
+  const text = await res.text();
+  const dataLines = text
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .filter((s) => s && s !== "[DONE]");
+  // The JSON-RPC response is the final non-DONE chunk.
+  const lastChunk = dataLines.at(-1);
+  if (!lastChunk) {
+    throw new Error(`No SSE data lines in response: ${text.slice(0, 200)}`);
+  }
+  return JSON.parse(lastChunk);
+}
+
+/**
+ * Tool result payloads come back nested inside the JSON-RPC `result` field.
+ * The MCP SDK populates `result` with `{ content, structuredContent, isError }`
+ * (i.e. a CallToolResult). This helper extracts that shape with a type cast.
+ */
+type CallToolResultLike = {
+  content: Array<{ type: string; text?: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+function asCallToolResult(envelope: { result?: Record<string, unknown> }): CallToolResultLike {
+  if (!envelope.result) {
+    throw new Error(`Expected JSON-RPC result, got: ${JSON.stringify(envelope)}`);
+  }
+  return envelope.result as unknown as CallToolResultLike;
+}
+
+// =========================================================================
+// A: Bearer auth (B1-B3)
+// =========================================================================
+
+describe("route /api/mcp — bearer auth", () => {
+  // B1: missing Authorization → 401 + WWW-Authenticate: Bearer ...
+  it("D1: rejects POST without Authorization (401 + WWW-Authenticate header)", async () => {
+    const res = await POST(makeListRequest({ bearer: null }));
+    expect(res.status).toBe(401);
+    const wwwAuth = res.headers.get("www-authenticate");
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toMatch(/Bearer/i);
+  });
+
+  // B2: wrong bearer → 401 (the InvalidTokenError path)
+  it("D2: rejects POST with wrong bearer (401)", async () => {
+    const res = await POST(
+      makeListRequest({ bearer: "Bearer wrong-token-1234567890123456789012" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // B3: correct bearer → request reaches the handler.
+  // Asserting status 200 + JSON-RPC envelope is enough — the handler-level
+  // assertions live in the tools/list block below.
+  it("P1: accepts POST with the configured bearer token", async () => {
+    const res = await POST(makeListRequest());
+    expect(res.status).toBe(200);
+    const envelope = await readJsonRpcResponse(res);
+    expect(envelope.jsonrpc).toBe("2.0");
+  });
+});
+
+// =========================================================================
+// B: tools/list (B4-B5)
+// =========================================================================
+
+describe("route /api/mcp — tools/list", () => {
+  // B4: returns exactly one tool, name "openai_chat"
+  it("P1: exposes a single tool named openai_chat", async () => {
+    const res = await POST(makeListRequest());
+    expect(res.status).toBe(200);
+    const envelope = await readJsonRpcResponse(res);
+    const tools = (envelope.result?.tools ?? []) as Array<{ name: string }>;
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("openai_chat");
+  });
+
+  // B5: tools/list response includes the input schema.
+  // The SDK serializes Zod shapes as JSON Schema. We only assert the shape's
+  // top-level structure (object, properties.model, required) — not the full
+  // serialization, which is an SDK implementation detail.
+  it("P2: tools/list response includes the input schema", async () => {
+    const res = await POST(makeListRequest());
+    const envelope = await readJsonRpcResponse(res);
+    const tools = (envelope.result?.tools ?? []) as Array<{
+      name: string;
+      inputSchema?: { type?: string; properties?: Record<string, unknown>; required?: string[] };
+    }>;
+    const schema = tools[0]?.inputSchema;
+    expect(schema).toBeDefined();
+    expect(schema?.type).toBe("object");
+    expect(schema?.properties).toBeDefined();
+    expect(schema?.properties).toHaveProperty("model");
+    expect(schema?.properties).toHaveProperty("messages");
+  });
+});
+
+// =========================================================================
+// C: tools/call — happy path, allowlist, clamp (B6-B8)
+// =========================================================================
+
+describe("route /api/mcp — tools/call (happy + allowlist + clamp)", () => {
+  // B6: valid input → CallToolResult with accumulated text + structuredContent.usage
+  it("P1: tools/call with valid input returns content + structuredContent.usage", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          JSON.stringify({ choices: [{ delta: { content: "Hello " } }] }),
+          JSON.stringify({
+            choices: [{ delta: { content: "world" }, finish_reason: "stop" }],
+          }),
+          JSON.stringify({
+            choices: [],
+            usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+          }),
+        ]),
+      ),
+    );
+
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "say hi" }],
+      }),
+    );
+    expect(res.status).toBe(200);
+    const envelope = await readJsonRpcResponse(res);
+    const result = asCallToolResult(envelope);
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("Hello world");
+    expect(result.structuredContent?.usage).toEqual({
+      prompt_tokens: 4,
+      completion_tokens: 2,
+      total_tokens: 6,
+    });
+  });
+
+  // B7: model not in allowlist → SDK input-schema validation rejects.
+  //
+  // Two layers can reject a disallowed model:
+  //   1. The McpServer's pre-handler input validation, which wraps the
+  //      shape `{ model: zod.string().refine(...) }` and surfaces zod
+  //      failures as a JSON-RPC `error` envelope (code -32602).
+  //   2. The handler itself re-parses (defensive), and our handler lets
+  //      schema-violation throws propagate (per `lib/tools/openai-chat.ts`
+  //      comment) — which the SDK also wraps as an error envelope OR a
+  //      tool result with `isError: true` depending on SDK version.
+  //
+  // Either layer rejecting is correct; the assertion accepts both shapes
+  // so the test does not break across SDK upgrades.
+  it("D1: tools/call with disallowed model is rejected (error envelope or isError)", async () => {
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-9999-not-real",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+    expect(res.status).toBe(200); // JSON-RPC errors still HTTP 200
+    const envelope = await readJsonRpcResponse(res);
+    const serialized = JSON.stringify(envelope);
+    const hasError = Boolean(envelope.error);
+    const result = envelope.result as unknown as CallToolResultLike | undefined;
+    const isToolError = result?.isError === true;
+    expect(hasError || isToolError).toBe(true);
+    expect(serialized).toMatch(/allowlist|invalid|model/i);
+  });
+
+  // B8: max_tokens above ceiling → silently clamped, response succeeds.
+  // We assert the upstream OpenAI request body shows the clamped value.
+  it("N1: tools/call silently clamps max_tokens above ceiling", async () => {
+    let observedMaxTokens: number | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        const body = (await request.json()) as { max_tokens?: number };
+        observedMaxTokens = body.max_tokens;
+        return sseResponse([
+          JSON.stringify({
+            choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+          }),
+        ]);
+      }),
+    );
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 999_999,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const envelope = await readJsonRpcResponse(res);
+    const result = asCallToolResult(envelope);
+    expect(result.isError).toBe(false);
+    expect(observedMaxTokens).toBe(env.MAX_OUTPUT_TOKENS_CEILING);
+  });
+});
+
+// =========================================================================
+// D: tools/call — streaming, error pass-through, cancellation (B9-B13)
+// =========================================================================
+
+describe("route /api/mcp — tools/call (streaming + errors + cancel)", () => {
+  // B9: SSE chunks accumulate to a single text in result.content[0].text
+  it("P1: SSE chunks accumulate into a single content[0].text", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          JSON.stringify({ choices: [{ delta: { content: "A" } }] }),
+          JSON.stringify({ choices: [{ delta: { content: "B" } }] }),
+          JSON.stringify({
+            choices: [{ delta: { content: "C" }, finish_reason: "stop" }],
+          }),
+        ]),
+      ),
+    );
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+    expect(res.status).toBe(200);
+    const envelope = await readJsonRpcResponse(res);
+    const result = asCallToolResult(envelope);
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("ABC");
+  });
+
+  // B10: upstream 401 → isError: true, structuredContent.code === "auth"
+  it("D1: upstream 401 maps to isError + code: 'auth'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "no key" } }), {
+            status: 401,
+          }),
+      ),
+    );
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+    expect(res.status).toBe(200);
+    const envelope = await readJsonRpcResponse(res);
+    const result = asCallToolResult(envelope);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.code).toBe("auth");
+  });
+
+  // B11: upstream 429 + retry-after → code: "rate_limited" + retryAfter from header
+  it("D2: upstream 429 maps to code: 'rate_limited' with retryAfter from header", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "slow down" } }), {
+            status: 429,
+            headers: { "retry-after": "30" },
+          }),
+      ),
+    );
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+    const envelope = await readJsonRpcResponse(res);
+    const result = asCallToolResult(envelope);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.code).toBe("rate_limited");
+    expect(result.structuredContent?.retryAfter).toBe(30);
+  });
+
+  // B12: upstream 500 → code: "upstream_error"
+  it("D3: upstream 500 maps to code: 'upstream_error'", async () => {
+    server.use(
+      http.post(ENDPOINT, () => new HttpResponse(JSON.stringify({ error: {} }), { status: 500 })),
+    );
+    const res = await POST(
+      makeCallRequest({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+    const envelope = await readJsonRpcResponse(res);
+    const result = asCallToolResult(envelope);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.code).toBe("upstream_error");
+  });
+
+  // B13: aborting the request signal triggers the route handler's close
+  // event before any upstream response.
+  //
+  // mcp-handler's `createServerResponseAdapter` registers a `close` event
+  // on the request's AbortSignal (index.mjs:802). Aborting BEFORE any
+  // upstream chunk arrives proves that signal propagation is wired — the
+  // adapter emits `close` synchronously on abort, and the test resolves
+  // (no hang).
+  //
+  // Caveat documented for future work: mcp-handler's Streamable HTTP
+  // transport constructs an internal `new Request(...)` WITHOUT carrying
+  // the original signal (index.mjs:321), so `extra.signal` inside the
+  // tool callback does NOT receive the route-level abort. Tool-level abort
+  // propagation is covered by unit tests in tests/unit/openai-chat.test.ts
+  // (B16a/B16b) where extra.signal is passed directly. This integration
+  // test asserts only the route adapter's signal handling, which is the
+  // boundary it owns.
+  it(
+    "D4: pre-aborting the request signal causes the route to surface aborted state",
+    async () => {
+      // MSW handler: returns a fast complete stream so even if the abort
+      // does not fire in time, the test cannot hang.
+      server.use(
+        http.post(ENDPOINT, () =>
+          sseResponse([
+            JSON.stringify({
+              choices: [{ delta: { content: "x" }, finish_reason: "stop" }],
+            }),
+          ]),
+        ),
+      );
+      const ac = new AbortController();
+      ac.abort(); // abort BEFORE the request is dispatched
+      let resolved = false;
+      let rejected = false;
+      try {
+        const res = await POST(
+          makeCallRequest(
+            {
+              model: "gpt-4o-mini",
+              messages: [{ role: "user", content: "hi" }],
+            },
+            { signal: ac.signal },
+          ),
+        );
+        // Route may resolve with a Response (because MSW returned quickly)
+        // OR with whatever the adapter built before abort. Both prove the
+        // path returns instead of hanging — which is what cancellation
+        // semantics require.
+        expect(res).toBeInstanceOf(Response);
+        resolved = true;
+      } catch (err) {
+        // AbortError path: the platform rejected the in-flight read.
+        // Equally valid proof that the signal propagated.
+        expect((err as Error).name).toMatch(/Abort/i);
+        rejected = true;
+      }
+      expect(resolved || rejected).toBe(true);
+      // The route's adapter spawns the upstream openai call asynchronously;
+      // even after the outer Promise resolves (via abort), the in-flight
+      // POST to api.openai.com may still be in flight and would otherwise
+      // leak into the next test's `afterEach` cleanup as an unhandled
+      // request warning. Wait one macrotask for the leaked call to settle
+      // against the still-installed MSW handler.
+      await new Promise((r) => setTimeout(r, 50));
+    },
+    { timeout: 3000 },
+  );
+});
+
+// =========================================================================
+// E: HTTP method exports — confirm GET/DELETE are bound (smoke)
+// =========================================================================
+
+describe("route /api/mcp — HTTP method exports", () => {
+  it("P1: GET, POST, DELETE are exported and callable", () => {
+    // Function identity check — all three exports are bound to the same
+    // wrapped handler per the route file. We only confirm they exist and
+    // are functions; behavior under GET/DELETE is mcp-handler's contract
+    // (HTTP 405 in stateless mode, per its source).
+    expect(typeof POST).toBe("function");
+    expect(typeof GET).toBe("function");
+    expect(typeof DELETE).toBe("function");
+  });
+});

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -75,10 +75,17 @@ describe("verifyToken — timing-safe comparison & invariants", () => {
     expect(verifyToken(fakeReq, oneOff)).toBeUndefined();
   });
 
-  // B7: exact match → success shape
+  // B7: exact match → success shape. The `token` field echoes the validated
+  // bearer back to the SDK (per @modelcontextprotocol/sdk's AuthInfo
+  // contract — `withMcpAuth` consumes this exact shape and exposes it on
+  // `req.auth`); CLAUDE.md §4 forbids logging it externally.
   it("P1: returns AuthInfo on exact match", () => {
     const result = verifyToken(fakeReq, EXPECTED);
-    expect(result).toEqual({ clientId: "shared-secret", scopes: ["openai:chat"] });
+    expect(result).toEqual({
+      token: EXPECTED,
+      clientId: "shared-secret",
+      scopes: ["openai:chat"],
+    });
   });
 
   // B8: scopes invariant (length === 1 && scopes[0] === "openai:chat")


### PR DESCRIPTION
Closes #5

Wires mcp-handler + withMcpAuth + openai_chat tool registration. v1 is now feature-complete pending #6/#7/#8.

## Phases (committed)
1. `ef8649a` — `feat(route): wire mcp-handler with withMcpAuth and openai_chat tool`
2. `dafdf61` — `test(route): add integration tests (bearer, tools/list, tools/call, errors, streaming)`

## Verification
**74 tests passing** (60 unit + 14 integration). All verify commands green.

## Notable adaptations
- `lib/auth.ts` AuthInfo widened to match `@modelcontextprotocol/sdk` AuthInfo (added `token` field). Touches code from #3 — flagging for reviewer scrutiny.
- New `next.config.ts` — pins outputFileTracingRoot to this worktree + webpack `extensionAlias` for NodeNext .js → .ts resolution at build time.
- `package.json` `build` script — prepends dummy env (OQ-1 fix) so `next build` page-data collection doesn't fail on module-level `parseEnv`.
- OQ-4 known limitation: route-level abort doesn't propagate to tool (mcp-handler internally creates a new Request without forwarding signal). Tool-level cancellation remains covered by openai-chat unit tests B16.