### PR TITLE
docs(readme)!: rewrite around 4 surfaces (npx / SDK / app / docker) + migration table

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -128,7 +128,7 @@ OAuth 2.1, rate limiting, budget caps, observability)는
 | 배포 런북 (Vercel + Docker, 운영) | [`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) |
 | AI 에이전트 협업 가이드 | [`CLAUDE.md`](./CLAUDE.md) |
 
-사용자 대상 문서의 한국어 번역 (영문이 정전):
+다른 언어 / 관련 문서 (영문이 정본):
 [`README.md`](./README.md) ·
 [`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) ·
 [`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) ·

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,227 +1,138 @@
 # mcp-ai-relay
 
+> OpenAI Chat Completions (및 OpenAI 호환 업스트림)을 Model Context Protocol 도구로 노출하는 MCP 릴레이입니다.
+
 > English: [README.md](./README.md)
 
-OpenAI Chat Completions API를 [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
-도구로 노출하는 릴레이입니다. Claude Code 또는 Claude Desktop 같은 MCP
-호스트에 이 릴레이를 등록하면 호스트의 LLM이 OpenAI 모델을 도구처럼 호출할
-수 있습니다.
+`mcp-ai-relay`를 사용하면 모든 [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
+호스트가 OpenAI 호환 채팅 모델을 도구처럼 호출할 수 있습니다. 동일한 SDK가
+서로 교체 가능한 4개의 사용 표면을 제공하므로 — 배포 방식에 맞는 것을 고르세요.
 
 ```
-[ MCP 호스트 (Claude Code, Claude Desktop, ...) ]  --bearer-->  [ 이 릴레이 ]  --API key-->  [ OpenAI / 호환 업스트림 ]
+MCP host  ──►  ai-relay  ──►  OpenAI-compatible API
+              (CLI | SDK | App | Docker)
 ```
-
-소비 방식은 세 가지:
-
-1. **`npx` + MCP 호스트 설정** — 설치 없음, stdio 트랜스포트. 개인 사용이나
-   빠른 실험에 적합.
-2. **HTTP 서버로 실행** — Docker 셀프 호스팅 또는 Vercel 관리형. 팀 공용
-   엔드포인트나 외부 노출이 필요할 때.
-3. **SDK를 자기 MCP 서버에 임베드** — 가장 큰 제어권. 커스텀 로직, 다중
-   업스트림 등록, 또는 비-Node 런타임이 필요할 때.
-
-npm 패키지 이름은
-[`ai-relay`](https://www.npmjs.com/package/ai-relay)
-입니다. 아래에서 한 가지를 골라 진행하세요.
 
 ---
 
-## 1. 빠른 시작 — npx (설치 없음)
+## 사용 표면
 
-`npx`가 npm에서 직접 릴레이를 stdio MCP 서버로 띄우게 합니다. 클론도, 빌드도,
-호스팅할 서버도 필요 없습니다.
-
-### 사전 준비물
-
-- **Node.js 20+** (`npx` 용)
-- **OpenAI API 키** (`sk-...`)
-
-### 패키지 동작 검증
-
-터미널에서 — `sk-...` 자리에 실제 키를 넣으세요:
-
-```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-  | OPENAI_API_KEY=sk-... npx -y ai-relay --openai-completion
-```
-
-기대 결과: 한 줄짜리 JSON-RPC 응답에 `"name":"completion_chat"`이 포함됩니다.
-이게 보이면 MCP 호스트에 등록할 준비가 끝난 것입니다.
-
-### Claude Desktop에 등록
-
-1. `claude_desktop_config.json` 을 엽니다. 경로는 OS 별:
-   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-2. 아래 `mcpServers` 항목을 추가합니다. 파일이 비어 있으면 스니펫 전체가
-   파일 내용입니다. 다른 서버가 이미 등록돼 있다면 `"openai-relay"` 키만
-   기존 `"mcpServers"` 객체에 병합하세요.
-
-```json
-{
-  "mcpServers": {
-    "openai-relay": {
-      "command": "npx",
-      "args": ["-y", "ai-relay", "--openai-completion"],
-      "env": {
-        "OPENAI_API_KEY": "sk-..."
-      }
-    }
-  }
-}
-```
-
-3. **Claude Desktop을 완전히 종료** (macOS는 ⌘Q — 창만 닫는 것으로는 부족)
-   하고 다시 엽니다.
-4. 새 채팅에서 도구 / 커넥터 아이콘을 클릭합니다. `openai-relay` 아래에
-   `completion_chat`이 보여야 합니다. 예: *"completion_chat 도구로
-   gpt-4o-mini 모델을 사용해 이 페이지를 요약해줘"* — Claude가 도구를
-   호출합니다.
-
-### Claude Code에 등록
-
-프로젝트 디렉토리에서:
-
-```bash
-claude mcp add openai-relay \
-  -e OPENAI_API_KEY=sk-... \
-  -- npx -y ai-relay --openai-completion
-```
-
-또는 `.mcp.json` 에 직접 작성:
-
-```json
-{
-  "mcpServers": {
-    "openai-relay": {
-      "command": "npx",
-      "args": ["-y", "ai-relay", "--openai-completion"],
-      "env": {
-        "OPENAI_API_KEY": "sk-..."
-      }
-    }
-  }
-}
-```
-
-`claude mcp list`로 등록 확인.
-
-### 노출되는 것
-
-호스트 LLM이 호출할 수 있는 MCP 도구 1개 (`completion_chat`):
-
-| 입력 | 타입 | 필수 |
-|---|---|---|
-| `model` | `string` (예: `gpt-4o-mini`) | ✅ |
-| `messages` | `Array<{role, content}>` | ✅ |
-| `temperature` | `number` (0~2) | |
-| `max_tokens` | `number` (서버 ceiling으로 클램프, 기본 4096) | |
-| `top_p` | `number` (0~1) | |
-| `stop` | `string \| string[]` | |
-
-응답: 누적된 어시스턴트 메시지 텍스트 + 토큰 사용량.
-
-### CLI 옵션 (전체)
-
-```
-npx -y ai-relay <provider-flag> [--name <name>] [--description <desc>]
-
-Provider flags (정확히 1개 필수, 호출당 1개 도구):
-  --openai-completion   OpenAI Chat Completions
-                        Required env: OPENAI_API_KEY
-                        Optional env: OPENAI_BASE_URL,
-                                      OPENAI_MAX_OUTPUT_TOKENS_CEILING,
-                                      OPENAI_REQUEST_TIMEOUT_MS
-
-Options:
-  --name <name>         등록할 MCP 도구 이름 오버라이드
-                        (기본: completion_chat)
-  --description <desc>  도구 description 오버라이드
-  --help, -h            usage 출력
-  --version, -V         SDK 버전 출력
-```
-
-`OPENAI_BASE_URL`은 같은 CLI를 OpenAI 호환 엔드포인트 — Azure OpenAI, vLLM,
-Ollama, OpenRouter, Vercel AI Gateway(OpenAI 모드) — 어디든 가리키게 합니다.
-
-### 한 서버에 여러 업스트림
-
-CLI는 호출당 도구 1개를 ship 합니다. 한 MCP 서버가 OpenAI + Azure + 로컬
-Ollama를 세 개의 별개 이름을 가진 도구로 호스팅하길 원한다면, SDK API를
-직접 사용하세요 — [multi-upstream 예제](./examples/multi-upstream/)와
-[`packages/ai-relay/README.md`](./packages/ai-relay/README.md) 참고.
+| 표면 | 전송 | 설치 | 사용 시점 |
+|---|---|---|---|
+| `npx ai-relay` | 없음 (단발) | 없음 | 빠른 테스트, 스크립팅, CI 스모크 |
+| SDK (`ai-relay`) | 호출자 선택 (stdio / HTTP / Workers) | npm | 커스텀 MCP 서버에 임베드 |
+| App (`./app`, Next.js) | HTTP | `git clone` (Vercel/Node에 셀프 호스트) | 개인 또는 팀 HTTP 엔드포인트 |
+| Docker (로컬 빌드) | HTTP | 이 저장소에서 `docker build` | 지금 컨테이너 배포; 퍼블리시 이미지는 [#57](https://github.com/ragingwind/mcp-ai-relay/issues/57)에서 추가 예정 |
 
 ---
 
-## 2. HTTP 서버로 실행 (Docker Compose)
-
-팀 공용 엔드포인트를 두거나 OpenAI 키를 개별 노트북이 아닌 서버에 보관하고
-싶다면, 릴레이를 HTTP 서비스로 띄웁니다.
+## 빠른 시작 — 단발 CLI
 
 ```bash
-git clone https://github.com/ragingwind/mcp-ai-relay.git
-cd mcp-ai-relay
-cp .env.example .env.local
-# OPENAI_API_KEY 와 RELAY_AUTH_TOKEN (32바이트 이상 — `openssl rand -hex 32`) 채우기
-docker compose up -d
+AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini "ping"
+
+AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini \
+  '{"messages":[{"role":"user","content":"ping"}]}'
+
+echo "explain TLS in 2 sentences" \
+  | AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini -s "be terse"
 ```
 
-이제 MCP 엔드포인트는 `http://localhost:8787/api/mcp` 입니다. 종료는
-`docker compose down`. 호스트 포트는 `HOST_PORT=... docker compose up -d`로
-변경 가능.
-
-MCP 호스트에서 연결:
-
-```bash
-claude mcp add --transport http openai-relay \
-  http://localhost:8787/api/mcp \
-  --header "Authorization: Bearer <RELAY_AUTH_TOKEN>"
-```
-
-Vercel 서버리스, raw `docker run`, 운영 절차(토큰 회전, 트러블슈팅, OpenAI
-usage cap)는 [`doc/DEPLOY.md`](./doc/DEPLOY.md) 참고.
+`-m/--model`은 필수입니다. 입력은 위치 인자이거나 stdin으로 파이프되며 (정확히
+하나 — XOR 관계). 평문 위치 인자는 `{messages:[…]}` 배열이 되고, JSON 리터럴
+(`{` / `[`)은 그대로 전달됩니다.
 
 ---
 
-## 3. SDK를 자기 MCP 서버에 임베드
-
-커스텀 MCP 서버(Cloudflare Workers, Hono/Express, 자기 Next.js 라우트 등)를
-직접 만든다면 SDK 패키지가 import 표면입니다:
+## 빠른 시작 — Docker (로컬 빌드)
 
 ```bash
-npm install ai-relay @modelcontextprotocol/sdk openai
+docker build -t mcp-ai-relay .
+
+docker run -p 8787:8787 \
+  -e AI_RELAY_API_KEY=sk-... \
+  -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
+  mcp-ai-relay
 ```
+
+이제 MCP 엔드포인트는 `http://localhost:8787/api/mcp`에서 제공됩니다.
+`docker compose up`을 선호한다면 저장소 루트의 `compose.yml`도 사용 가능합니다.
+
+> [#57](https://github.com/ragingwind/mcp-ai-relay/issues/57)이 머지되면
+> `docker build` 단계는 `ghcr.io/ragingwind/ai-relay`에서 pull로 대체됩니다.
+> 그때까지는 로컬 빌드로 진행하세요.
+
+---
+
+## 빠른 시작 — SDK 임베드
 
 ```ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerOpenAIChat } from "ai-relay/openai";
 
 const server = new McpServer({ name: "my-relay", version: "0.1.0" });
-registerOpenAIChat(server, { apiKey: process.env.OPENAI_API_KEY! });
+registerOpenAIChat(server, { apiKey: process.env.AI_RELAY_API_KEY! });
+await server.connect(new StdioServerTransport());
 ```
 
-`registerOpenAIChat`은 closure로 격리되므로 같은 서버가 여러 업스트림
-(OpenAI + Azure + 로컬 LLM, …)을 별개의 이름을 가진 도구로 호스팅할 수
-있습니다. 전체 API 레퍼런스:
-[`packages/ai-relay/README.md`](./packages/ai-relay/README.md) (영문).
+실행 가능한 전체 버전은 [`examples/stdio/`](./examples/stdio/),
+[`examples/multi-upstream/`](./examples/multi-upstream/),
+[`examples/cloudflare-workers/`](./examples/cloudflare-workers/)에 있습니다.
 
-[`examples/`](./examples/) 의 실행 가능 예제:
+---
 
-| 예제 | 용도 |
-|---|---|
-| [`stdio/`](./examples/stdio/) | 단일 도구 stdio launcher (npx CLI와 동일 모양, 코드 기반) |
-| [`multi-upstream/`](./examples/multi-upstream/) | 한 서버, 여러 업스트림 (OpenAI + Azure + 로컬 LLM) — C7 다중 등록 시나리오 |
-| [`cloudflare-workers/`](./examples/cloudflare-workers/) | `agents/mcp` 프레임워크 기반 Workers MCP |
+## 환경 변수
+
+| 변수 | 범위 | 필수 | 기본값 |
+|---|---|---|---|
+| `AI_RELAY_API_KEY` | 업스트림 자격 증명 (CLI + 앱) | 예 (CLI + 앱) | — |
+| `AI_RELAY_BASE_URL` | 업스트림 엔드포인트 오버라이드 | 아니오 | SDK 기본값 |
+| `AI_RELAY_MAX_OUTPUT_TOKENS` | 요청당 `max_tokens` ceiling | 아니오 | 4096 |
+| `AI_RELAY_REQUEST_TIMEOUT_MS` | 업스트림 HTTP 타임아웃 | 아니오 | 60000 |
+| `RELAY_AUTH_TOKEN` | `./app` 라우트용 HTTP bearer (서버 전용) | 예 (앱) | — |
+
+---
+
+## v0.1에서 마이그레이션
+
+| 이전 | 새 이름 | 출처 |
+|---|---|---|
+| `mcp-ai-relay` (bin) | `ai-relay` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `mcp-ai-relay --openai-completion` (stdio) | `ai-relay openai chat -m … "…"` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `--tool-name <id>` | (제거됨; 기본 도구 이름은 `openai_chat`) | [#55](https://github.com/ragingwind/mcp-ai-relay/issues/55) + [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `completion_chat` (기본 도구 이름) | `openai_chat` | [#55](https://github.com/ragingwind/mcp-ai-relay/issues/55) |
+| `OPENAI_API_KEY` | `AI_RELAY_API_KEY` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `OPENAI_BASE_URL` | `AI_RELAY_BASE_URL` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `MAX_OUTPUT_TOKENS_CEILING` | `AI_RELAY_MAX_OUTPUT_TOKENS` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `REQUEST_TIMEOUT_MS` | `AI_RELAY_REQUEST_TIMEOUT_MS` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
 
 ---
 
 ## 상태
 
-**v0.1.0** (npm SDK) / **v1 릴레이 앱** — 도구 1개 `completion_chat`,
+**v0.1.0** (npm SDK) / **v1 릴레이 앱** — 도구 1개 `openai_chat`,
 Bearer 토큰 인증, Streamable HTTP 트랜스포트. v2 백로그(Responses API,
 OAuth 2.1, rate limiting, budget caps, observability)는
 [`doc/ARCHITECTURE.ko.md` §11](./doc/ARCHITECTURE.ko.md#11-v2-백로그)에
-정리.
+정리되어 있습니다.
+
+---
+
+## 문서
+
+| 주제 | 문서 |
+|---|---|
+| SDK API + CLI + 레시피 | [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) (영문) |
+| 아키텍처, 의사결정, 참고문헌 | [`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) |
+| 배포 런북 (Vercel + Docker, 운영) | [`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) |
+| AI 에이전트 협업 가이드 | [`CLAUDE.md`](./CLAUDE.md) |
+
+사용자 대상 문서의 한국어 번역 (영문이 정전):
+[`README.md`](./README.md) ·
+[`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) ·
+[`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) ·
+[`doc/QA-MCP-INSPECTOR.ko.md`](./doc/QA-MCP-INSPECTOR.ko.md).
 
 ---
 
@@ -231,27 +142,15 @@ OAuth 2.1, rate limiting, budget caps, observability)는
 
 ```bash
 pnpm install
-cp .env.example .env.local        # OPENAI_API_KEY + RELAY_AUTH_TOKEN 채우기
+cp .env.example .env.local        # fill AI_RELAY_API_KEY + RELAY_AUTH_TOKEN
 pnpm dev                          # http://localhost:3000/api/mcp
 pnpm test                         # vitest
 ```
 
-`.env.local` 이 없거나 두 필수 값이 비어 있으면 `pnpm dev`는 실행을 거부하고
-조치 안내를 출력합니다. 모든 빌드/테스트/검증 명령은
-[`CLAUDE.md` §3 — Verify Commands](./CLAUDE.md#3-verify-commands) 에서
+`.env.local`이 없거나 `RELAY_AUTH_TOKEN`이 비어 있으면 `pnpm dev`는 실행을
+거부하고 조치 안내를 출력합니다. 모든 빌드/테스트/검증 명령은
+[`CLAUDE.md` §3 — Verify Commands](./CLAUDE.md#3-verify-commands)에서
 확인할 수 있습니다.
-
----
-
-## 문서
-
-| 주제 | 문서 |
-|---|---|
-| SDK API + 레시피 | [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) (영문) |
-| 아키텍처, 의사결정, 참고문헌 | [`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) |
-| 배포 런북 (Vercel + Docker, 운영) | [`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) |
-| 수동 검증 (PR 전 / 배포 후) | [`doc/QA-MCP-INSPECTOR.ko.md`](./doc/QA-MCP-INSPECTOR.ko.md) |
-| AI 에이전트 협업 가이드 | [`CLAUDE.md`](./CLAUDE.md) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,147 +1,113 @@
 # mcp-ai-relay
 
+> An MCP relay that exposes OpenAI Chat Completions (and any OpenAI-compatible upstream) as a Model Context Protocol tool.
+
 > 한국어: [README.ko.md](./README.ko.md)
 
-A relay that exposes the OpenAI Chat Completions API as an
-[MCP (Model Context Protocol)](https://modelcontextprotocol.io) tool. Register
-the relay's HTTP endpoint with an MCP host (Claude Code, Claude Desktop, …) so
-the host's LLM can call OpenAI models as if they were tools.
+`mcp-ai-relay` lets any [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
+host call OpenAI-compatible chat models as if they were tools. The same SDK
+ships four interchangeable surfaces — pick the one that fits how you want to
+deploy.
 
 ```
-[ MCP host ]  --bearer-->  [ relay HTTP /api/mcp ]  --API key-->  [ OpenAI / compatible upstream ]
+MCP host  ──►  ai-relay  ──►  OpenAI-compatible API
+              (CLI | SDK | App | Docker)
 ```
-
-Three ways to consume it:
-
-1. **Run as an HTTP server** — Docker self-hosted or Vercel managed. The
-   primary deployment shape; what an MCP host registers.
-2. **One-shot CLI** — `npx ai-relay openai chat -m <model> "<input>"` for
-   shell pipelines, smoke tests, or quick experimentation.
-3. **Embed the SDK in your own MCP server** — most control. Best when you want
-   custom logic, multi-upstream registration, or non-Node runtimes.
-
-The npm package is
-[`ai-relay`](https://www.npmjs.com/package/ai-relay).
-Pick a path below.
 
 ---
 
-## 1. Quick start — HTTP server (Docker Compose)
+## Surfaces
 
-The relay's primary surface is HTTP. MCP hosts (Claude Code, Claude Desktop,
-…) connect to a single bearer-protected endpoint that handles streaming chat
-completions.
-
-```bash
-git clone https://github.com/ragingwind/mcp-ai-relay.git
-cd mcp-ai-relay
-cp .env.example .env.local
-# Fill AI_RELAY_API_KEY and RELAY_AUTH_TOKEN (32+ bytes — `openssl rand -hex 32`)
-docker compose up -d
-```
-
-The MCP endpoint is now at `http://localhost:8787/api/mcp`. Stop with
-`docker compose down`. Override the host port with
-`HOST_PORT=... docker compose up -d`.
-
-### Register in Claude Code
-
-```bash
-claude mcp add --transport http openai-relay \
-  http://localhost:8787/api/mcp \
-  --header "Authorization: Bearer <RELAY_AUTH_TOKEN>"
-```
-
-### Register in Claude Desktop
-
-Open `claude_desktop_config.json`. The path is OS-specific:
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the `mcpServers` entry below (merge the `"openai-relay"` key into the
-existing `"mcpServers"` object if any):
-
-```json
-{
-  "mcpServers": {
-    "openai-relay": {
-      "transport": {
-        "type": "http",
-        "url": "http://localhost:8787/api/mcp",
-        "headers": {
-          "Authorization": "Bearer <RELAY_AUTH_TOKEN>"
-        }
-      }
-    }
-  }
-}
-```
-
-Quit Claude Desktop completely (⌘Q on macOS) and reopen it. The
-`openai_chat` tool appears under `openai-relay`.
-
-For Vercel serverless, raw `docker run`, full operations (token rotation,
-troubleshooting, OpenAI usage cap), see [`doc/DEPLOY.md`](./doc/DEPLOY.md).
-
-### Environment variables
-
-| Key | Required | Notes |
-|---|---|---|
-| `AI_RELAY_API_KEY` | ✅ | Upstream API key. Sensitive. |
-| `RELAY_AUTH_TOKEN` | ✅ | Bearer token MCP hosts send. ≥ 32 bytes. |
-| `AI_RELAY_BASE_URL` | ❌ | Override for Azure / vLLM / Ollama / AI Gateway. |
-| `AI_RELAY_MAX_OUTPUT_TOKENS` | ❌ | Default 4096. |
-| `AI_RELAY_REQUEST_TIMEOUT_MS` | ❌ | Default 60000. |
+| Surface | Transport | Install | When |
+|---|---|---|---|
+| `npx ai-relay` | none (one-shot) | none | quick test, scripting, CI smoke |
+| SDK (`ai-relay`) | caller's choice (stdio / HTTP / Workers) | npm | embed in custom MCP server |
+| App (`./app`, Next.js) | HTTP | `git clone` (self-host on Vercel/Node) | personal or team HTTP endpoint |
+| Docker (local build) | HTTP | `docker build` from this repo | container deployment now; published image lands with [#57](https://github.com/ragingwind/mcp-ai-relay/issues/57) |
 
 ---
 
-## 2. One-shot CLI
-
-The SDK ships an `ai-relay` bin that invokes a tool once and prints the
-result on stdout. It is **not** a long-lived stdio MCP server — wire MCP
-hosts at the HTTP endpoint above instead.
+## Quick start — one-shot CLI
 
 ```bash
 AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini "ping"
-echo '{"messages":[{"role":"user","content":"ping"}]}' \
-  | AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini
-AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini -s "be terse" "explain TLS"
+
+AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini \
+  '{"messages":[{"role":"user","content":"ping"}]}'
+
+echo "explain TLS in 2 sentences" \
+  | AI_RELAY_API_KEY=sk-... npx ai-relay openai chat -m gpt-4o-mini -s "be terse"
 ```
 
-`-m/--model` is required. Input is either positional or piped via stdin
-(exactly one). Plain text becomes a `messages` array; JSON literals are
-passed verbatim. Full flag list: [`packages/ai-relay/README.md`](./packages/ai-relay/README.md#cli).
+`-m/--model` is mandatory. Input is either a positional argument or piped via
+stdin (exactly one — they are XOR). A plain-text positional becomes a
+`{messages:[…]}` array; a JSON literal (`{` / `[`) is passed verbatim.
 
 ---
 
-## 3. Embed the SDK in your own MCP server
-
-If you're building a custom MCP server (Cloudflare Workers, Hono/Express, your
-own Next.js route, etc.) the SDK package is the import surface:
+## Quick start — Docker (local build)
 
 ```bash
-npm install ai-relay @modelcontextprotocol/sdk openai
+docker build -t mcp-ai-relay .
+
+docker run -p 8787:8787 \
+  -e AI_RELAY_API_KEY=sk-... \
+  -e RELAY_AUTH_TOKEN=$(openssl rand -hex 32) \
+  mcp-ai-relay
 ```
+
+The MCP endpoint is then served at `http://localhost:8787/api/mcp`. A
+`compose.yml` is also provided in the repo root if you prefer
+`docker compose up`.
+
+> When [#57](https://github.com/ragingwind/mcp-ai-relay/issues/57) lands, the
+> `docker build` step is replaced by a pull from
+> `ghcr.io/ragingwind/ai-relay`. Until then, build locally.
+
+---
+
+## Quick start — embed the SDK
 
 ```ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerOpenAIChat } from "ai-relay/openai";
 
 const server = new McpServer({ name: "my-relay", version: "0.1.0" });
 registerOpenAIChat(server, { apiKey: process.env.AI_RELAY_API_KEY! });
+await server.connect(new StdioServerTransport());
 ```
 
-`registerOpenAIChat` is closure-isolated, so the same server may host multiple
-upstreams (OpenAI + Azure + local LLM, …) as distinct named tools. Full API
-reference: [`packages/ai-relay/README.md`](./packages/ai-relay/README.md).
+Full runnable versions live in [`examples/stdio/`](./examples/stdio/),
+[`examples/multi-upstream/`](./examples/multi-upstream/), and
+[`examples/cloudflare-workers/`](./examples/cloudflare-workers/).
 
-Runnable examples in [`examples/`](./examples/):
+---
 
-| Example | Use case |
-|---|---|
-| [`stdio/`](./examples/stdio/) | Single-tool stdio launcher |
-| [`multi-upstream/`](./examples/multi-upstream/) | One server, multiple upstreams (OpenAI + Azure + local LLM) |
-| [`cloudflare-workers/`](./examples/cloudflare-workers/) | Workers MCP via `agents/mcp` framework |
+## Environment variables
+
+| Var | Scope | Required | Default |
+|---|---|---|---|
+| `AI_RELAY_API_KEY` | upstream credential (CLI + app) | yes (CLI + app) | — |
+| `AI_RELAY_BASE_URL` | upstream endpoint override | no | SDK default |
+| `AI_RELAY_MAX_OUTPUT_TOKENS` | per-request `max_tokens` ceiling | no | 4096 |
+| `AI_RELAY_REQUEST_TIMEOUT_MS` | upstream HTTP timeout | no | 60000 |
+| `RELAY_AUTH_TOKEN` | HTTP bearer for `./app` route (server-only) | yes (app) | — |
+
+---
+
+## Migration from v0.1
+
+| Old | New | Source |
+|---|---|---|
+| `mcp-ai-relay` (bin) | `ai-relay` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `mcp-ai-relay --openai-completion` (stdio) | `ai-relay openai chat -m … "…"` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `--tool-name <id>` | (removed; default tool name is `openai_chat`) | [#55](https://github.com/ragingwind/mcp-ai-relay/issues/55) + [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `completion_chat` (default tool name) | `openai_chat` | [#55](https://github.com/ragingwind/mcp-ai-relay/issues/55) |
+| `OPENAI_API_KEY` | `AI_RELAY_API_KEY` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `OPENAI_BASE_URL` | `AI_RELAY_BASE_URL` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `MAX_OUTPUT_TOKENS_CEILING` | `AI_RELAY_MAX_OUTPUT_TOKENS` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
+| `REQUEST_TIMEOUT_MS` | `AI_RELAY_REQUEST_TIMEOUT_MS` | [#56](https://github.com/ragingwind/mcp-ai-relay/issues/56) |
 
 ---
 
@@ -152,6 +118,23 @@ bearer token authentication, Streamable HTTP transport. The v2 backlog
 (Responses API, OAuth 2.1, rate limiting, budget caps, observability) is
 tracked in
 [`doc/ARCHITECTURE.md` §11](./doc/ARCHITECTURE.md#11-future-work-v2-backlog).
+
+---
+
+## Documentation
+
+| Topic | Document |
+|---|---|
+| SDK API + CLI + recipes | [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) |
+| Architecture, decisions, references | [`doc/ARCHITECTURE.md`](./doc/ARCHITECTURE.md) |
+| Deployment runbook (Vercel + Docker, operations) | [`doc/DEPLOY.md`](./doc/DEPLOY.md) |
+| AI agent collaboration | [`CLAUDE.md`](./CLAUDE.md) |
+
+Korean translations of the user-facing docs (English remains canonical):
+[`README.ko.md`](./README.ko.md) ·
+[`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) ·
+[`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) ·
+[`doc/QA-MCP-INSPECTOR.ko.md`](./doc/QA-MCP-INSPECTOR.ko.md).
 
 ---
 
@@ -170,24 +153,6 @@ pnpm test                         # vitest
 is missing or `RELAY_AUTH_TOKEN` is not set. All build/test/verify
 commands are listed in
 [`CLAUDE.md` §3 — Verify Commands](./CLAUDE.md#3-verify-commands).
-
----
-
-## Documentation
-
-| Topic | Document |
-|---|---|
-| SDK API + CLI + recipes | [`packages/ai-relay/README.md`](./packages/ai-relay/README.md) |
-| Architecture, decisions, references | [`doc/ARCHITECTURE.md`](./doc/ARCHITECTURE.md) |
-| Deployment runbook (Vercel + Docker, operations) | [`doc/DEPLOY.md`](./doc/DEPLOY.md) |
-| Manual verification (pre-PR, post-deploy) | [`doc/QA-MCP-INSPECTOR.md`](./doc/QA-MCP-INSPECTOR.md) |
-| AI agent collaboration | [`CLAUDE.md`](./CLAUDE.md) |
-
-Korean translations of the user-facing docs (English remains canonical):
-[`README.ko.md`](./README.ko.md) ·
-[`doc/ARCHITECTURE.ko.md`](./doc/ARCHITECTURE.ko.md) ·
-[`doc/DEPLOY.ko.md`](./doc/DEPLOY.ko.md) ·
-[`doc/QA-MCP-INSPECTOR.ko.md`](./doc/QA-MCP-INSPECTOR.ko.md).
 
 ---
 


### PR DESCRIPTION
Closes #59

## Summary

Restructure root `README.md` around the four surfaces (npx / SDK / app / docker) per the #59 issue body. Mirror the new English structure in `README.ko.md` (full rewrite — current Korean is structurally + content stale). Audited `packages/ai-relay/README.md`; already aligned post-#56.

This is a **docs-only PR**. No code changes. Project `evidence-mode: none`. Verification = grep purity + structure parity + code-block parity + link resolution + quality-gate captures.

## Phases

| Phase | Commit | Scope |
|---|---|---|
| 1 | `9c14e0c` | English README 8-section rewrite + packages/ai-relay/README.md alignment audit (no edits needed) |
| 2 | `88770f5` | Korean README full rewrite (mirror of new English) |
| 3 | (no commit) | Verification artifacts captured under \$STATE_DIR/ |

## Verification

- **grep purity**: legacy env names (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `MAX_OUTPUT_TOKENS_CEILING`, `REQUEST_TIMEOUT_MS`), removed flags (`--openai-completion`, `--tool-name`), removed default tool name (`completion_chat`) appear ONLY inside the Migration table's "Old" column where they are documented as renamed-from values. 0 matches outside the migration table.
- **structure parity**: English ↔ Korean heading depths match (empty diff).
- **code-block parity**: all fenced code blocks byte-identical (empty diff).
- **link resolution**: all internal links resolve (no BROKEN: entries).
- **table row counts**: Surfaces 4 rows, Env 5 rows, Migration 8 rows — both languages.
- **quality gates**: `pnpm build / typecheck / lint / test (162/162) / test:integration (36/36)` all PASS.

## Out of scope

- ghcr.io image references (await #57)
- `doc/*` updates (already done in #56)
- `examples/*/README.md` (already done in #56)