### PR TITLE
chore(docker): default host port 8787 (Cloudflare MCP convention)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,21 @@ cp .env.example .env.local
 docker compose up -d
 ```
 
-The MCP endpoint is now at `http://localhost:3939/api/mcp`. Connect from any
+The MCP endpoint is now at `http://localhost:8787/api/mcp`. Connect from any
 MCP host:
 
 ```bash
 claude mcp add --transport http openai-relay \
-  http://localhost:3939/api/mcp \
+  http://localhost:8787/api/mcp \
   --header "Authorization: Bearer <RELAY_AUTH_TOKEN value>"
 ```
 
-Stop with `docker compose down`. The host port defaults to `3939` to avoid
-clashing with the typical Next.js / Node `:3000`; override with `HOST_PORT=...
-docker compose up -d`. For other deployment paths (raw `docker run`, Vercel
-serverless), see [Deployment options](#deployment-options) below.
+Stop with `docker compose down`. The host port defaults to `8787` — the same
+default Cloudflare Wrangler and Cloudflare's remote-MCP examples use, so
+familiar to anyone in the MCP ecosystem. Override with
+`HOST_PORT=... docker compose up -d`. For other deployment paths (raw
+`docker run`, Vercel serverless), see [Deployment options](#deployment-options)
+below.
 
 ---
 
@@ -115,7 +117,7 @@ Or raw `docker run`:
 
 ```bash
 docker build -t mcp-openai-relay .
-docker run --rm -p 3939:3000 \
+docker run --rm -p 8787:3000 \
   -e OPENAI_API_KEY=sk-... -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
   mcp-openai-relay
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     image: mcp-openai-relay
     ports:
-      - "${HOST_PORT:-3939}:3000"
+      - "${HOST_PORT:-8787}:3000"
     env_file:
       - .env.local
     restart: unless-stopped

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -212,7 +212,7 @@ secrets — the `pnpm build` script injects build-time dummy values.
 ### Run — inline `-e` flags
 
 ```bash
-docker run --rm -p 3939:3000 \
+docker run --rm -p 8787:3000 \
   -e OPENAI_API_KEY=sk-... \
   -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
   -e OPENAI_BASE_URL=https://your-gateway.example.com/v1 \
@@ -222,7 +222,7 @@ docker run --rm -p 3939:3000 \
 ```
 
 The container listens on port `3000` internally; the host-side mapping
-defaults to `3939` to avoid clashing with the typical Next.js / Node `:3000`.
+defaults to `8787` to avoid clashing with the typical Next.js / Node `:3000`.
 Pick any free host port you prefer (`-p 9876:3000`, etc.).
 
 `OPENAI_API_KEY` and `RELAY_AUTH_TOKEN` are required. `OPENAI_BASE_URL`,
@@ -234,7 +234,7 @@ Pick any free host port you prefer (`-p 9876:3000`, etc.).
 Keep secrets in a file the operator manages (gitignored, locked-down perms):
 
 ```bash
-docker run --rm -p 3939:3000 --env-file .env.production mcp-openai-relay
+docker run --rm -p 8787:3000 --env-file .env.production mcp-openai-relay
 ```
 
 ### HEALTHCHECK verification
@@ -249,10 +249,10 @@ which proves the function reached).
 
 ### Smoke test
 
-With the container running (default host port `3939`):
+With the container running (default host port `8787`):
 
 ```bash
-pnpm inspect --url=http://localhost:3939/api/mcp --method=tools/list
+pnpm inspect --url=http://localhost:8787/api/mcp --method=tools/list
 ```
 
 Expect a single tool named `completion_chat`. For the full pre-PR procedure
@@ -281,14 +281,16 @@ cp .env.example .env.local           # then fill OPENAI_API_KEY + RELAY_AUTH_TOK
 docker compose up -d                  # builds on first run, then starts
 ```
 
-The relay is reachable at `http://localhost:3939/api/mcp`. `restart:
+The relay is reachable at `http://localhost:8787/api/mcp`. `restart:
 unless-stopped` keeps it running across reboots.
 
 ### Host port override
 
-The host-side port defaults to **`3939`** (chosen to avoid conflicts with the
-common Next.js / Node `:3000`). To map the relay to a different host port,
-set `HOST_PORT`:
+The host-side port defaults to **`8787`** — the same default Cloudflare
+Wrangler and Cloudflare's remote-MCP server examples use, so users in the
+MCP ecosystem will recognise it. It also avoids the typical Next.js / Node
+`:3000` collision. To map the relay to a different host port, set
+`HOST_PORT`:
 
 ```bash
 HOST_PORT=9876 docker compose up -d   # → http://localhost:9876/api/mcp
@@ -310,7 +312,7 @@ docker compose up -d --build          # rebuild after Dockerfile / source change
 ### Smoke
 
 ```bash
-pnpm inspect --url=http://localhost:3939/api/mcp --method=tools/list
+pnpm inspect --url=http://localhost:8787/api/mcp --method=tools/list
 ```
 
 ### Env contract


### PR DESCRIPTION
## Why

The prior default `3939` (#33) was chosen as "uncommon" but had no lineage. Replacing with `8787` borrows from a well-established MCP-adjacent convention: **Cloudflare Wrangler** (`wrangler dev` default) and Cloudflare's remote-MCP server examples both use `:8787`. Users already running MCP tools through Cloudflare's tooling will recognise it.

## Reference projects considered

| Port | Project | Verdict |
|---|---|---|
| 11434 | Ollama | High collision risk on AI dev machines |
| 1234 | LM Studio | VNC subport collision |
| 8000 | Django, vLLM, LocalAI | Too common |
| 8080 | nginx, Tomcat, OpenWebUI | Universal collision |
| 7860 | text-generation-webui, Gradio | Common on AI dev machines |
| 4000 | LiteLLM, Phoenix | Likely paired with this relay |
| **8787** | **Cloudflare Wrangler / remote-MCP** | **chosen** — MCP ecosystem lineage, narrow conflict surface (RStudio Server) |

## Changes

Pure default-value bump across three files:

- `compose.yml` — `ports: "${HOST_PORT:-8787}:3000"`.
- `README.md` Quick start endpoint URL → `localhost:8787`; lineage note added.
- `doc/DEPLOY.md` §5b/§5c — `docker run` examples and smoke commands updated; lineage note in §5c "Host port override".

Container's internal port is still `3000`. `HOST_PORT` override unchanged.

## Verification

- `docker compose config` valid.
- `docker compose up -d` → `Status: healthy`, mapped `0.0.0.0:8787->3000/tcp`.
- `pnpm inspect --method=tools/list` against `:8787` → `completion_chat` returned.
- `pnpm typecheck` exit 0; `pnpm test` 73/73.