### PR TITLE
docs(sdk): publish prep — README, CHANGELOG, root + DEPLOY links (Phase 3)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -92,6 +92,31 @@ claude mcp add --transport http openai-relay \
 
 ---
 
+## 자기 MCP 서버에 임베드
+
+이 릴레이 앱을 그대로 띄우는 대신 자기 MCP 서버(Vercel/Next.js,
+Cloudflare Workers, Claude Desktop 직결용 stdio, Hono 등)에
+`completion_chat` 기능만 심고 싶다면 SDK 패키지를 설치합니다:
+
+```bash
+npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai
+```
+
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOpenAIChat } from "@ragingwind/mcp-ai-relay/openai";
+
+const server = new McpServer({ name: "my-relay", version: "0.1.0" });
+registerOpenAIChat(server, { apiKey: process.env.OPENAI_API_KEY! });
+```
+
+`registerOpenAIChat`은 closure로 격리되므로, 같은 서버가 여러 업스트림
+(OpenAI proper + Azure + 로컬 vLLM, …)을 별개의 이름을 가진 도구로
+호스팅할 수 있습니다. 전체 API 레퍼런스와 런타임별 레시피:
+[`packages/sdk/README.md`](./packages/sdk/README.md) (영문).
+
+---
+
 ## 기여하기
 
 로컬 개발에는 Node.js 20.x + pnpm 9가 필요합니다:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ Or register directly in `.mcp.json`:
 
 ---
 
+## Embed in your own MCP server
+
+If you want to host the `completion_chat` capability in your own MCP
+server (Vercel/Next.js, Cloudflare Workers, raw stdio for Claude Desktop
+direct, Hono, etc.) instead of running this relay app, install the
+SDK package:
+
+```bash
+npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai
+```
+
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOpenAIChat } from "@ragingwind/mcp-ai-relay/openai";
+
+const server = new McpServer({ name: "my-relay", version: "0.1.0" });
+registerOpenAIChat(server, { apiKey: process.env.OPENAI_API_KEY! });
+```
+
+`registerOpenAIChat` is closure-isolated, so the same server may host
+multiple upstreams (OpenAI proper + Azure + local vLLM, …) as distinct
+named tools. Full API reference and runtime-specific recipes:
+[`packages/sdk/README.md`](./packages/sdk/README.md).
+
+---
+
 ## Contributing
 
 Local development needs Node.js 20.x + pnpm 9:

--- a/doc/DEPLOY.ko.md
+++ b/doc/DEPLOY.ko.md
@@ -27,6 +27,14 @@
 - 외부 노출 시 reverse proxy / load balancer (TLS와 long-running 요청
   타임아웃 처리).
 
+**Embed via SDK** (자기 MCP 서버 — Cloudflare Workers, Claude Desktop
+직결 stdio, Hono, Express 등 — 안에 기능을 임베드):
+- `npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai`.
+- 전체 API + 런타임별 레시피 (Vercel/Next.js, stdio, Cloudflare
+  Workers, 다중 업스트림): [`packages/sdk/README.md`](../packages/sdk/README.md) (영문).
+- 아래 운영 절차 (회전 + 트러블슈팅)는 env 레벨에서 그대로 적용 — 배포
+  표면은 자기 MCP 서버가 ship 하는 곳.
+
 ---
 
 ## 2. OpenAI hard usage cap (필수)

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -27,6 +27,14 @@ For **Docker**:
 - A reverse proxy / load balancer if exposing publicly (handles TLS and
   long-running request timeouts).
 
+For **Embed via SDK** (host the capability inside your own MCP server —
+Cloudflare Workers, raw stdio for Claude Desktop, Hono, Express, etc.):
+- `npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai`.
+- Full API + runtime-specific recipes (Vercel/Next.js, stdio,
+  Cloudflare Workers, multi-upstream): [`packages/sdk/README.md`](../packages/sdk/README.md).
+- Operations (rotation + troubleshooting) below still apply at the env
+  level; deployment surface is whatever your MCP server ships on.
+
 ---
 
 ## 2. OpenAI hard usage cap (MANDATORY)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to `@ragingwind/mcp-ai-relay` are recorded here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+the project adheres to [Semantic Versioning](https://semver.org/) once
+v1.0 ships. Pre-v1.0 minor bumps may include breaking changes — read
+this file before upgrading.
+
+## [0.1.0] — Unreleased
+
+First public release. Extracts the durable, framework-agnostic core of
+[mcp-ai-relay](https://github.com/ragingwind/mcp-ai-relay) into a
+publishable npm package.
+
+### Added
+
+- **`registerOpenAIChat(server, config)`** — register the
+  `completion_chat` MCP tool on any `McpServer`. Each call creates an
+  independent closure; the same server may be registered against
+  multiple times with different `name` + `apiKey` + `baseURL` to expose
+  multiple upstreams as distinct tools (OpenAI proper, Azure OpenAI,
+  vLLM, Ollama, OpenRouter, Vercel AI Gateway in OpenAI mode).
+- **`makeOpenAIChatHandler(config)`** — same factory exposed at handler
+  granularity for advanced consumers (custom dispatchers, non-McpServer
+  hosts, integration tests).
+- **`verifyBearer(actual, expected)`** — constant-time bearer-token
+  comparison using `TextEncoder` + a manual XOR-OR loop. Portable to
+  Node, Bun, Deno, and Cloudflare Workers without `nodejs_compat`.
+- **`parseEnv(source)`** (subpath `./env`) — opt-in zod-validated
+  environment parser. Side-effect-free on import; the consumer chooses
+  when to read `process.env`.
+- **`createOpenAIClient(config)`** (subpath `./openai`) — lower-level
+  factory exposing the OpenAI SDK instance + per-client
+  `AsyncLocalStorage` scope used for upstream-error redaction.
+- Subpath exports: `.`, `./auth`, `./env`, `./openai`. Future provider
+  subpaths (`./anthropic`, `./gemini`, `./ai-gateway`) will be added
+  without breaking existing consumers.
+
+### Tested against
+
+- Node.js 20.x (engine declaration)
+- `@modelcontextprotocol/sdk@^1.26`
+- `openai@^6`
+- `mcp-handler@^1.1` (for Vercel/Next.js consumers)
+
+### Notes for early adopters
+
+- API surface is **stable in shape but pre-1.0** — minor bumps may
+  refine names. v1.0 freezes the surface (planned after ≥4 weeks of
+  dogfooding).
+- `openai` is a peer dependency marked `optional`. The 0.1.0 SDK ships
+  only the `./openai` subpath, so consumers do need it today —
+  `peerDependenciesMeta.openai.optional = true` is forward-looking for
+  the planned `./anthropic` / `./gemini` / `./ai-gateway` subpaths.
+- `AsyncLocalStorage` is required for the upstream-body redaction
+  feature. Workers must enable `compatibility_flags = ["nodejs_compat"]`;
+  runtimes without AsyncLocalStorage get a no-op fallback (the SDK's
+  default error message remains, just without the redacted snippet).

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jimmy Moon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,311 @@
+# @ragingwind/mcp-ai-relay
+
+Provider-agnostic MCP relay SDK. Embed `completion_chat` (OpenAI Chat
+Completions, OpenAI-compatible APIs, and unified gateways) — and future
+provider tools — into any [Model Context Protocol](https://modelcontextprotocol.io)
+server.
+
+The SDK is the durable artifact. The
+[mcp-ai-relay](https://github.com/ragingwind/mcp-ai-relay) repository
+also ships a Vercel/Next.js reference relay that consumes this package;
+see its README for self-hosted Docker and Vercel deployment paths.
+
+> **v0.1.0** ships only the OpenAI provider. Future provider subpaths
+> (`./anthropic`, `./gemini`, `./ai-gateway`) will land under their own
+> directories without breaking existing `./openai` consumers.
+
+---
+
+## Install
+
+```bash
+npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai
+# or
+pnpm add @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai
+```
+
+`@modelcontextprotocol/sdk` and `openai` are declared as **peer
+dependencies** so the consumer controls their versions. `openai` is
+optional in the package metadata — future non-OpenAI subpaths will not
+require it — but you need it today for `./openai`.
+
+Requires **Node.js 20+** (or any runtime with `node:async_hooks`
+compatibility — Bun, Deno, Cloudflare Workers with `nodejs_compat`).
+
+---
+
+## Quick start
+
+### Embed in a Vercel/Next.js MCP route
+
+```ts
+// app/api/[transport]/route.ts
+import { verifyBearer } from "@ragingwind/mcp-ai-relay";
+import { parseEnv } from "@ragingwind/mcp-ai-relay/env";
+import { registerOpenAIChat } from "@ragingwind/mcp-ai-relay/openai";
+import { createMcpHandler, withMcpAuth } from "mcp-handler";
+
+const env = parseEnv(process.env);
+
+const handler = createMcpHandler(
+  (server) => {
+    registerOpenAIChat(server, {
+      apiKey: env.OPENAI_API_KEY,
+      ...(env.OPENAI_BASE_URL ? { baseURL: env.OPENAI_BASE_URL } : {}),
+      maxOutputTokensCeiling: env.MAX_OUTPUT_TOKENS_CEILING,
+      requestTimeoutMs: env.REQUEST_TIMEOUT_MS,
+    });
+  },
+  {},
+  { basePath: "/api" },
+);
+
+const wrapped = withMcpAuth(
+  handler,
+  (_req, token) =>
+    verifyBearer(token, env.RELAY_AUTH_TOKEN)
+      ? { token: token as string, clientId: "shared-secret", scopes: ["openai:chat"] }
+      : undefined,
+  { required: true, requiredScopes: ["openai:chat"] },
+);
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+export { wrapped as GET, wrapped as POST, wrapped as DELETE };
+```
+
+### Embed in a stdio MCP server (Claude Desktop direct)
+
+```ts
+// server.ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerOpenAIChat } from "@ragingwind/mcp-ai-relay/openai";
+
+const server = new McpServer({ name: "openai-relay", version: "0.1.0" });
+registerOpenAIChat(server, {
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+await server.connect(new StdioServerTransport());
+```
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "node",
+      "args": ["/absolute/path/to/server.js"],
+      "env": { "OPENAI_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+### Embed in a Cloudflare Workers MCP
+
+```ts
+// src/index.ts
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOpenAIChat } from "@ragingwind/mcp-ai-relay/openai";
+
+export class OpenAIRelay extends McpAgent {
+  server = new McpServer({ name: "openai-relay", version: "0.1.0" });
+
+  async init() {
+    registerOpenAIChat(this.server, { apiKey: this.env.OPENAI_API_KEY });
+  }
+}
+```
+
+`wrangler.toml` requires `compatibility_flags = ["nodejs_compat"]` so
+`AsyncLocalStorage` (used internally for upstream-error redaction) is
+available. Without it, the SDK degrades gracefully — the request still
+succeeds, but upstream 5xx body snippets won't appear in the result text.
+
+### Multi-upstream (one server, multiple instances)
+
+`registerOpenAIChat` is closure-isolated: each call captures its own
+client, ceiling, and timeout. Call it any number of times on the same
+server with distinct `name` values to expose multiple upstreams as
+distinct tools.
+
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOpenAIChat } from "@ragingwind/mcp-ai-relay/openai";
+
+const server = new McpServer({ name: "multi-relay", version: "0.1.0" });
+
+// OpenAI proper.
+registerOpenAIChat(server, {
+  name: "openai_chat",
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+// Azure OpenAI deployment.
+registerOpenAIChat(server, {
+  name: "azure_chat",
+  apiKey: process.env.AZURE_OPENAI_KEY!,
+  baseURL: "https://<resource>.openai.azure.com/openai/deployments/<deployment>",
+  description: "Azure OpenAI — internal-data tier",
+});
+
+// Local Ollama / vLLM (OpenAI-compatible).
+registerOpenAIChat(server, {
+  name: "local_llm",
+  apiKey: "not-needed",
+  baseURL: "http://localhost:11434/v1",
+  maxOutputTokensCeiling: 8192,
+});
+```
+
+`tools/list` then exposes `openai_chat`, `azure_chat`, and `local_llm`
+as three distinct entries. Each `tools/call` routes to the upstream
+captured at registration time. Aborting one in-flight call does not
+affect the others.
+
+---
+
+## API reference
+
+### `registerOpenAIChat(server, config)`
+
+```ts
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type OpenAI from "openai";
+import type { RequestScope } from "@ragingwind/mcp-ai-relay/openai";
+
+export interface OpenAIChatConfig {
+  /** Registered MCP tool name. Default `"completion_chat"`.
+   *  Must be unique within an MCP server when multiple instances are
+   *  registered. snake_case is the MCP convention. */
+  name?: string;
+  /** Description override. Default is the SDK's built-in summary. */
+  description?: string;
+  /** OpenAI API key. Required unless `openaiClient` is supplied. */
+  apiKey: string;
+  /** OpenAI base URL override (Azure / vLLM / Ollama / AI Gateway / mock). */
+  baseURL?: string;
+  /** Server-side ceiling for `max_tokens`. Default 4096. */
+  maxOutputTokensCeiling?: number;
+  /** Per-request OpenAI timeout in ms. Default 60_000. */
+  requestTimeoutMs?: number;
+  /** Inject a pre-built OpenAI client. When supplied,
+   *  `apiKey` / `baseURL` / `requestTimeoutMs` are ignored. */
+  openaiClient?: OpenAI;
+  /** Inject a request scope paired with `openaiClient`. Required only
+   *  when both are supplied AND upstream-body redaction must remain wired. */
+  requestScope?: RequestScope;
+}
+
+export function registerOpenAIChat(server: McpServer, config: OpenAIChatConfig): void;
+```
+
+### `makeOpenAIChatHandler(config)`
+
+The factory `registerOpenAIChat` calls internally. Exposed for advanced
+consumers (custom dispatchers, non-McpServer hosts, integration tests).
+
+```ts
+export function makeOpenAIChatHandler(config: OpenAIChatConfig): {
+  schema: OpenAIChatSchema;
+  handler: OpenAIChatHandler;
+  name: string;
+  description: string;
+};
+```
+
+### `verifyBearer(actual, expected)`
+
+Constant-time byte comparison using `TextEncoder` and a manual XOR-OR
+loop. Portable to Node, Bun, Deno, and Workers without `nodejs_compat`.
+
+```ts
+export function verifyBearer(
+  actual: string | undefined,
+  expected: string | undefined,
+): boolean;
+```
+
+### `parseEnv(source)` (opt-in subpath)
+
+```ts
+import { parseEnv } from "@ragingwind/mcp-ai-relay/env";
+
+const env = parseEnv(process.env);  // explicit — no auto-load on import
+```
+
+Recognized keys: `OPENAI_API_KEY` (default `""`), `OPENAI_BASE_URL`
+(optional URL), `RELAY_AUTH_TOKEN` (required, ≥32 bytes),
+`MAX_OUTPUT_TOKENS_CEILING` (default 4096), `REQUEST_TIMEOUT_MS`
+(default 60000). Error messages never echo input values.
+
+### `createOpenAIClient(config)`
+
+Lower-level factory that returns an `OpenAI` client wired with
+fetch-redaction (5xx body capture) and a per-client `AsyncLocalStorage`
+scope. Used internally by `registerOpenAIChat`; exported for consumers
+who want to share one client across multiple registrations.
+
+---
+
+## Result shape
+
+```ts
+{
+  content: [{ type: "text", text: string }],
+  structuredContent: {
+    model: string,
+    usage?: { prompt_tokens, completion_tokens, total_tokens },
+    finish_reason?: "stop" | "length" | "tool_calls" | "content_filter" | "function_call",
+    code?: ToolErrorCode,         // only when isError === true
+    retryAfter?: number,           // only on rate_limited
+  },
+  isError: boolean,
+}
+```
+
+`ToolErrorCode` values: `"auth"`, `"rate_limited"`, `"context_length"`,
+`"content_policy"`, `"upstream_error"`, `"bad_request"`. Error result
+text is the SDK's mapped message; the raw upstream body is never echoed
+unless it appears in a 5xx fallback path (where the API key is redacted
+to `[REDACTED]` before the body is included).
+
+---
+
+## Compatibility
+
+Tested against:
+
+| Dependency | Version |
+|---|---|
+| Node.js | 20.x |
+| `@modelcontextprotocol/sdk` | `^1.26` |
+| `openai` | `^6` |
+| `mcp-handler` (optional, for Vercel/Next.js) | `^1.1` |
+
+The SDK is ESM-only (`"type": "module"`). Transitive `node:` imports
+limited to `node:async_hooks` (used in `createOpenAIClient`); replace
+with explicit threading if your runtime lacks AsyncLocalStorage and
+upstream-body redaction matters.
+
+---
+
+## Non-goals (v0.x)
+
+- Embeddings / image / audio tools — provider tools beyond chat
+  completion are tracked for v1.x via the planned `./openai` companion
+  registrars (`registerOpenAIEmbeddings`, etc.).
+- OAuth 2.1 — bearer-shared-secret only.
+- Rate limiting / budget caps / observability — consumer-side concerns.
+- Adapter sub-packages (e.g. `./adapters/mcp-handler`) — kept minimal
+  in 0.x; cookbook examples cover wiring.
+
+---
+
+## License
+
+MIT.


### PR DESCRIPTION
Phase 3 of the SDK extraction (epic #39, sub-issue #42). Splits the documentation deliverables of #42 from the actual `pnpm publish` step. The publish itself runs from a developer machine with npm auth and is **not** included in this PR.

## Scope of this PR

### Added

- **`packages/sdk/README.md`** — full consumer-facing SDK doc:
  - Install + peerDeps (`@modelcontextprotocol/sdk`, `openai`)
  - Quick starts: Vercel/Next.js, stdio (Claude Desktop direct), Cloudflare Workers
  - **Multi-upstream registration** (one server, multiple `registerOpenAIChat` calls with distinct `name` + `apiKey` + `baseURL`)
  - API reference for `registerOpenAIChat`, `makeOpenAIChatHandler`, `verifyBearer`, `parseEnv`, `createOpenAIClient`
  - Result shape + error code table
  - Compatibility matrix (Node 20+, MCP SDK `^1.26`, `openai ^6`, `mcp-handler ^1.1`)
  - v0.x non-goals
- **`packages/sdk/CHANGELOG.md`** — Keep a Changelog format. `0.1.0` entry summarizes Phase 1 + Phase 2 surface and notes early-adopter caveats (semver pre-1.0, AsyncLocalStorage Workers requirement, `openai` peerDep optional being forward-looking).
- **`packages/sdk/LICENSE`** — copied from the repo root (MIT) so the npm tarball includes it.

### Updated

- **`README.md`** (+ `README.ko.md`) — new **'Embed in your own MCP server'** section with a 4-line quick example and link to `packages/sdk/README.md`.
- **`doc/DEPLOY.md`** (+ `.ko.md`) — adds **'Embed via SDK'** as the fourth path in §1 Prerequisites, pointing at the SDK README. Vercel + Docker procedures themselves are unchanged.

## Tarball verification (`npm pack --dry-run`)

```
@ragingwind/mcp-ai-relay@0.1.0
27 files, 14.2 kB compressed, 45.6 kB unpacked

Contents:
  dist/ (.js + .d.ts + .map for index, auth, env, openai/{chat,client,index})
  README.md (9.6 kB)
  LICENSE (1.1 kB)
  package.json (1.3 kB)
```

No source `.ts`, no tests, no config files. The `files` field in `package.json` correctly limits to `["dist", "README.md", "LICENSE"]`.

## Out of scope (split from this PR — to be done after merge)

- **Actual publish**: `pnpm publish --filter @ragingwind/mcp-ai-relay --tag next --access public` (smoke), then promote to latest. Requires:
  - `npm login` on the maintainer's machine
  - `@ragingwind` npm scope ownership
  - Scope availability check (`npm view @ragingwind/mcp-ai-relay`)
- **Tag**: `git tag sdk-v0.1.0 && git push --tags` after publish succeeds.
- **Smoke validation**: scratch project install + 10-line stdio launcher against real OpenAI.

#42 stays open until the package is live on npm.

## Verification

- `pnpm typecheck` — green
- `pnpm test` — **80 tests pass**
- `pnpm build` — green
- `pnpm --filter @ragingwind/mcp-ai-relay exec npm pack --dry-run` — green (27 files, no leakage of src/tests)

---

> **Note**: opened as **draft** for the same gate-harness reason as #45/#46. Substantive checks pass per Verification.