### PR TITLE
chore(ci): GitHub Actions PR verification workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # mcp-handler and @modelcontextprotocol/sdk are ABI-coupled per
+      # CLAUDE.md §4 — bump them as a pair to avoid peer-dep breakage.
+      mcp:
+        patterns:
+          - "mcp-handler"
+          - "@modelcontextprotocol/sdk"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Dummy values so module-level parseEnv(process.env) succeeds during
+      # next build / vitest module evaluation. The real OpenAI HTTP boundary is
+      # mocked by MSW in tests; no real upstream calls are made in CI.
+      OPENAI_API_KEY: ci-dummy-openai-key
+      RELAY_AUTH_TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
Closes #6

Adds the CI workflow per the plan in #6.

## What's in
- `.github/workflows/ci.yml` — single `verify` job: install (frozen-lockfile) + typecheck + lint + build + test on Node 20 / pnpm 9 / Ubuntu. Dummy OPENAI_API_KEY + RELAY_AUTH_TOKEN injected as workflow env vars (MSW mocks the real OpenAI HTTP boundary so no real upstream calls).
- `.github/dependabot.yml` — weekly npm + actions updates; `mcp-handler` and `@modelcontextprotocol/sdk` grouped (ABI-paired upgrade per CLAUDE.md §4).

## Self-validation
This PR itself triggers the new workflow — the workflow run on this PR is the proof of correctness. If green, the gate works.