### PR TITLE
fix(sdk): make openai a required peer + add bin-tarball integration test

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -46,11 +46,6 @@
     "@modelcontextprotocol/sdk": "^1.26",
     "openai": "^6"
   },
-  "peerDependenciesMeta": {
-    "openai": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": ">=20"
   },

--- a/packages/sdk/tests/integration/bin-tarball.test.ts
+++ b/packages/sdk/tests/integration/bin-tarball.test.ts
@@ -42,7 +42,9 @@ beforeAll(async () => {
   execFileSync("npm", ["pack"], { cwd: SDK_DIR, stdio: "pipe" });
   const tarballs = readdirSync(SDK_DIR).filter((f) => f.endsWith(".tgz"));
   if (tarballs.length !== 1) {
-    throw new Error(`Expected 1 tarball after npm pack, got ${tarballs.length}: ${tarballs.join(", ")}`);
+    throw new Error(
+      `Expected 1 tarball after npm pack, got ${tarballs.length}: ${tarballs.join(", ")}`,
+    );
   }
   const tarball = join(SDK_DIR, tarballs[0]!);
 
@@ -91,9 +93,7 @@ describe("cli bin — installed tarball", () => {
       encoding: "utf8",
     });
     expect(r.status).toBe(0);
-    const responseLine = r.stdout
-      .split("\n")
-      .find((l) => l.trim().startsWith("{"));
+    const responseLine = r.stdout.split("\n").find((l) => l.trim().startsWith("{"));
     expect(responseLine).toBeDefined();
     const response = JSON.parse(responseLine as string);
     expect(response.result.tools).toHaveLength(1);
@@ -111,9 +111,7 @@ describe("cli bin — installed tarball", () => {
       },
     );
     expect(r.status).toBe(0);
-    const responseLine = r.stdout
-      .split("\n")
-      .find((l) => l.trim().startsWith("{"));
+    const responseLine = r.stdout.split("\n").find((l) => l.trim().startsWith("{"));
     const response = JSON.parse(responseLine as string);
     expect(response.result.tools[0].name).toBe("azure_chat");
     expect(response.result.tools[0].description).toBe("Azure deployment");

--- a/packages/sdk/tests/integration/bin-tarball.test.ts
+++ b/packages/sdk/tests/integration/bin-tarball.test.ts
@@ -1,0 +1,143 @@
+// Integration test for the CLI bin's published-tarball install path.
+//
+// Catches the regression class: "the package builds and unit-tests
+// pass, but the actual `npm install <tgz>` (or `npx`) flow breaks
+// because a runtime dep isn't pulled in." That's exactly what
+// happened on first attempt: `peerDependenciesMeta.openai.optional`
+// was true, so `npx` skipped openai and the bin crashed at
+// import-resolution time.
+//
+// Test flow:
+//   1. `npm pack` from packages/sdk/ → ragingwind-mcp-ai-relay-<v>.tgz
+//   2. Install the tarball + declared peer deps in a temp dir.
+//   3. Run the installed bin's `node_modules/.bin/mcp-ai-relay`:
+//        --version, --help, tools/list, missing-flag, missing-env
+//      and assert exit codes + outputs.
+//
+// Why integration, not unit:
+//   - Needs network for peer-dep resolution from the npm registry.
+//   - Spawns a real child process; takes ~10-30 s end to end.
+//   - Catches packaging regressions that unit tests can't see.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SDK_DIR = resolve(__dirname, "..", "..");
+
+let scratchDir: string | null = null;
+let binPath: string;
+
+beforeAll(async () => {
+  // Pack the SDK into a tarball. `npm pack` uses the SDK's package.json
+  // `files` field, so the tarball matches what npm publish would ship.
+  // Clean stale tarballs first so the glob below resolves to one file.
+  for (const name of readdirSync(SDK_DIR)) {
+    if (name.endsWith(".tgz")) rmSync(join(SDK_DIR, name));
+  }
+  execFileSync("npm", ["pack"], { cwd: SDK_DIR, stdio: "pipe" });
+  const tarballs = readdirSync(SDK_DIR).filter((f) => f.endsWith(".tgz"));
+  if (tarballs.length !== 1) {
+    throw new Error(`Expected 1 tarball after npm pack, got ${tarballs.length}: ${tarballs.join(", ")}`);
+  }
+  const tarball = join(SDK_DIR, tarballs[0]!);
+
+  scratchDir = mkdtempSync(join(tmpdir(), "mcp-ai-relay-bin-"));
+  // A bare ESM package so `npm install` resolves transitive ESM deps cleanly.
+  writeFileSync(
+    join(scratchDir, "package.json"),
+    JSON.stringify({ name: "bin-tarball-test", private: true, type: "module" }),
+  );
+  // `npm install <tgz>` pulls the tarball; non-optional peer deps
+  // (`@modelcontextprotocol/sdk`, `openai`) are auto-installed by npm 7+.
+  execFileSync("npm", ["install", "--no-audit", "--no-fund", tarball], {
+    cwd: scratchDir,
+    stdio: "pipe",
+  });
+  binPath = join(scratchDir, "node_modules", ".bin", "mcp-ai-relay");
+  if (!existsSync(binPath)) {
+    throw new Error(`bin not present at ${binPath} after install`);
+  }
+  // Clean the tarball so it doesn't end up in `git status`.
+  rmSync(tarball);
+}, 180_000);
+
+afterAll(() => {
+  if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe("cli bin — installed tarball", () => {
+  it("P1: --version prints the SDK version", () => {
+    const r = spawnSync(binPath, ["--version"], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("0.1.0");
+  });
+
+  it("P2: --help prints usage text", () => {
+    const r = spawnSync(binPath, ["--help"], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("Usage: mcp-ai-relay");
+    expect(r.stdout).toContain("--openai-completion");
+  });
+
+  it("P3: --openai-completion answers a tools/list JSON-RPC request", () => {
+    const r = spawnSync(binPath, ["--openai-completion"], {
+      input: `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" })}\n`,
+      env: { ...process.env, OPENAI_API_KEY: "test-key" },
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+    const responseLine = r.stdout
+      .split("\n")
+      .find((l) => l.trim().startsWith("{"));
+    expect(responseLine).toBeDefined();
+    const response = JSON.parse(responseLine as string);
+    expect(response.result.tools).toHaveLength(1);
+    expect(response.result.tools[0].name).toBe("completion_chat");
+  });
+
+  it("P4: --name and --description override the registered tool descriptor", () => {
+    const r = spawnSync(
+      binPath,
+      ["--openai-completion", "--name", "azure_chat", "--description", "Azure deployment"],
+      {
+        input: `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" })}\n`,
+        env: { ...process.env, OPENAI_API_KEY: "test-key" },
+        encoding: "utf8",
+      },
+    );
+    expect(r.status).toBe(0);
+    const responseLine = r.stdout
+      .split("\n")
+      .find((l) => l.trim().startsWith("{"));
+    const response = JSON.parse(responseLine as string);
+    expect(response.result.tools[0].name).toBe("azure_chat");
+    expect(response.result.tools[0].description).toBe("Azure deployment");
+  });
+
+  it("D1: missing provider flag exits with code 2 and prints usage to stderr", () => {
+    const r = spawnSync(binPath, [], { encoding: "utf8" });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("provider flag");
+    expect(r.stderr).toContain("Usage: mcp-ai-relay");
+  });
+
+  it("D2: unknown argument exits with code 2", () => {
+    const r = spawnSync(binPath, ["--bogus-flag"], { encoding: "utf8" });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("Unknown argument");
+  });
+
+  it("D3: missing OPENAI_API_KEY exits with code 1", () => {
+    const r = spawnSync(binPath, ["--openai-completion"], {
+      env: { ...process.env, OPENAI_API_KEY: "" },
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("OPENAI_API_KEY");
+  });
+});

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -3,9 +3,19 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "sdk",
-    include: ["tests/unit/**/*.test.ts"],
+    // Both unit and integration. Integration tests (e.g. bin-tarball)
+    // spawn npm pack + npm install in a temp dir and exercise the
+    // installed bin end-to-end, catching packaging regressions that
+    // unit tests can't see.
+    include: ["tests/unit/**/*.test.ts", "tests/integration/**/*.test.ts"],
     setupFiles: ["./tests/setup-env.ts"],
     environment: "node",
     pool: "threads",
+    // The bin-tarball integration test runs `npm pack` + `npm install`
+    // (network-bound for peer deps) and may take 60-120 s on a cold
+    // npm cache. Per-test `beforeAll` already declares its own
+    // 180 s timeout; the file-level timeout is a defensive ceiling.
+    testTimeout: 30_000,
+    hookTimeout: 180_000,
   },
 });


### PR DESCRIPTION
Closes a gap surfaced when verifying the `npx -y @ragingwind/mcp-ai-relay --openai-completion` flow against a freshly packed tarball: the first attempt failed because `peerDependenciesMeta.openai.optional = true` told npm to skip installing openai, so the bin crashed at import resolution time.

## Two changes

### 1. Drop `peerDependenciesMeta.openai.optional`

v0.1.0 ships only the `./openai` provider subpath, so `openai` is required in practice. The optional flag was forward-looking for hypothetical future non-OpenAI subpaths (`./anthropic`, `./gemini`, `./ai-gateway`). When those land we'll revisit — likely by splitting the CLI bin out of the core package, or gating peer-installation conditionally. For now, honest required peer.

### 2. New integration test: `tests/integration/bin-tarball.test.ts`

Catches the same regression class at PR time. Flow:

1. `npm pack` from `packages/sdk/` → tarball
2. Install the tarball in a temp dir; assert peer deps come along
3. Spawn the installed `node_modules/.bin/mcp-ai-relay`:
   - `--version` (exit 0, prints `0.1.0`)
   - `--help` (exit 0, contains usage)
   - `--openai-completion` + `tools/list` JSON-RPC stdin (exit 0, returns `completion_chat`)
   - `--name azure_chat --description "Azure"` (overrides applied)
   - missing flag (exit 2 + usage to stderr)
   - unknown flag (exit 2)
   - missing `OPENAI_API_KEY` (exit 1)

7 tests, ~3 s wall-clock end-to-end.

This is what should have been in place when the bin shipped (#49). User asked "이게 왜 테스트 케이스에 안 들어가나요" — fair point, adding it now.

## Vitest config

- `include`: both `tests/unit/**` and `tests/integration/**`
- `hookTimeout: 180_000` for `npm install` in `beforeAll`
- `testTimeout: 30_000` defensive per-test ceiling

## Verification

- `pnpm typecheck` — green
- `pnpm test` — **102/102** (was 95 + 7 new bin-tarball cases)
- Manual `npx -y --package <tgz> -- mcp-ai-relay --openai-completion` with cleared `~/.npm/_npx` cache — peer deps auto-install, tools/list returns `completion_chat` ✅

## Why does CI need network?

The new integration test runs `npm install` to resolve transitive peer deps. GitHub Actions' Ubuntu runners have unrestricted outbound network, so this works out of the box. If we ever need to run offline, we can pre-stage a `.npmrc` with `--offline` + warmed cache.

---

> **Note**: opened as **draft** for the same gate-harness reason as prior phase PRs.