### PR TITLE
fix(env): allow empty OPENAI_API_KEY

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -26,7 +26,7 @@ const csvList = (defaults: readonly string[]) =>
     .refine((arr) => arr.length > 0, "must contain at least one entry");
 
 const envSchema = z.object({
-  OPENAI_API_KEY: z.string().min(1),
+  OPENAI_API_KEY: z.string().default(""),
   RELAY_AUTH_TOKEN: z
     .string()
     .refine((s) => Buffer.byteLength(s, "utf8") >= 32, "must be at least 32 bytes"),

--- a/scripts/check-dev-env.mjs
+++ b/scripts/check-dev-env.mjs
@@ -8,7 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const ENV_PATH = resolve(process.cwd(), ".env.local");
-const REQUIRED = ["OPENAI_API_KEY", "RELAY_AUTH_TOKEN"];
+const REQUIRED = ["RELAY_AUTH_TOKEN"];
 
 function fail(lines) {
   for (const line of lines) console.error(line);
@@ -21,7 +21,7 @@ if (!existsSync(ENV_PATH)) {
     "[mcp-openai-relay] .env.local is missing.",
     "",
     "  cp .env.example .env.local",
-    "  # then set OPENAI_API_KEY and RELAY_AUTH_TOKEN",
+    "  # then set RELAY_AUTH_TOKEN (required) and OPENAI_API_KEY (optional)",
     "  # token: openssl rand -hex 32",
     "",
   ]);

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -20,10 +20,10 @@ const expectThrow = (input: EnvSource): Error => {
 };
 
 describe("parseEnv — required keys", () => {
-  // B1: OPENAI_API_KEY missing
-  it("throws when OPENAI_API_KEY is missing", () => {
-    const err = expectThrow({ RELAY_AUTH_TOKEN: "x".repeat(32) });
-    expect(err.message).toContain("OPENAI_API_KEY");
+  // B1: OPENAI_API_KEY missing → defaults to empty string
+  it("defaults OPENAI_API_KEY to empty string when missing", () => {
+    const env = parseEnv({ RELAY_AUTH_TOKEN: "x".repeat(32) });
+    expect(env.OPENAI_API_KEY).toBe("");
   });
 
   // B2: RELAY_AUTH_TOKEN missing
@@ -32,10 +32,10 @@ describe("parseEnv — required keys", () => {
     expect(err.message).toContain("RELAY_AUTH_TOKEN");
   });
 
-  // B3: empty OPENAI_API_KEY
-  it("throws when OPENAI_API_KEY is empty string", () => {
-    const err = expectThrow({ OPENAI_API_KEY: "", RELAY_AUTH_TOKEN: "x".repeat(32) });
-    expect(err.message).toContain("OPENAI_API_KEY");
+  // B3: empty OPENAI_API_KEY is accepted
+  it("accepts empty OPENAI_API_KEY", () => {
+    const env = parseEnv({ OPENAI_API_KEY: "", RELAY_AUTH_TOKEN: "x".repeat(32) });
+    expect(env.OPENAI_API_KEY).toBe("");
   });
 
   // B4: RELAY_AUTH_TOKEN under 32 bytes


### PR DESCRIPTION
## Summary

Make \`OPENAI_API_KEY\` optional so dev can boot without an OpenAI key configured. Useful for working on the JSON-RPC route, bearer auth, allowlist validation, or zod schemas without burning OpenAI quota or needing a personal key on hand. Production deployments still set the key — this only changes what is *enforced at module load*.

## Changes

- **\`lib/env.ts\`**: \`OPENAI_API_KEY: z.string().min(1)\` → \`z.string().default("")\`
- **\`scripts/check-dev-env.mjs\`**: drop \`OPENAI_API_KEY\` from \`REQUIRED\` preflight (only \`RELAY_AUTH_TOKEN\` remains required)
- **\`tests/unit/env.test.ts\`**: B1 (missing) + B3 (empty) flip from "throws" to "accepts/defaults"

## Behavior

| Scenario | Before | After |
|---|---|---|
| \`OPENAI_API_KEY\` unset | throws at module load | parses to \`""\` |
| \`OPENAI_API_KEY=""\` | throws at module load | parses to \`""\` |
| \`OPENAI_API_KEY=sk-...\` | works | works (unchanged) |
| Calling \`openai_chat\` with empty key | unreachable (boot failed) | fails at OpenAI HTTP boundary with normal 401 |

Failing at the HTTP boundary instead of module load is the right place — it surfaces a clear runtime error tied to the actual call, instead of a buried boot-time crash.

## Verify Commands output

\`\`\`
$ pnpm typecheck    → clean
$ pnpm lint         → Checked 11 files. No fixes applied.
$ pnpm build        → Route (app) /_not-found, /api/[transport]
$ pnpm test         → 4 files, 74 tests passed
\`\`\`

## MCP Inspector verification

> N/A — env-validation behavior change. No runtime code in \`app/\` or the route is touched.

## v1 non-goal self-check

- [x] No Responses API usage
- [x] No embeddings / image tools
- [x] No OAuth 2.1 / DCR
- [x] No rate limiting (Upstash, etc.)
- [x] No daily budget counters
- [x] No external observability (Sentry, OTel, Axiom)
- [x] No SSE transport / Redis
- [x] No additional MCP routes (single \`app/api/[transport]/route.ts\` only)

## Notes for reviewer

- This trades a **fail-fast at boot** behavior for **fail-at-call** behavior, scoped to the OpenAI key only. \`RELAY_AUTH_TOKEN\` remains strictly required (32+ bytes) because requests cannot be authenticated without it.
- Production deployments are unchanged in practice — Vercel sets \`OPENAI_API_KEY\` as a sensitive env var per [\`doc/DEPLOY.md\`](../doc/DEPLOY.md). The constraint only relaxed the *validator*, not the *expectation*.