### PR TITLE
chore(docker): default host port 3939 (HOST_PORT override)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,19 @@ cp .env.example .env.local
 docker compose up -d
 ```
 
-The MCP endpoint is now at `http://localhost:3000/api/mcp`. Connect from any
+The MCP endpoint is now at `http://localhost:3939/api/mcp`. Connect from any
 MCP host:
 
 ```bash
 claude mcp add --transport http openai-relay \
-  http://localhost:3000/api/mcp \
+  http://localhost:3939/api/mcp \
   --header "Authorization: Bearer <RELAY_AUTH_TOKEN value>"
 ```
 
-Stop with `docker compose down`. For other deployment paths (raw `docker run`,
-Vercel serverless), see [Deployment options](#deployment-options) below.
+Stop with `docker compose down`. The host port defaults to `3939` to avoid
+clashing with the typical Next.js / Node `:3000`; override with `HOST_PORT=...
+docker compose up -d`. For other deployment paths (raw `docker run`, Vercel
+serverless), see [Deployment options](#deployment-options) below.
 
 ---
 
@@ -113,7 +115,7 @@ Or raw `docker run`:
 
 ```bash
 docker build -t mcp-openai-relay .
-docker run --rm -p 3000:3000 \
+docker run --rm -p 3939:3000 \
   -e OPENAI_API_KEY=sk-... -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
   mcp-openai-relay
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     image: mcp-openai-relay
     ports:
-      - "3000:3000"
+      - "${HOST_PORT:-3939}:3000"
     env_file:
       - .env.local
     restart: unless-stopped

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -212,7 +212,7 @@ secrets — the `pnpm build` script injects build-time dummy values.
 ### Run — inline `-e` flags
 
 ```bash
-docker run --rm -p 3000:3000 \
+docker run --rm -p 3939:3000 \
   -e OPENAI_API_KEY=sk-... \
   -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
   -e OPENAI_BASE_URL=https://your-gateway.example.com/v1 \
@@ -220,6 +220,10 @@ docker run --rm -p 3000:3000 \
   -e REQUEST_TIMEOUT_MS=60000 \
   mcp-openai-relay
 ```
+
+The container listens on port `3000` internally; the host-side mapping
+defaults to `3939` to avoid clashing with the typical Next.js / Node `:3000`.
+Pick any free host port you prefer (`-p 9876:3000`, etc.).
 
 `OPENAI_API_KEY` and `RELAY_AUTH_TOKEN` are required. `OPENAI_BASE_URL`,
 `MAX_OUTPUT_TOKENS_CEILING`, and `REQUEST_TIMEOUT_MS` are optional (see
@@ -230,7 +234,7 @@ docker run --rm -p 3000:3000 \
 Keep secrets in a file the operator manages (gitignored, locked-down perms):
 
 ```bash
-docker run --rm -p 3000:3000 --env-file .env.production mcp-openai-relay
+docker run --rm -p 3939:3000 --env-file .env.production mcp-openai-relay
 ```
 
 ### HEALTHCHECK verification
@@ -245,10 +249,10 @@ which proves the function reached).
 
 ### Smoke test
 
-With the container running on port 3000:
+With the container running (default host port `3939`):
 
 ```bash
-pnpm inspect --url=http://localhost:3000/api/mcp --method=tools/list
+pnpm inspect --url=http://localhost:3939/api/mcp --method=tools/list
 ```
 
 Expect a single tool named `completion_chat`. For the full pre-PR procedure
@@ -277,8 +281,21 @@ cp .env.example .env.local           # then fill OPENAI_API_KEY + RELAY_AUTH_TOK
 docker compose up -d                  # builds on first run, then starts
 ```
 
-The relay is reachable at `http://localhost:3000/api/mcp`. `restart:
+The relay is reachable at `http://localhost:3939/api/mcp`. `restart:
 unless-stopped` keeps it running across reboots.
+
+### Host port override
+
+The host-side port defaults to **`3939`** (chosen to avoid conflicts with the
+common Next.js / Node `:3000`). To map the relay to a different host port,
+set `HOST_PORT`:
+
+```bash
+HOST_PORT=9876 docker compose up -d   # → http://localhost:9876/api/mcp
+```
+
+The container always listens on `3000` internally — only the host-side
+mapping changes.
 
 ### Lifecycle
 
@@ -293,7 +310,7 @@ docker compose up -d --build          # rebuild after Dockerfile / source change
 ### Smoke
 
 ```bash
-pnpm inspect --url=http://localhost:3000/api/mcp --method=tools/list
+pnpm inspect --url=http://localhost:3939/api/mcp --method=tools/list
 ```
 
 ### Env contract


### PR DESCRIPTION
## Why

The compose default mapped `3000:3000`, which collides with the typical
Next.js / Node dev server (e.g., `pnpm dev` on the same machine, another
project's `next dev`, etc.). Reported when the user hit
`Bind for 0.0.0.0:3000 failed: port is already allocated` on a fresh
`docker compose up -d`.

## What

- **`compose.yml`** — `ports: "${HOST_PORT:-3939}:3000"`. Container still listens
  on `3000` internally; only the host-side mapping moves. Override at run
  time: `HOST_PORT=9876 docker compose up -d`.
- **`README.md`** — Quick start endpoint URL becomes `http://localhost:3939/api/mcp`,
  with a one-line note about the override and the rationale.
- **`doc/DEPLOY.md` §5b** — `docker run` examples use `-p 3939:3000`; clarified
  that the container's internal port is `3000` (so the operator can map any
  free host port).
- **`doc/DEPLOY.md` §5c** — new "Host port override" subsection between
  one-shot and lifecycle. Smoke command updated to `:3939`.

## Why 3939?

- 4 digits, easy to remember (memorable repeated pattern).
- Unassigned by IANA in any common-tool range.
- Not used by Node/Next/React/Vite/Astro/Vercel/Docker Desktop/RStudio/Prometheus or other dev tools that commonly grab a port without asking.
- Stays under 65535 and outside ephemeral range (32768+).

## Verification

- `docker compose config` → valid syntax.
- `docker compose up -d` → `Status: healthy` mapped to `0.0.0.0:3939->3000/tcp`.
- `pnpm inspect --method=tools/list` against `:3939` → `completion_chat` returned.
- `HOST_PORT=9876 docker compose up -d` → `Status: healthy` mapped to `0.0.0.0:9876->3000/tcp`.
- `pnpm typecheck` exit 0; `pnpm test` 73/73.

## What is NOT changed

- `pnpm dev` (Next.js) still binds `:3000` — the relay's container port and Node dev port are now distinct, so both can run side-by-side.
- `MCP_URL` default for `pnpm verify` / `pnpm inspect` stays at `http://localhost:3000/api/mcp` because that script targets `pnpm dev`, not the container. Override via `MCP_URL` or `--url=` for container smoke (already documented).