### PR TITLE
feat(sdk): zero-config CLI bin (mcp-ai-relay --openai-completion)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -96,7 +96,25 @@ claude mcp add --transport http openai-relay \
 
 이 릴레이 앱을 그대로 띄우는 대신 자기 MCP 서버(Vercel/Next.js,
 Cloudflare Workers, Claude Desktop 직결용 stdio, Hono 등)에
-`completion_chat` 기능만 심고 싶다면 SDK 패키지를 설치합니다:
+`completion_chat` 기능만 심고 싶다면 두 가지 경로가 있습니다:
+
+**Zero-config (코드 없이) — `npx`**
+
+Claude Desktop의 `claude_desktop_config.json`에 바로 등록:
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "npx",
+      "args": ["-y", "@ragingwind/mcp-ai-relay", "--openai-completion"],
+      "env": { "OPENAI_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+**라이브러리 API (전체 제어권)**
 
 ```bash
 npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai

--- a/README.md
+++ b/README.md
@@ -97,8 +97,26 @@ Or register directly in `.mcp.json`:
 
 If you want to host the `completion_chat` capability in your own MCP
 server (Vercel/Next.js, Cloudflare Workers, raw stdio for Claude Desktop
-direct, Hono, etc.) instead of running this relay app, install the
-SDK package:
+direct, Hono, etc.) instead of running this relay app, the SDK supports
+two paths:
+
+**Zero-config (no code) — `npx`**
+
+Register directly in Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "npx",
+      "args": ["-y", "@ragingwind/mcp-ai-relay", "--openai-completion"],
+      "env": { "OPENAI_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+**Library API (full control)**
 
 ```bash
 npm install @ragingwind/mcp-ai-relay @modelcontextprotocol/sdk openai

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -14,6 +14,16 @@ publishable npm package.
 
 ### Added
 
+- **CLI bin `mcp-ai-relay`** — zero-config stdio MCP server launcher.
+  `npx -y @ragingwind/mcp-ai-relay --openai-completion` registers the
+  `completion_chat` tool and connects via stdio. Provider flag set is
+  designed for forward extension (`--anthropic-messages`,
+  `--gemini-generate`, `--ai-gateway-chat` reserved). `--name` and
+  `--description` flags override the default tool descriptor; env vars
+  (`OPENAI_API_KEY`, optional `OPENAI_BASE_URL`,
+  `OPENAI_MAX_OUTPUT_TOKENS_CEILING`, `OPENAI_REQUEST_TIMEOUT_MS`)
+  supply the runtime config. Multi-upstream registration stays a
+  code-based use case — the CLI ships one tool per invocation.
 - **`registerOpenAIChat(server, config)`** — register the
   `completion_chat` MCP tool on any `McpServer`. Each call creates an
   independent closure; the same server may be registered against

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -36,6 +36,57 @@ compatibility — Bun, Deno, Cloudflare Workers with `nodejs_compat`).
 
 ## Quick start
 
+### Zero-config CLI (no code, no install — `npx`)
+
+Easiest path for the single-OpenAI use case. The SDK ships a `bin`
+named `mcp-ai-relay`; pass a provider flag and the package launches a
+stdio MCP server that registers the matching tool.
+
+Register directly in `claude_desktop_config.json` (Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "npx",
+      "args": ["-y", "@ragingwind/mcp-ai-relay", "--openai-completion"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+CLI surface:
+
+```
+mcp-ai-relay <provider-flag> [--name <name>] [--description <desc>]
+
+Provider flags (exactly one required):
+  --openai-completion   OpenAI Chat Completions
+                        Required env: OPENAI_API_KEY
+                        Optional env: OPENAI_BASE_URL,
+                                      OPENAI_MAX_OUTPUT_TOKENS_CEILING,
+                                      OPENAI_REQUEST_TIMEOUT_MS
+
+Options:
+  --name <name>         Override the registered MCP tool name
+                        (default: completion_chat)
+  --description <desc>  Override the tool description
+  --help, -h            Show this message
+  --version, -V         Print SDK version
+```
+
+Future flags (reserved): `--anthropic-messages`, `--gemini-generate`,
+`--ai-gateway-chat`. Each follows the same pattern: provider-prefixed
+env vars supply the credentials.
+
+**Multi-upstream is intentionally not expressible via the CLI.** Use
+the SDK API directly when you want one server hosting OpenAI + Azure +
+local LLM as distinct named tools — see
+[examples/multi-upstream/](https://github.com/ragingwind/mcp-ai-relay/tree/main/examples/multi-upstream).
+
 ### Embed in a Vercel/Next.js MCP route
 
 ```ts

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,13 +25,16 @@
       "import": "./dist/openai/index.js"
     }
   },
+  "bin": {
+    "mcp-ai-relay": "./dist/bin/cli.js"
+  },
   "files": [
     "dist",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node -e \"require('node:fs').chmodSync('dist/bin/cli.js', 0o755)\"",
     "build:watch": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run --passWithNoTests",
     "clean": "rm -rf dist"

--- a/packages/sdk/src/bin/cli.ts
+++ b/packages/sdk/src/bin/cli.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+//
+// Zero-config CLI for @ragingwind/mcp-ai-relay.
+//
+// Launches a single-tool stdio MCP server using the SDK's registrar
+// for the provider/capability selected by a flag. Designed for direct
+// consumption from `claude_desktop_config.json` via `npx`:
+//
+//   {
+//     "mcpServers": {
+//       "openai-relay": {
+//         "command": "npx",
+//         "args": ["-y", "@ragingwind/mcp-ai-relay", "--openai-completion"],
+//         "env": { "OPENAI_API_KEY": "sk-..." }
+//       }
+//     }
+//   }
+//
+// One flag = one provider/capability. Future flags reserved:
+//   --openai-completion    OpenAI Chat Completions       [SHIPPING in 0.1.0]
+//   --anthropic-messages   Anthropic Messages            [reserved]
+//   --gemini-generate      Gemini generateContent        [reserved]
+//   --ai-gateway-chat      Vercel AI Gateway (chat mode) [reserved]
+//
+// Multi-upstream registration (one server, multiple distinct names) is
+// not expressible via the CLI surface. Use the SDK API directly — see
+// `examples/multi-upstream/` in the repo.
+//
+// Pure helpers (parseArgs, buildOpenAIChatConfig, …) live in
+// `./helpers.js` so unit tests can import them without invoking
+// `main()`.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerOpenAIChat } from "../openai/index.js";
+import { buildOpenAIChatConfig, parseArgs, type ParsedArgs } from "./helpers.js";
+
+// Bumped in lockstep with package.json on every release.
+const VERSION = "0.1.0";
+
+const USAGE = `Usage: mcp-ai-relay <provider-flag> [--name <name>] [--description <desc>]
+
+Provider flags (exactly one required):
+  --openai-completion   OpenAI Chat Completions
+                        Required env: OPENAI_API_KEY
+                        Optional env: OPENAI_BASE_URL,
+                                      OPENAI_MAX_OUTPUT_TOKENS_CEILING,
+                                      OPENAI_REQUEST_TIMEOUT_MS
+
+Options:
+  --name <name>         Override the registered MCP tool name
+                        (default: completion_chat)
+  --description <desc>  Override the tool description
+  --help, -h            Show this message
+  --version, -V         Print SDK version
+
+Example:
+  OPENAI_API_KEY=sk-... npx -y @ragingwind/mcp-ai-relay --openai-completion
+
+Multi-upstream registration is not expressible via the CLI; use the
+SDK API directly. See:
+  https://github.com/ragingwind/mcp-ai-relay/tree/main/examples/multi-upstream
+`;
+
+async function main(): Promise<void> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    process.stderr.write(`${(e as Error).message}\n\n${USAGE}`);
+    process.exit(2);
+  }
+
+  if (args.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+  if (args.version) {
+    process.stdout.write(`${VERSION}\n`);
+    return;
+  }
+  if (!args.provider) {
+    process.stderr.write(`A provider flag is required.\n\n${USAGE}`);
+    process.exit(2);
+  }
+
+  const server = new McpServer({
+    name: `mcp-ai-relay-${args.provider}`,
+    version: VERSION,
+  });
+
+  switch (args.provider) {
+    case "openai-completion":
+      registerOpenAIChat(server, buildOpenAIChatConfig(args));
+      break;
+  }
+
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((err) => {
+  process.stderr.write(`${(err as Error).stack ?? (err as Error).message}\n`);
+  process.exit(1);
+});

--- a/packages/sdk/src/bin/cli.ts
+++ b/packages/sdk/src/bin/cli.ts
@@ -33,7 +33,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerOpenAIChat } from "../openai/index.js";
-import { buildOpenAIChatConfig, parseArgs, type ParsedArgs } from "./helpers.js";
+import { buildOpenAIChatConfig, type ParsedArgs, parseArgs } from "./helpers.js";
 
 // Bumped in lockstep with package.json on every release.
 const VERSION = "0.1.0";

--- a/packages/sdk/src/bin/helpers.ts
+++ b/packages/sdk/src/bin/helpers.ts
@@ -1,0 +1,92 @@
+// Pure helpers for the CLI bin. Separated from `cli.ts` so unit tests
+// can import them without triggering the top-level `main()` call that
+// runs when the entry script is loaded.
+
+import type { OpenAIChatConfig } from "../openai/index.js";
+
+export type Provider = "openai-completion";
+
+export interface ParsedArgs {
+  provider: Provider | null;
+  name?: string;
+  description?: string;
+  help: boolean;
+  version: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const result: ParsedArgs = { provider: null, help: false, version: false };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--openai-completion":
+        if (result.provider !== null) {
+          throw new Error(
+            `Multiple provider flags supplied. Pass exactly one (got: --${result.provider} and ${arg}).`,
+          );
+        }
+        result.provider = "openai-completion";
+        break;
+      case "--name": {
+        const next = argv[++i];
+        if (!next || next.startsWith("--")) throw new Error("--name requires a value");
+        result.name = next;
+        break;
+      }
+      case "--description": {
+        const next = argv[++i];
+        if (!next || next.startsWith("--")) throw new Error("--description requires a value");
+        result.description = next;
+        break;
+      }
+      case "--help":
+      case "-h":
+        result.help = true;
+        break;
+      case "--version":
+      case "-V":
+        result.version = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return result;
+}
+
+export function requireEnv(key: string): string {
+  const v = process.env[key];
+  if (!v) {
+    process.stderr.write(`Required environment variable ${key} is not set.\n`);
+    process.exit(1);
+  }
+  return v;
+}
+
+export function optionalNumberEnv(key: string): number | undefined {
+  const v = process.env[key];
+  if (!v) return undefined;
+  const n = Number(v);
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(`Environment variable ${key} must be a positive number, got: ${v}\n`);
+    process.exit(1);
+  }
+  return n;
+}
+
+export function buildOpenAIChatConfig(args: ParsedArgs): OpenAIChatConfig {
+  const config: OpenAIChatConfig = {
+    apiKey: requireEnv("OPENAI_API_KEY"),
+  };
+  const baseURL = process.env.OPENAI_BASE_URL;
+  if (baseURL) config.baseURL = baseURL;
+  const ceiling = optionalNumberEnv("OPENAI_MAX_OUTPUT_TOKENS_CEILING");
+  if (ceiling !== undefined) config.maxOutputTokensCeiling = ceiling;
+  const timeoutMs = optionalNumberEnv("OPENAI_REQUEST_TIMEOUT_MS");
+  if (timeoutMs !== undefined) config.requestTimeoutMs = timeoutMs;
+  if (args.name) config.name = args.name;
+  if (args.description) config.description = args.description;
+  return config;
+}

--- a/packages/sdk/tests/unit/cli.test.ts
+++ b/packages/sdk/tests/unit/cli.test.ts
@@ -1,0 +1,165 @@
+// Unit tests for the CLI's pure helpers — `parseArgs` and
+// `buildOpenAIChatConfig`. The `main()` invocation itself is left
+// untested at the unit layer (it touches stdin/stdout + process.exit
+// which is awkward to harness); end-to-end smoke is the README's
+// `--help` and `tools/list` invocations.
+//
+// Helpers live in `src/bin/helpers.ts` (split from `cli.ts`) so
+// importing them does NOT trigger the CLI's top-level `main()`.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildOpenAIChatConfig, parseArgs } from "../../src/bin/helpers.js";
+
+describe("parseArgs", () => {
+  it("P1: parses --openai-completion as provider", () => {
+    const out = parseArgs(["--openai-completion"]);
+    expect(out.provider).toBe("openai-completion");
+    expect(out.help).toBe(false);
+    expect(out.version).toBe(false);
+  });
+
+  it("P2: --help short and long forms set help: true", () => {
+    expect(parseArgs(["--help"]).help).toBe(true);
+    expect(parseArgs(["-h"]).help).toBe(true);
+  });
+
+  it("P3: --version short and long forms set version: true", () => {
+    expect(parseArgs(["--version"]).version).toBe(true);
+    expect(parseArgs(["-V"]).version).toBe(true);
+  });
+
+  it("P4: --name <value> captures the next token", () => {
+    const out = parseArgs(["--openai-completion", "--name", "my_chat"]);
+    expect(out.name).toBe("my_chat");
+  });
+
+  it("P5: --description <value> captures the next token", () => {
+    const out = parseArgs(["--openai-completion", "--description", "my desc"]);
+    expect(out.description).toBe("my desc");
+  });
+
+  it("D1: rejects unknown arguments", () => {
+    expect(() => parseArgs(["--unknown"])).toThrow(/Unknown argument: --unknown/);
+  });
+
+  it("D2: rejects multiple provider flags (when more land in v0.x)", () => {
+    // Synthetic test: simulate by running --openai-completion twice. Since
+    // we ship one provider today, the same flag twice exercises the same
+    // guard the future multi-flag rejection will use.
+    expect(() => parseArgs(["--openai-completion", "--openai-completion"])).toThrow(
+      /Multiple provider flags/,
+    );
+  });
+
+  it("D3: rejects --name without a value", () => {
+    expect(() => parseArgs(["--openai-completion", "--name"])).toThrow(/--name requires a value/);
+  });
+
+  it("D4: rejects --name when the next token starts with --", () => {
+    expect(() => parseArgs(["--openai-completion", "--name", "--description", "x"])).toThrow(
+      /--name requires a value/,
+    );
+  });
+
+  it("N1: empty argv yields provider: null + help/version: false", () => {
+    const out = parseArgs([]);
+    expect(out.provider).toBeNull();
+    expect(out.help).toBe(false);
+    expect(out.version).toBe(false);
+    expect(out.name).toBeUndefined();
+    expect(out.description).toBeUndefined();
+  });
+});
+
+describe("buildOpenAIChatConfig", () => {
+  // Snapshot env keys the helper reads so we can restore exact state.
+  const KEYS = [
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_MAX_OUTPUT_TOKENS_CEILING",
+    "OPENAI_REQUEST_TIMEOUT_MS",
+  ] as const;
+  let saved: Partial<Record<(typeof KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      const v = saved[k];
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  it("P1: builds minimum config from OPENAI_API_KEY only", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const config = buildOpenAIChatConfig({
+      provider: "openai-completion",
+      help: false,
+      version: false,
+    });
+    expect(config.apiKey).toBe("sk-test");
+    expect(config.baseURL).toBeUndefined();
+    expect(config.maxOutputTokensCeiling).toBeUndefined();
+    expect(config.requestTimeoutMs).toBeUndefined();
+    expect(config.name).toBeUndefined();
+    expect(config.description).toBeUndefined();
+  });
+
+  it("P2: forwards OPENAI_BASE_URL", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_BASE_URL = "https://azure.example.com/v1";
+    const config = buildOpenAIChatConfig({
+      provider: "openai-completion",
+      help: false,
+      version: false,
+    });
+    expect(config.baseURL).toBe("https://azure.example.com/v1");
+  });
+
+  it("P3: parses OPENAI_MAX_OUTPUT_TOKENS_CEILING + OPENAI_REQUEST_TIMEOUT_MS as numbers", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_MAX_OUTPUT_TOKENS_CEILING = "8192";
+    process.env.OPENAI_REQUEST_TIMEOUT_MS = "30000";
+    const config = buildOpenAIChatConfig({
+      provider: "openai-completion",
+      help: false,
+      version: false,
+    });
+    expect(config.maxOutputTokensCeiling).toBe(8192);
+    expect(config.requestTimeoutMs).toBe(30000);
+  });
+
+  it("P4: --name and --description override flow into config", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const config = buildOpenAIChatConfig({
+      provider: "openai-completion",
+      name: "my_chat",
+      description: "Custom",
+      help: false,
+      version: false,
+    });
+    expect(config.name).toBe("my_chat");
+    expect(config.description).toBe("Custom");
+  });
+
+  it("N1: omits OPENAI_BASE_URL when env is empty string", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_BASE_URL = "";
+    const config = buildOpenAIChatConfig({
+      provider: "openai-completion",
+      help: false,
+      version: false,
+    });
+    expect(config.baseURL).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds a `bin` entry to `@ragingwind/mcp-ai-relay` so users can register the relay in Claude Desktop config with **zero code**:

```json
{
  "mcpServers": {
    "openai-relay": {
      "command": "npx",
      "args": ["-y", "@ragingwind/mcp-ai-relay", "--openai-completion"],
      "env": { "OPENAI_API_KEY": "sk-..." }
    }
  }
}
```

## CLI surface

```
mcp-ai-relay <provider-flag> [--name <name>] [--description <desc>]

Provider flags (extensible — one per invocation):
  --openai-completion    OpenAI Chat Completions   [SHIPPING in 0.1.0]
  --anthropic-messages   Anthropic Messages        [reserved]
  --gemini-generate      Gemini generateContent    [reserved]
  --ai-gateway-chat      Vercel AI Gateway         [reserved]

Options:
  --name <name>          Override default tool name (default: completion_chat)
  --description <desc>   Override default tool description
  --help, -h
  --version, -V
```

Env vars per provider follow `<PROVIDER>_<KEY>`:
- `--openai-completion`: `OPENAI_API_KEY` (required), `OPENAI_BASE_URL`, `OPENAI_MAX_OUTPUT_TOKENS_CEILING`, `OPENAI_REQUEST_TIMEOUT_MS` (optional)

**Multi-upstream is intentionally NOT expressible via CLI** — that case stays on the SDK API + `examples/multi-upstream/`. CLI ships one tool per invocation.

## Implementation

| File | Purpose |
|---|---|
| `packages/sdk/src/bin/cli.ts` | Shebang entry. Imports helpers, parses argv, builds config from env, registers tool, connects stdio. |
| `packages/sdk/src/bin/helpers.ts` | Pure functions split from `cli.ts` so unit tests can import without invoking `main()` (which calls `process.exit` on missing flags). |
| `packages/sdk/package.json` | `bin: { mcp-ai-relay: ./dist/bin/cli.js }` + cross-platform `chmod +x` via `node -e fs.chmodSync(...)` in build. |
| `packages/sdk/tests/unit/cli.test.ts` | 15 unit tests covering `parseArgs` (P1-P5, D1-D4, N1) + `buildOpenAIChatConfig` (P1-P4, N1) — all pure helpers, no I/O. |

## Live smoke

```bash
$ node packages/sdk/dist/bin/cli.js --help                 # ✓ usage printed
$ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
    | OPENAI_API_KEY=test node packages/sdk/dist/bin/cli.js --openai-completion
{ "result": { "tools": [ { "name": "completion_chat", ... } ] }, ... }      # ✓
$ ... --openai-completion --name azure_chat --description "Azure"
{ "result": { "tools": [ { "name": "azure_chat", "description": "Azure", ... } ] } }  # ✓
```

## Docs

- `packages/sdk/README.md` — new 'Zero-config CLI' section as the **first** Quick Start (the most common consumer path).
- `packages/sdk/CHANGELOG.md` — `0.1.0` entry now leads with the CLI bin.
- root `README.md` (+ `.ko.md`) — 'Embed in your own MCP server' splits into 'Zero-config (npx)' and 'Library API' subsections.

## Verification

- `pnpm typecheck` — green
- `pnpm test` — **95/95** (was 80 + 15 cli helper tests)
- `pnpm build` — green
- `npm pack --dry-run` — 35 files (was 27); adds `cli.js`, `helpers.js`, their `.d.ts` and sourcemaps. No source TS leakage.

## Activation timeline

The CLI activates the moment `@ragingwind/mcp-ai-relay@0.1.0` is published to npm (Phase 3 #42 still open). After publish, this becomes the recommended quick-start path. README docs are already wired.

---

> **Note**: opened as **draft** for the same gate-harness reason as prior phase PRs. Substantive checks are green per Verification.