### PR TITLE
feat(docker): add Dockerfile for self-hosted container deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+.env*
+.git
+.github
+.claude
+.vercel
+coverage
+tests
+doc
+*.log
+*.md
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+RUN corepack enable pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+RUN corepack enable pnpm
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup -S nodejs && adduser -S nextjs -u 1001 -G nodejs
+USER nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://localhost:'+(process.env.PORT||3000)+'/api/mcp').then(r=>process.exit(r.status>=500?1:0)).catch(()=>process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Flags fall back to `process.env` then `.env.local`: `MCP_URL`, `MCP_TOOL`,
 For the full five-scenario manual procedure (including C4 clamp and C6
 cancellation), see [`doc/QA-MCP-INSPECTOR.md`](./doc/QA-MCP-INSPECTOR.md).
 
+### Docker (self-hosted)
+
+```bash
+docker build -t mcp-openai-relay .
+docker run --rm -p 3000:3000 \
+  -e OPENAI_API_KEY=sk-... -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
+  mcp-openai-relay
+```
+
+See [`doc/DEPLOY.md` §5b](./doc/DEPLOY.md#5b-docker-self-hosted-container) for the full container runbook.
+
 ### Vercel deployment
 
 Quick path:

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -181,6 +181,84 @@ In the Inspector UI:
 
 ---
 
+## 5b. Docker (self-hosted container)
+
+If you cannot or do not want to run on Vercel, the relay ships a multi-stage
+`Dockerfile` at the repo root that produces a ~120 MB runtime image based on
+`node:20-alpine`, running as a non-root user (UID 1001) with a Node `fetch`
+HEALTHCHECK against `/api/mcp`.
+
+> The container is the relay process only. Configure your reverse proxy / load
+> balancer to allow long-running requests — there is no analogue of Vercel's
+> 300 s function timeout, so the upstream timeout becomes the operator's
+> responsibility. 300 s is a reasonable starting value if you want parity with
+> the Vercel deployment.
+
+### Build
+
+```bash
+docker build -t mcp-openai-relay .
+```
+
+Final image size should be under 200 MB. The build does not need real
+secrets — the `pnpm build` script injects build-time dummy values.
+
+### Run — inline `-e` flags
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e OPENAI_API_KEY=sk-... \
+  -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
+  -e OPENAI_BASE_URL=https://your-gateway.example.com/v1 \
+  -e MAX_OUTPUT_TOKENS_CEILING=4096 \
+  -e REQUEST_TIMEOUT_MS=60000 \
+  mcp-openai-relay
+```
+
+`OPENAI_API_KEY` and `RELAY_AUTH_TOKEN` are required. `OPENAI_BASE_URL`,
+`MAX_OUTPUT_TOKENS_CEILING`, and `REQUEST_TIMEOUT_MS` are optional (see
+[`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-environment-variables) for defaults).
+
+### Run — `--env-file`
+
+Keep secrets in a file the operator manages (gitignored, locked-down perms):
+
+```bash
+docker run --rm -p 3000:3000 --env-file .env.production mcp-openai-relay
+```
+
+### HEALTHCHECK verification
+
+```bash
+docker inspect --format '{{.State.Health.Status}}' <container>
+```
+
+Expect `healthy` within ~30 s of start. The check sends `GET /api/mcp` and
+treats any non-5xx response as healthy (mcp-handler returns 405 to a bare GET,
+which proves the function reached).
+
+### Smoke test
+
+With the container running on port 3000:
+
+```bash
+pnpm inspect --url=http://localhost:3000/api/mcp --method=tools/list
+```
+
+Expect a single tool named `completion_chat`. For the full pre-PR procedure
+(C1–C6) see [`QA-MCP-INSPECTOR.md`](./QA-MCP-INSPECTOR.md).
+
+### Verifying no secrets baked
+
+```bash
+docker history mcp-openai-relay --no-trunc | grep -iE 'OPENAI_API_KEY|RELAY_AUTH_TOKEN'
+```
+
+Only the `pnpm build` script's dummy values (`build-dummy`, 32×`x`) should
+appear — never real credentials.
+
+---
+
 ## 6. Token rotation runbook (`RELAY_AUTH_TOKEN`)
 
 Run when:

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ import type { NextConfig } from "next";
 // "webpack config without turbopack config" build error in Next 16.
 const config: NextConfig = {
   outputFileTracingRoot: __dirname,
+  output: "standalone",
   turbopack: {},
 };
 


### PR DESCRIPTION
Closes #30

## Summary

Multi-stage `Dockerfile` + `.dockerignore` at repo root, Next.js standalone output, and updated docs (`doc/DEPLOY.md` §5b, `README.md` Quick start). Operators can now `docker build` and `docker run` without Vercel.

## What changed

- `Dockerfile` — three stages (`deps` → `builder` → `runner`) on `node:20-alpine`. Final image **68.7 MB** (target < 200 MB). Runs as `nextjs:nodejs` (UID 1001). HEALTHCHECK via `node -e "fetch(...)"` accepts any non-5xx. `EXPOSE 3000`. `CMD ["node", "server.js"]`.
- `.dockerignore` — excludes `node_modules`, `.next`, `.env*`, `.git`, `.github`, `.claude`, `.vercel`, `coverage`, `tests`, `doc`, `*.log`, `*.md`, `.DS_Store`.
- `next.config.ts` — `output: "standalone"` added (one line).
- `doc/DEPLOY.md` — new `## 5b. Docker (self-hosted container)` section between §5 and §6 with build/run/env-file/HEALTHCHECK/smoke/secrets-check flow.
- `README.md` — one-line Docker entry in Quick start linking to `doc/DEPLOY.md#5b-docker-self-hosted-container`.

## Verification

- `pnpm build && pnpm typecheck && pnpm test` → exit 0, **73/73 tests pass**.
- `docker build -t mcp-openai-relay:test .` → **68.7 MB** image, no warnings.
- Container reaches `Status: healthy` within 2 s of start.
- `docker exec ... id` → `uid=1001(nextjs) gid=101(nodejs)`.
- **S1 tools/list** — `pnpm inspect --url=http://localhost:3000/api/mcp --method=tools/list` returns single `completion_chat` tool.
- **S2 tools/call** — round-trip succeeds against the configured upstream (`isError: false`, non-empty text). Note: `usage.total_tokens` is absent because the configured upstream does not emit a `usage` object — that is upstream behavior, not a container regression.
- **S3 secrets / size** — `docker history --no-trunc | grep -iE 'OPENAI_API_KEY|RELAY_AUTH_TOKEN'` returns NO_LEAK; image size < 200 MB.
- Smoke transcript: `\$STATE_DIR/30-docker-smoke.log`.

## Manual tests

- [x] `docker build` exits 0 on clean checkout
- [x] `docker run` reaches healthy state with required env
- [x] Container runs as non-root (UID 1001)
- [x] `tools/list` returns `completion_chat` against the container
- [x] `tools/call` returns text + `isError: false` against the container
- [x] No real secrets in `docker history`
- [x] `pnpm test` 73/73 pass

## v1 non-goal self-check

- [x] Responses API tools — N/A
- [x] Embeddings / image tools — N/A
- [x] OAuth 2.1 — N/A
- [x] Rate limiting — N/A
- [x] Daily token / dollar budget counters — N/A
- [x] External observability — N/A
- [x] Progress notifications — N/A
- [x] Tool/function-calling pass-through — N/A

## Out of scope (deferred per #30)

- CI workflow that publishes to GHCR / Docker Hub on tag
- Kubernetes / Helm
- `docker-compose.yml`
- Multi-arch image builds