### PR TITLE
docs: lead README with npx Quick Start (zero install)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -3,104 +3,59 @@
 > English: [README.md](./README.md)
 
 OpenAI Chat Completions API를 [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
-도구로 노출하는 릴레이 서버입니다. Claude Code 같은 MCP 호스트에 이 서버를
-등록하면 호스트의 LLM이 OpenAI 모델을 도구처럼 호출할 수 있습니다.
+도구로 노출하는 릴레이입니다. Claude Code 또는 Claude Desktop 같은 MCP
+호스트에 이 릴레이를 등록하면 호스트의 LLM이 OpenAI 모델을 도구처럼 호출할
+수 있습니다.
 
 ```
-[ MCP 호스트 (Claude Code) ]  --bearer-->  [ 이 릴레이 ]  --API key-->  [ OpenAI / 호환 업스트림 ]
+[ MCP 호스트 (Claude Code, Claude Desktop, ...) ]  --bearer-->  [ 이 릴레이 ]  --API key-->  [ OpenAI / 호환 업스트림 ]
 ```
 
-**Vercel** (관리형 서버리스) 또는 **Docker 컨테이너** (셀프 호스팅)로 실행
-가능합니다.
+소비 방식은 세 가지:
+
+1. **`npx` + MCP 호스트 설정** — 설치 없음, stdio 트랜스포트. 개인 사용이나
+   빠른 실험에 적합.
+2. **HTTP 서버로 실행** — Docker 셀프 호스팅 또는 Vercel 관리형. 팀 공용
+   엔드포인트나 외부 노출이 필요할 때.
+3. **SDK를 자기 MCP 서버에 임베드** — 가장 큰 제어권. 커스텀 로직, 다중
+   업스트림 등록, 또는 비-Node 런타임이 필요할 때.
+
+npm 패키지 이름은
+[`@ragingwind/ai-relay`](https://www.npmjs.com/package/@ragingwind/ai-relay)
+입니다. 아래에서 한 가지를 골라 진행하세요.
 
 ---
 
-## 빠른 시작 (Docker Compose)
+## 1. 빠른 시작 — npx (설치 없음)
 
-로컬이나 단일 호스트에서 가장 빠르게 띄우는 방법:
+`npx`가 npm에서 직접 릴레이를 stdio MCP 서버로 띄우게 합니다. 클론도, 빌드도,
+호스팅할 서버도 필요 없습니다.
+
+### 사전 준비물
+
+- **Node.js 20+** (`npx` 용)
+- **OpenAI API 키** (`sk-...`)
+
+### 패키지 동작 검증
+
+터미널에서 — `sk-...` 자리에 실제 키를 넣으세요:
 
 ```bash
-git clone https://github.com/ragingwind/mcp-ai-relay.git
-cd mcp-ai-relay
-cp .env.example .env.local
-# OPENAI_API_KEY 와 RELAY_AUTH_TOKEN(32바이트 이상 — `openssl rand -hex 32`) 채우기
-docker compose up -d
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | OPENAI_API_KEY=sk-... npx -y @ragingwind/ai-relay --openai-completion
 ```
 
-이제 MCP 엔드포인트는 `http://localhost:8787/api/mcp` 입니다. 종료는
-`docker compose down`. 호스트 포트를 바꾸려면
-`HOST_PORT=... docker compose up -d`.
+기대 결과: 한 줄짜리 JSON-RPC 응답에 `"name":"completion_chat"`이 포함됩니다.
+이게 보이면 MCP 호스트에 등록할 준비가 끝난 것입니다.
 
-다른 배포 경로(Vercel 서버리스, raw `docker run`, 운영 절차 전반)는
-[`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) 참고.
+### Claude Desktop에 등록
 
----
-
-## 상태
-
-**v1 (현재)** — 도구 1개 `completion_chat`, Bearer 토큰 인증, Streamable
-HTTP 트랜스포트. v2 백로그(Responses API, OAuth 2.1, rate limiting,
-budget caps, observability)는
-[`doc/ARCHITECTURE.ko.md` §11](./doc/ARCHITECTURE.ko.md#11-v2-백로그)에
-정리되어 있습니다.
-
----
-
-## 도구: `completion_chat`
-
-OpenAI Chat Completions를 한 번 호출하고 누적된 응답 텍스트를 반환합니다.
-
-| 입력 | 타입 | 필수 |
-|---|---|---|
-| `model` | `string` | ✅ |
-| `messages` | `Array<{role, content}>` | ✅ |
-| `temperature` | `number` (0~2) | |
-| `max_tokens` | `number` (서버 ceiling으로 클램프) | |
-| `top_p` | `number` (0~1) | |
-| `stop` | `string \| string[]` | |
-
-응답: 누적 텍스트 + `usage` 메타데이터. 전체 스키마는
-[`doc/ARCHITECTURE.ko.md` §4](./doc/ARCHITECTURE.ko.md#4-mcp-도구-정의)에
-있습니다.
-
----
-
-## Claude Code에서 사용
-
-```bash
-claude mcp add --transport http openai-relay \
-  http://localhost:8787/api/mcp \
-  --header "Authorization: Bearer <RELAY_AUTH_TOKEN>"
-```
-
-또는 `.mcp.json`에 직접 등록:
-
-```json
-{
-  "mcpServers": {
-    "openai-relay": {
-      "type": "http",
-      "url": "${RELAY_URL:-http://localhost:8787/api/mcp}",
-      "headers": { "Authorization": "Bearer ${RELAY_AUTH_TOKEN}" }
-    }
-  }
-}
-```
-
-> **Claude Desktop**은 원격 MCP 서버를 UI의 **Settings → Connectors**에서
-> 등록합니다 (Pro/Max 요금제 한정). `claude_desktop_config.json`이 아닙니다.
-
----
-
-## 자기 MCP 서버에 임베드
-
-이 릴레이 앱을 그대로 띄우는 대신 자기 MCP 서버(Vercel/Next.js,
-Cloudflare Workers, Claude Desktop 직결용 stdio, Hono 등)에
-`completion_chat` 기능만 심고 싶다면 두 가지 경로가 있습니다:
-
-**Zero-config (코드 없이) — `npx`**
-
-Claude Desktop의 `claude_desktop_config.json`에 바로 등록:
+1. `claude_desktop_config.json` 을 엽니다. 경로는 OS 별:
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+2. 아래 `mcpServers` 항목을 추가합니다. 파일이 비어 있으면 스니펫 전체가
+   파일 내용입니다. 다른 서버가 이미 등록돼 있다면 `"openai-relay"` 키만
+   기존 `"mcpServers"` 객체에 병합하세요.
 
 ```json
 {
@@ -108,13 +63,130 @@ Claude Desktop의 `claude_desktop_config.json`에 바로 등록:
     "openai-relay": {
       "command": "npx",
       "args": ["-y", "@ragingwind/ai-relay", "--openai-completion"],
-      "env": { "OPENAI_API_KEY": "sk-..." }
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
     }
   }
 }
 ```
 
-**라이브러리 API (전체 제어권)**
+3. **Claude Desktop을 완전히 종료** (macOS는 ⌘Q — 창만 닫는 것으로는 부족)
+   하고 다시 엽니다.
+4. 새 채팅에서 도구 / 커넥터 아이콘을 클릭합니다. `openai-relay` 아래에
+   `completion_chat`이 보여야 합니다. 예: *"completion_chat 도구로
+   gpt-4o-mini 모델을 사용해 이 페이지를 요약해줘"* — Claude가 도구를
+   호출합니다.
+
+### Claude Code에 등록
+
+프로젝트 디렉토리에서:
+
+```bash
+claude mcp add openai-relay \
+  -e OPENAI_API_KEY=sk-... \
+  -- npx -y @ragingwind/ai-relay --openai-completion
+```
+
+또는 `.mcp.json` 에 직접 작성:
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "npx",
+      "args": ["-y", "@ragingwind/ai-relay", "--openai-completion"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+`claude mcp list`로 등록 확인.
+
+### 노출되는 것
+
+호스트 LLM이 호출할 수 있는 MCP 도구 1개 (`completion_chat`):
+
+| 입력 | 타입 | 필수 |
+|---|---|---|
+| `model` | `string` (예: `gpt-4o-mini`) | ✅ |
+| `messages` | `Array<{role, content}>` | ✅ |
+| `temperature` | `number` (0~2) | |
+| `max_tokens` | `number` (서버 ceiling으로 클램프, 기본 4096) | |
+| `top_p` | `number` (0~1) | |
+| `stop` | `string \| string[]` | |
+
+응답: 누적된 어시스턴트 메시지 텍스트 + 토큰 사용량.
+
+### CLI 옵션 (전체)
+
+```
+npx -y @ragingwind/ai-relay <provider-flag> [--name <name>] [--description <desc>]
+
+Provider flags (정확히 1개 필수, 호출당 1개 도구):
+  --openai-completion   OpenAI Chat Completions
+                        Required env: OPENAI_API_KEY
+                        Optional env: OPENAI_BASE_URL,
+                                      OPENAI_MAX_OUTPUT_TOKENS_CEILING,
+                                      OPENAI_REQUEST_TIMEOUT_MS
+
+Options:
+  --name <name>         등록할 MCP 도구 이름 오버라이드
+                        (기본: completion_chat)
+  --description <desc>  도구 description 오버라이드
+  --help, -h            usage 출력
+  --version, -V         SDK 버전 출력
+```
+
+`OPENAI_BASE_URL`은 같은 CLI를 OpenAI 호환 엔드포인트 — Azure OpenAI, vLLM,
+Ollama, OpenRouter, Vercel AI Gateway(OpenAI 모드) — 어디든 가리키게 합니다.
+
+### 한 서버에 여러 업스트림
+
+CLI는 호출당 도구 1개를 ship 합니다. 한 MCP 서버가 OpenAI + Azure + 로컬
+Ollama를 세 개의 별개 이름을 가진 도구로 호스팅하길 원한다면, SDK API를
+직접 사용하세요 — [multi-upstream 예제](./examples/multi-upstream/)와
+[`packages/ai-relay/README.md`](./packages/ai-relay/README.md) 참고.
+
+---
+
+## 2. HTTP 서버로 실행 (Docker Compose)
+
+팀 공용 엔드포인트를 두거나 OpenAI 키를 개별 노트북이 아닌 서버에 보관하고
+싶다면, 릴레이를 HTTP 서비스로 띄웁니다.
+
+```bash
+git clone https://github.com/ragingwind/mcp-ai-relay.git
+cd mcp-ai-relay
+cp .env.example .env.local
+# OPENAI_API_KEY 와 RELAY_AUTH_TOKEN (32바이트 이상 — `openssl rand -hex 32`) 채우기
+docker compose up -d
+```
+
+이제 MCP 엔드포인트는 `http://localhost:8787/api/mcp` 입니다. 종료는
+`docker compose down`. 호스트 포트는 `HOST_PORT=... docker compose up -d`로
+변경 가능.
+
+MCP 호스트에서 연결:
+
+```bash
+claude mcp add --transport http openai-relay \
+  http://localhost:8787/api/mcp \
+  --header "Authorization: Bearer <RELAY_AUTH_TOKEN>"
+```
+
+Vercel 서버리스, raw `docker run`, 운영 절차(토큰 회전, 트러블슈팅, OpenAI
+usage cap)는 [`doc/DEPLOY.md`](./doc/DEPLOY.md) 참고.
+
+---
+
+## 3. SDK를 자기 MCP 서버에 임베드
+
+커스텀 MCP 서버(Cloudflare Workers, Hono/Express, 자기 Next.js 라우트 등)를
+직접 만든다면 SDK 패키지가 import 표면입니다:
 
 ```bash
 npm install @ragingwind/ai-relay @modelcontextprotocol/sdk openai
@@ -128,18 +200,28 @@ const server = new McpServer({ name: "my-relay", version: "0.1.0" });
 registerOpenAIChat(server, { apiKey: process.env.OPENAI_API_KEY! });
 ```
 
-`registerOpenAIChat`은 closure로 격리되므로, 같은 서버가 여러 업스트림
-(OpenAI proper + Azure + 로컬 vLLM, …)을 별개의 이름을 가진 도구로
-호스팅할 수 있습니다. 전체 API 레퍼런스:
+`registerOpenAIChat`은 closure로 격리되므로 같은 서버가 여러 업스트림
+(OpenAI + Azure + 로컬 LLM, …)을 별개의 이름을 가진 도구로 호스팅할 수
+있습니다. 전체 API 레퍼런스:
 [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) (영문).
 
 [`examples/`](./examples/) 의 실행 가능 예제:
 
 | 예제 | 용도 |
 |---|---|
-| [`stdio/`](./examples/stdio/) | Claude Desktop 직결용 단일 도구 stdio launcher |
-| [`multi-upstream/`](./examples/multi-upstream/) | 한 서버에 여러 업스트림 등록 (OpenAI + Azure + 로컬 LLM) — C7 다중 등록 시나리오 |
+| [`stdio/`](./examples/stdio/) | 단일 도구 stdio launcher (npx CLI와 동일 모양, 코드 기반) |
+| [`multi-upstream/`](./examples/multi-upstream/) | 한 서버, 여러 업스트림 (OpenAI + Azure + 로컬 LLM) — C7 다중 등록 시나리오 |
 | [`cloudflare-workers/`](./examples/cloudflare-workers/) | `agents/mcp` 프레임워크 기반 Workers MCP |
+
+---
+
+## 상태
+
+**v0.1.0** (npm SDK) / **v1 릴레이 앱** — 도구 1개 `completion_chat`,
+Bearer 토큰 인증, Streamable HTTP 트랜스포트. v2 백로그(Responses API,
+OAuth 2.1, rate limiting, budget caps, observability)는
+[`doc/ARCHITECTURE.ko.md` §11](./doc/ARCHITECTURE.ko.md#11-v2-백로그)에
+정리.
 
 ---
 
@@ -154,10 +236,10 @@ pnpm dev                          # http://localhost:3000/api/mcp
 pnpm test                         # vitest
 ```
 
-`.env.local`이 없거나 두 필수 값이 비어 있으면 `pnpm dev`는 실행을 거부하고
+`.env.local` 이 없거나 두 필수 값이 비어 있으면 `pnpm dev`는 실행을 거부하고
 조치 안내를 출력합니다. 모든 빌드/테스트/검증 명령은
-[`CLAUDE.md` §3 — Verify Commands](./CLAUDE.md#3-verify-commands)에서 확인할
-수 있습니다.
+[`CLAUDE.md` §3 — Verify Commands](./CLAUDE.md#3-verify-commands) 에서
+확인할 수 있습니다.
 
 ---
 
@@ -165,6 +247,7 @@ pnpm test                         # vitest
 
 | 주제 | 문서 |
 |---|---|
+| SDK API + 레시피 | [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) (영문) |
 | 아키텍처, 의사결정, 참고문헌 | [`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) |
 | 배포 런북 (Vercel + Docker, 운영) | [`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) |
 | 수동 검증 (PR 전 / 배포 후) | [`doc/QA-MCP-INSPECTOR.ko.md`](./doc/QA-MCP-INSPECTOR.ko.md) |

--- a/README.md
+++ b/README.md
@@ -2,23 +2,165 @@
 
 > 한국어: [README.ko.md](./README.ko.md)
 
-A relay server that exposes the OpenAI Chat Completions API as an
-[MCP (Model Context Protocol)](https://modelcontextprotocol.io) tool.
-When you register this server with an MCP host such as Claude Code, the
+A relay that exposes the OpenAI Chat Completions API as an
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io) tool. When you
+register this relay with an MCP host such as Claude Code or Claude Desktop, the
 host's LLM can call OpenAI models as if they were tools.
 
 ```
-[ MCP host (Claude Code) ]  --bearer-->  [ this relay ]  --API key-->  [ OpenAI / compatible upstream ]
+[ MCP host (Claude Code, Claude Desktop, ...) ]  --bearer-->  [ this relay ]  --API key-->  [ OpenAI / compatible upstream ]
 ```
 
-Runs on **Vercel** (managed serverless) or as a **Docker container**
-(self-hosted).
+Three ways to consume it:
+
+1. **`npx` + your MCP host's config** — zero install, stdio transport. Best for
+   personal use or quick experiments.
+2. **Run as an HTTP server** — Docker self-hosted or Vercel managed. Best when
+   you want a shared endpoint for a team or to expose the relay publicly.
+3. **Embed the SDK in your own MCP server** — most control. Best when you want
+   custom logic, multi-upstream registration, or non-Node runtimes.
+
+The npm package is
+[`@ragingwind/ai-relay`](https://www.npmjs.com/package/@ragingwind/ai-relay).
+Pick a path below.
 
 ---
 
-## Quick start (Docker Compose)
+## 1. Quick start — npx (zero install)
 
-The fastest way to run the relay locally or on a single host:
+Have `npx` launch the relay as a stdio MCP server, direct from npm. No clone,
+no build, no server to host.
+
+### Prerequisites
+
+- **Node.js 20+** (for `npx`)
+- **An OpenAI API key** (`sk-...`)
+
+### Verify the package works
+
+In a terminal — replace `sk-...` with your real key:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | OPENAI_API_KEY=sk-... npx -y @ragingwind/ai-relay --openai-completion
+```
+
+Expected: a single-line JSON-RPC response that contains
+`"name":"completion_chat"`. If you see that, you're ready to register it in an
+MCP host.
+
+### Register in Claude Desktop
+
+1. Open `claude_desktop_config.json`. The path is OS-specific:
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+2. Add the `mcpServers` entry below. If the file is empty, the whole snippet
+   is the file. If it already has other servers, merge the `"openai-relay"`
+   key into the existing `"mcpServers"` object.
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "npx",
+      "args": ["-y", "@ragingwind/ai-relay", "--openai-completion"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+3. **Quit Claude Desktop completely** (⌘Q on macOS — closing the window
+   isn't enough) and reopen it.
+4. In a new chat, click the tools / connectors icon. You should see
+   `completion_chat` listed under `openai-relay`. Ask Claude something like
+   *"use the completion_chat tool with model gpt-4o-mini to summarize this
+   page"* — it will call the tool.
+
+### Register in Claude Code
+
+In a project directory:
+
+```bash
+claude mcp add openai-relay \
+  -e OPENAI_API_KEY=sk-... \
+  -- npx -y @ragingwind/ai-relay --openai-completion
+```
+
+Or write `.mcp.json` directly:
+
+```json
+{
+  "mcpServers": {
+    "openai-relay": {
+      "command": "npx",
+      "args": ["-y", "@ragingwind/ai-relay", "--openai-completion"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+Run `claude mcp list` to confirm the server is registered.
+
+### What you get
+
+A single MCP tool named `completion_chat` that the host LLM can invoke:
+
+| Input | Type | Required |
+|---|---|---|
+| `model` | `string` (e.g., `gpt-4o-mini`) | ✅ |
+| `messages` | `Array<{role, content}>` | ✅ |
+| `temperature` | `number` (0~2) | |
+| `max_tokens` | `number` (clamped to server ceiling, default 4096) | |
+| `top_p` | `number` (0~1) | |
+| `stop` | `string \| string[]` | |
+
+Returns the accumulated assistant message text plus token usage.
+
+### CLI options (full)
+
+```
+npx -y @ragingwind/ai-relay <provider-flag> [--name <name>] [--description <desc>]
+
+Provider flags (exactly one required, one tool per invocation):
+  --openai-completion   OpenAI Chat Completions
+                        Required env: OPENAI_API_KEY
+                        Optional env: OPENAI_BASE_URL,
+                                      OPENAI_MAX_OUTPUT_TOKENS_CEILING,
+                                      OPENAI_REQUEST_TIMEOUT_MS
+
+Options:
+  --name <name>         Override the registered MCP tool name
+                        (default: completion_chat)
+  --description <desc>  Override the tool description
+  --help, -h            Show usage
+  --version, -V         Print SDK version
+```
+
+`OPENAI_BASE_URL` lets you point the same CLI at any OpenAI-compatible
+endpoint — Azure OpenAI, vLLM, Ollama, OpenRouter, or Vercel AI Gateway in
+OpenAI mode.
+
+### Multiple upstreams in one server
+
+The CLI ships one tool per invocation. If you want a single MCP server that
+hosts OpenAI proper + Azure + a local Ollama as three distinct named tools,
+use the SDK API directly — see the
+[multi-upstream example](./examples/multi-upstream/) and
+[`packages/ai-relay/README.md`](./packages/ai-relay/README.md).
+
+---
+
+## 2. Run as an HTTP server (Docker Compose)
+
+If you want a shared endpoint a team can hit, or you'd rather keep the
+OpenAI key on a server instead of every developer's laptop, run the relay as
+an HTTP service.
 
 ```bash
 git clone https://github.com/ragingwind/mcp-ai-relay.git
@@ -32,40 +174,7 @@ The MCP endpoint is now at `http://localhost:8787/api/mcp`. Stop with
 `docker compose down`. Override the host port with
 `HOST_PORT=... docker compose up -d`.
 
-For other paths (Vercel serverless, raw `docker run`, full operations),
-see [`doc/DEPLOY.md`](./doc/DEPLOY.md).
-
----
-
-## Status
-
-**v1 (current)** — single tool `completion_chat`, bearer token authentication,
-Streamable HTTP transport. The v2 backlog (Responses API, OAuth 2.1, rate
-limiting, budget caps, observability) is tracked in
-[`doc/ARCHITECTURE.md` §11](./doc/ARCHITECTURE.md#11-future-work-v2-backlog).
-
----
-
-## Tool: `completion_chat`
-
-Invokes OpenAI Chat Completions once and returns the accumulated response
-text.
-
-| Input | Type | Required |
-|---|---|---|
-| `model` | `string` | ✅ |
-| `messages` | `Array<{role, content}>` | ✅ |
-| `temperature` | `number` (0~2) | |
-| `max_tokens` | `number` (clamped to server ceiling) | |
-| `top_p` | `number` (0~1) | |
-| `stop` | `string \| string[]` | |
-
-Response: accumulated text plus `usage` metadata. Full schema in
-[`doc/ARCHITECTURE.md` §4](./doc/ARCHITECTURE.md#4-mcp-tool-definition).
-
----
-
-## Use from Claude Code
+Connect from an MCP host:
 
 ```bash
 claude mcp add --transport http openai-relay \
@@ -73,50 +182,15 @@ claude mcp add --transport http openai-relay \
   --header "Authorization: Bearer <RELAY_AUTH_TOKEN>"
 ```
 
-Or register directly in `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "openai-relay": {
-      "type": "http",
-      "url": "${RELAY_URL:-http://localhost:8787/api/mcp}",
-      "headers": { "Authorization": "Bearer ${RELAY_AUTH_TOKEN}" }
-    }
-  }
-}
-```
-
-> **Claude Desktop** registers remote MCP servers through **Settings →
-> Connectors** in the UI (Pro/Max plans), not via
-> `claude_desktop_config.json`.
+For Vercel serverless, raw `docker run`, full operations (token rotation,
+troubleshooting, OpenAI usage cap), see [`doc/DEPLOY.md`](./doc/DEPLOY.md).
 
 ---
 
-## Embed in your own MCP server
+## 3. Embed the SDK in your own MCP server
 
-If you want to host the `completion_chat` capability in your own MCP
-server (Vercel/Next.js, Cloudflare Workers, raw stdio for Claude Desktop
-direct, Hono, etc.) instead of running this relay app, the SDK supports
-two paths:
-
-**Zero-config (no code) — `npx`**
-
-Register directly in Claude Desktop:
-
-```json
-{
-  "mcpServers": {
-    "openai-relay": {
-      "command": "npx",
-      "args": ["-y", "@ragingwind/ai-relay", "--openai-completion"],
-      "env": { "OPENAI_API_KEY": "sk-..." }
-    }
-  }
-}
-```
-
-**Library API (full control)**
+If you're building a custom MCP server (Cloudflare Workers, Hono/Express, your
+own Next.js route, etc.) the SDK package is the import surface:
 
 ```bash
 npm install @ragingwind/ai-relay @modelcontextprotocol/sdk openai
@@ -130,17 +204,27 @@ const server = new McpServer({ name: "my-relay", version: "0.1.0" });
 registerOpenAIChat(server, { apiKey: process.env.OPENAI_API_KEY! });
 ```
 
-`registerOpenAIChat` is closure-isolated, so the same server may host
-multiple upstreams (OpenAI proper + Azure + local vLLM, …) as distinct
-named tools. Full API reference: [`packages/ai-relay/README.md`](./packages/ai-relay/README.md).
+`registerOpenAIChat` is closure-isolated, so the same server may host multiple
+upstreams (OpenAI + Azure + local LLM, …) as distinct named tools. Full API
+reference: [`packages/ai-relay/README.md`](./packages/ai-relay/README.md).
 
 Runnable examples in [`examples/`](./examples/):
 
 | Example | Use case |
 |---|---|
-| [`stdio/`](./examples/stdio/) | Single-tool stdio launcher for Claude Desktop direct registration |
+| [`stdio/`](./examples/stdio/) | Single-tool stdio launcher (same shape as the npx CLI, but in code) |
 | [`multi-upstream/`](./examples/multi-upstream/) | One server, multiple upstreams (OpenAI + Azure + local LLM) — exercises the C7 multi-registration scenario |
 | [`cloudflare-workers/`](./examples/cloudflare-workers/) | Workers MCP via `agents/mcp` framework |
+
+---
+
+## Status
+
+**v0.1.0** (npm SDK) / **v1 relay app** — single tool `completion_chat`,
+bearer token authentication, Streamable HTTP transport. The v2 backlog
+(Responses API, OAuth 2.1, rate limiting, budget caps, observability) is
+tracked in
+[`doc/ARCHITECTURE.md` §11](./doc/ARCHITECTURE.md#11-future-work-v2-backlog).
 
 ---
 
@@ -166,6 +250,7 @@ commands are listed in
 
 | Topic | Document |
 |---|---|
+| SDK API + recipes | [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) |
 | Architecture, decisions, references | [`doc/ARCHITECTURE.md`](./doc/ARCHITECTURE.md) |
 | Deployment runbook (Vercel + Docker, operations) | [`doc/DEPLOY.md`](./doc/DEPLOY.md) |
 | Manual verification (pre-PR, post-deploy) | [`doc/QA-MCP-INSPECTOR.md`](./doc/QA-MCP-INSPECTOR.md) |


### PR DESCRIPTION
Now that `@ragingwind/ai-relay@0.1.0` is live on npm, zero-install via `npx` is the easiest way to use the relay. Both `README.md` and `README.ko.md` now lead with that path.

## New structure

| # | Heading | Audience |
|---|---|---|
| 1 | **Quick start — npx (zero install)** | most users |
| 2 | Run as an HTTP server (Docker Compose) | team / shared deploy |
| 3 | Embed the SDK in your own MCP server | custom MCP server builders |

The npx Quick Start includes (no abbreviation):

- Prerequisites (Node 20+, OpenAI key)
- A terminal one-liner that verifies the package works (`echo ... | OPENAI_API_KEY=... npx -y @ragingwind/ai-relay --openai-completion`) — same one we used in the post-publish smoke
- **Full `claude_desktop_config.json` snippet** (copy-paste ready) with OS-specific config paths (macOS, Windows), full quit-and-relaunch instructions, and a verification step ("click the tools icon, see completion_chat")
- **Full `claude mcp add` command** + the equivalent `.mcp.json` variant
- Input schema table for `completion_chat`
- **Full CLI usage block** (matches the bin's `--help` verbatim — provider flags, options, env vars)
- Pointer to the SDK API for multi-upstream setups

## Why

Before this PR the README led with the Docker Compose path, which is correct for self-hosted deployments but heavyweight for the most common case (a single dev wanting OpenAI tools in Claude Desktop). With the SDK published, npx is the new default starting point.

Existing Docker Compose content is preserved as section 2.

## Verification

- `pnpm test` — **102/102** (no code change)
- README links spot-checked
- Korean translation mirrors the structure 1:1

---

> Draft for the same gate-harness reason as prior PRs.