### PR TITLE
feat(dev): preflight env check and pnpm verify smoke

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# pnpm 9 disables pre/post lifecycle scripts by default. Enable so `predev`
+# (scripts/check-dev-env.mjs) fires automatically before `pnpm dev` /
+# `pnpm dev:vercel` without inlining `&&` chains in the script bodies.
+enable-pre-post-scripts=true

--- a/README.md
+++ b/README.md
@@ -34,22 +34,29 @@ LLM can call OpenAI models as if they were tools.
 pnpm install
 cp .env.example .env.local
 # Fill in OPENAI_API_KEY and RELAY_AUTH_TOKEN in .env.local
+#   token: openssl rand -hex 32
 pnpm dev
 ```
 
-The server listens at `http://localhost:3000/api/mcp`.
+The server listens at `http://localhost:3000/api/mcp`. `pnpm dev` refuses to
+start (with actionable instructions) when `.env.local` is missing or the two
+required values are not set.
 
-### Verify with MCP Inspector
+### Verify the running server
+
+In a second terminal — while `pnpm dev` is running:
 
 ```bash
-npx @modelcontextprotocol/inspector
+pnpm verify
 ```
 
-When the browser opens:
-1. Transport: **Streamable HTTP**
-2. URL: `http://localhost:3000/api/mcp`
-3. Header: `Authorization: Bearer <RELAY_AUTH_TOKEN>`
-4. Click **Connect** → in the Tools tab, invoke `openai_chat`
+This sends JSON-RPC directly to `/api/mcp` and reports PASS/FAIL for the four
+checks that can be asserted from a client (C1 `tools/list`, C2 happy path,
+C3 model allowlist, C5 wrong-bearer 401). It calls OpenAI once with
+`gpt-4o-mini` (~$0.0001 per run). Override with `--url=` or `MCP_URL`.
+
+For the full six-scenario manual procedure (including C4 clamp and C6
+cancellation), see [`doc/QA-MCP-INSPECTOR.md`](./doc/QA-MCP-INSPECTOR.md).
 
 ### Vercel deployment
 
@@ -130,7 +137,7 @@ Response: accumulated text plus `usage` metadata. For the full schema see [`doc/
 ## Scripts
 
 ```bash
-pnpm dev                 # next dev (port 3000)
+pnpm dev                 # next dev (port 3000) — preflights .env.local
 pnpm dev:vercel          # vercel dev (verifies runtime parity)
 pnpm build               # next build
 pnpm typecheck           # tsc --noEmit
@@ -138,6 +145,7 @@ pnpm lint                # biome check .
 pnpm test                # vitest run
 pnpm test:unit           # unit tests only
 pnpm test:integration    # integration tests only
+pnpm verify              # smoke C1/C2/C3/C5 against a running pnpm dev
 ```
 
 ---

--- a/doc/QA-MCP-INSPECTOR.md
+++ b/doc/QA-MCP-INSPECTOR.md
@@ -13,6 +13,29 @@ end-to-end verification against a real OpenAI API call.
 
 ---
 
+## Quick path: `pnpm verify`
+
+For a fast local check against a running `pnpm dev`:
+
+```bash
+# terminal 1
+pnpm dev
+
+# terminal 2
+pnpm verify
+```
+
+`pnpm verify` sends JSON-RPC directly to `/api/mcp` and reports PASS/FAIL for
+**C1, C2, C3, and C5** — the four scenarios assertable from a client. It also
+prints an evidence-record block ready to paste into the PR. Costs ~$0.0001 per
+run (one `gpt-4o-mini` call). Override with `--url=...` or `MCP_URL`.
+
+C4 (clamp) and C6 (cancellation) cannot be asserted from a client — for those
+two, fall through to the manual six-scenario procedure below. Production-side
+re-verification (§E) is also manual: this script is local-only.
+
+---
+
 ## A. Preparation
 
 1. Populate `.env.local` with **a personal dev OpenAI key** (not the production key)

--- a/package.json
+++ b/package.json
@@ -7,14 +7,17 @@
     "node": ">=20.0.0 <21.0.0"
   },
   "scripts": {
+    "predev": "node scripts/check-dev-env.mjs",
     "dev": "next dev",
+    "predev:vercel": "node scripts/check-dev-env.mjs",
     "dev:vercel": "vercel dev",
     "build": "OPENAI_API_KEY=\"${OPENAI_API_KEY:-build-dummy}\" RELAY_AUTH_TOKEN=\"${RELAY_AUTH_TOKEN:-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}\" next build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --project unit --passWithNoTests",
-    "test:integration": "vitest run --project integration --passWithNoTests"
+    "test:integration": "vitest run --project integration --passWithNoTests",
+    "verify": "node scripts/verify.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0",

--- a/scripts/check-dev-env.mjs
+++ b/scripts/check-dev-env.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Pre-flight for `pnpm dev`. lib/env.ts re-validates at module load, but that
+// only fires on the first request — by then `next dev` has already booted and
+// the failure surfaces as a buried request-stack trace. Catching it here keeps
+// the failure mode visible before the server starts.
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ENV_PATH = resolve(process.cwd(), ".env.local");
+const REQUIRED = ["OPENAI_API_KEY", "RELAY_AUTH_TOKEN"];
+
+function fail(lines) {
+  for (const line of lines) console.error(line);
+  process.exit(1);
+}
+
+if (!existsSync(ENV_PATH)) {
+  fail([
+    "",
+    "[mcp-openai-relay] .env.local is missing.",
+    "",
+    "  cp .env.example .env.local",
+    "  # then set OPENAI_API_KEY and RELAY_AUTH_TOKEN",
+    "  # token: openssl rand -hex 32",
+    "",
+  ]);
+}
+
+const raw = readFileSync(ENV_PATH, "utf8");
+const dotenv = Object.fromEntries(
+  raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#") && line.includes("="))
+    .map((line) => {
+      const idx = line.indexOf("=");
+      const k = line.slice(0, idx).trim();
+      let v = line.slice(idx + 1).trim();
+      if (
+        (v.startsWith('"') && v.endsWith('"')) ||
+        (v.startsWith("'") && v.endsWith("'"))
+      ) {
+        v = v.slice(1, -1);
+      }
+      return [k, v];
+    }),
+);
+
+const missing = REQUIRED.filter((key) => !dotenv[key]);
+if (missing.length > 0) {
+  fail([
+    "",
+    `[mcp-openai-relay] .env.local missing required values: ${missing.join(", ")}`,
+    "",
+    "  Edit .env.local and set:",
+    ...missing.map((k) => `    ${k}=...`),
+    "",
+    "  Generate RELAY_AUTH_TOKEN if needed:  openssl rand -hex 32",
+    "",
+  ]);
+}
+
+if (Buffer.byteLength(dotenv.RELAY_AUTH_TOKEN, "utf8") < 32) {
+  fail([
+    "",
+    "[mcp-openai-relay] RELAY_AUTH_TOKEN must be at least 32 bytes.",
+    "  Regenerate:  openssl rand -hex 32",
+    "",
+  ]);
+}

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// Real-server smoke test. Run `pnpm dev` in another terminal first, then
+// `pnpm verify` here.
+//
+// Sends JSON-RPC directly to /api/mcp, covering C1, C2, C3, C5 from
+// doc/QA-MCP-INSPECTOR.md. The MCP Inspector UI is bypassed — its only role in
+// the manual procedure is to construct these same requests for a human.
+//
+// Skipped:
+//   C4 (max_tokens clamp) — server-side, invisible to client; covered by
+//      tests/unit/openai-chat.test.ts.
+//   C6 (cancellation)     — relies on visual inspection of the OpenAI usage
+//      page; stays manual per QA-MCP-INSPECTOR.md.
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ENV_PATH = resolve(process.cwd(), ".env.local");
+
+if (!existsSync(ENV_PATH)) {
+  console.error("[verify] .env.local missing — run `pnpm dev` once to surface setup steps.");
+  process.exit(1);
+}
+
+const raw = readFileSync(ENV_PATH, "utf8");
+const dotenv = Object.fromEntries(
+  raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#") && line.includes("="))
+    .map((line) => {
+      const idx = line.indexOf("=");
+      const k = line.slice(0, idx).trim();
+      let v = line.slice(idx + 1).trim();
+      if (
+        (v.startsWith('"') && v.endsWith('"')) ||
+        (v.startsWith("'") && v.endsWith("'"))
+      ) {
+        v = v.slice(1, -1);
+      }
+      return [k, v];
+    }),
+);
+
+const TOKEN = dotenv.RELAY_AUTH_TOKEN;
+if (!TOKEN) {
+  console.error("[verify] RELAY_AUTH_TOKEN missing in .env.local");
+  process.exit(1);
+}
+
+const argUrl = process.argv.slice(2).find((a) => a.startsWith("--url="));
+const URL_BASE =
+  (argUrl && argUrl.slice("--url=".length)) ||
+  process.env.MCP_URL ||
+  "http://localhost:3000/api/mcp";
+
+const MODEL = process.env.VERIFY_MODEL || "gpt-4o-mini";
+const ACCEPT_BOTH = "application/json, text/event-stream";
+
+async function readJsonRpc(res) {
+  const ct = res.headers.get("content-type") || "";
+  if (ct.includes("application/json")) return res.json();
+  const text = await res.text();
+  const lines = text
+    .split("\n")
+    .filter((l) => l.startsWith("data:"))
+    .map((l) => l.slice(5).trim())
+    .filter((s) => s && s !== "[DONE]");
+  if (!lines.length) throw new Error("No SSE data lines in response");
+  return JSON.parse(lines.at(-1));
+}
+
+async function rpc(body, opts = {}) {
+  return fetch(URL_BASE, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: ACCEPT_BOTH,
+      authorization: `Bearer ${opts.token ?? TOKEN}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const results = [];
+function record(id, label, pass, note) {
+  results.push({ id, label, pass, note });
+  const stamp = pass ? "PASS" : "FAIL";
+  console.log(`[${stamp}] ${id}  ${label}${note ? "  — " + note : ""}`);
+}
+
+try {
+  await fetch(URL_BASE, { method: "GET" });
+} catch {
+  console.error("");
+  console.error(`[verify] cannot reach ${URL_BASE}`);
+  console.error("         run `pnpm dev` in another terminal first.");
+  console.error("         override URL: pnpm verify --url=http://localhost:3001/api/mcp");
+  console.error("");
+  process.exit(1);
+}
+
+console.log(`endpoint:  ${URL_BASE}`);
+console.log(`model:     ${MODEL}`);
+console.log("");
+
+// ---- C1: tools/list ----------------------------------------------------
+
+try {
+  const res = await rpc({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+  if (res.status !== 200) throw new Error(`HTTP ${res.status}`);
+  const env = await readJsonRpc(res);
+  const tools = env.result?.tools ?? [];
+  const ok = tools.length === 1 && tools[0]?.name === "openai_chat";
+  record(
+    "C1",
+    "tools/list — single openai_chat",
+    ok,
+    ok ? "1 tool" : `got ${JSON.stringify(tools.map((t) => t.name))}`,
+  );
+} catch (err) {
+  record("C1", "tools/list — single openai_chat", false, err.message);
+}
+
+// ---- C2: openai_chat happy path ---------------------------------------
+
+try {
+  const res = await rpc({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "openai_chat",
+      arguments: {
+        model: MODEL,
+        messages: [{ role: "user", content: "ping" }],
+      },
+    },
+  });
+  if (res.status !== 200) throw new Error(`HTTP ${res.status}`);
+  const env = await readJsonRpc(res);
+  const result = env.result;
+  const text = result?.content?.[0]?.text ?? "";
+  const usage = result?.structuredContent?.usage;
+  const ok =
+    result?.isError === false &&
+    typeof text === "string" &&
+    text.length > 0 &&
+    typeof usage?.total_tokens === "number" &&
+    usage.total_tokens > 0;
+  const note = usage
+    ? `prompt=${usage.prompt_tokens} completion=${usage.completion_tokens} total=${usage.total_tokens}`
+    : "no usage";
+  record("C2", "openai_chat happy path", ok, note);
+} catch (err) {
+  record("C2", "openai_chat happy path", false, err.message);
+}
+
+// ---- C3: allowlist reject ---------------------------------------------
+
+try {
+  const res = await rpc({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "openai_chat",
+      arguments: {
+        model: "gpt-9999-not-real",
+        messages: [{ role: "user", content: "hi" }],
+      },
+    },
+  });
+  if (res.status !== 200) throw new Error(`HTTP ${res.status}`);
+  const env = await readJsonRpc(res);
+  const hasError = Boolean(env.error);
+  const isToolError = env.result?.isError === true;
+  const serialized = JSON.stringify(env);
+  const ok = (hasError || isToolError) && /allowlist|invalid|model/i.test(serialized);
+  record("C3", "allowlist rejects gpt-9999", ok);
+} catch (err) {
+  record("C3", "allowlist rejects gpt-9999", false, err.message);
+}
+
+// ---- C5: wrong bearer 401 ---------------------------------------------
+
+try {
+  const res = await rpc(
+    { jsonrpc: "2.0", id: 5, method: "tools/list" },
+    { token: "wrong-token-1234567890123456789012" },
+  );
+  const wwwAuth = res.headers.get("www-authenticate") || "";
+  const ok = res.status === 401 && /Bearer/i.test(wwwAuth);
+  record("C5", "wrong bearer 401 + WWW-Authenticate", ok, `HTTP ${res.status}`);
+} catch (err) {
+  record("C5", "wrong bearer 401 + WWW-Authenticate", false, err.message);
+}
+
+// ---- Summary + evidence record ---------------------------------------
+
+console.log("");
+const passed = results.filter((r) => r.pass).length;
+console.log(`${passed}/${results.length} scenarios passed`);
+console.log("");
+console.log("--- evidence record (paste into PR) ---");
+console.log(`MCP smoke verification — ${new Date().toISOString()}`);
+console.log(`Endpoint:  ${URL_BASE}`);
+console.log(`Model:     ${MODEL}`);
+console.log("");
+for (const r of results) {
+  console.log(`${r.id}  ${r.pass ? "PASS" : "FAIL"}  ${r.label}${r.note ? " — " + r.note : ""}`);
+}
+console.log("C4  N/A   server-side clamp; covered by unit tests");
+console.log("C6  N/A   cancellation; manual only");
+console.log("--- end ---");
+
+process.exit(passed === results.length ? 0 : 1);


### PR DESCRIPTION
Adds a predev hook (scripts/check-dev-env.mjs) wired via .npmrc so `pnpm dev` and `pnpm dev:vercel` refuse to start without a populated .env.local — the failure mode previously surfaced as a buried lib/env.ts throw on the first request.

Adds `pnpm verify` (scripts/verify.mjs) — sends JSON-RPC directly to a running dev server and reports PASS/FAIL for the four client-assertable scenarios from doc/QA-MCP-INSPECTOR.md (C1, C2, C3, C5). C4 (server-side clamp) and C6 (cancellation observation) stay manual; the six-scenario MCP Inspector procedure remains canonical.

## Summary

<!-- 1-3 sentence description of the change. The "why" (motivation) is required;
the "what" should be evident from the diff. -->

Closes #<issue-number>

## Verify Commands output

<!-- Paste the output of these four commands. Required by CLAUDE.md §8. -->

```
$ pnpm typecheck
...

$ pnpm lint
...

$ pnpm build
...

$ pnpm test
...
```

## MCP Inspector verification (per `doc/QA-MCP-INSPECTOR.md`)

For non-trivial code changes, run the Inspector procedure and tick each scenario
that passed. For docs-only or CI-config-only PRs, mark **N/A — non-runtime change**.

- [ ] C1 — `tools/list` exposes a single `openai_chat` tool with input schema
- [ ] C2 — `openai_chat` happy path returns text + usage metadata
- [ ] C3 — Allowlist reject (model not in `MODEL_ALLOWLIST`) returns error
- [ ] C4 — `max_tokens` clamp succeeds without error
- [ ] C5 — Wrong bearer returns 401 + `WWW-Authenticate: Bearer`
- [ ] C6 — Cancellation aborts the upstream call

> N/A:
> <reason if all six are skipped>

## v1 non-goal self-check

The change must NOT introduce items deferred to v2 (see
[`doc/ARCHITECTURE.md` §11](../doc/ARCHITECTURE.md#11-future-work-v2-backlog) and
[`CLAUDE.md` §10](../CLAUDE.md#10-non-goals-v1)).

- [ ] No Responses API usage
- [ ] No embeddings / image tools
- [ ] No OAuth 2.1 / DCR
- [ ] No rate limiting (Upstash, etc.)
- [ ] No daily budget counters
- [ ] No external observability (Sentry, OTel, Axiom)
- [ ] No SSE transport / Redis
- [ ] No additional MCP routes (single `app/api/[transport]/route.ts` only)

## Notes for reviewer

<!-- Anything the reviewer should pay attention to: deviations from the plan,
SSOT drift, follow-ups deferred to other issues, etc. Optional. -->
