### PR TITLE
chore(scripts): dedupe dotenv parsers via node --env-file-if-exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Jimmy Moon <ragingwind@gmail.com>",
   "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": ">=20.0.0 <21.0.0"
+    "node": ">=20.10.0 <21.0.0"
   },
   "scripts": {
     "dev": "node scripts/check-dev-env.mjs && pnpm -r --filter ai-relay build && pnpm -F app dev",
@@ -18,8 +18,9 @@
     "test": "pnpm --filter ai-relay build && vitest run --passWithNoTests",
     "test:unit": "pnpm --filter ai-relay test",
     "test:integration": "pnpm --filter ai-relay build && vitest run --project integration --passWithNoTests",
-    "verify": "node scripts/verify.mjs",
-    "inspect": "node scripts/mcp-inspect.mjs"
+    "verify": "node --env-file-if-exists=.env.local scripts/verify.mjs",
+    "inspect": "node --env-file-if-exists=.env.local scripts/mcp-inspect.mjs",
+    "check-env": "node --env-file-if-exists=.env.local scripts/check-dev-env.mjs"
   },
   "dependencies": {
     "ai-relay": "workspace:*"

--- a/scripts/check-dev-env.mjs
+++ b/scripts/check-dev-env.mjs
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
-// Pre-flight for `pnpm dev`. app/src/env.ts re-validates at module load, but
-// that only fires when the server boots — by then `pnpm -F app dev` may have
-// printed an unrelated stack trace. Catching it here keeps the failure mode
-// visible before the server starts.
+// Standalone env pre-flight. Invoke via `pnpm check-env` (which auto-loads
+// .env.local via Node's --env-file-if-exists flag). Replicates the runtime
+// validation in app/src/env.ts to surface failures without booting the server.
 
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
-
-const ENV_PATH = resolve(process.cwd(), ".env.local");
 const REQUIRED = ["AI_RELAY_AUTH_TOKEN"];
 
 function fail(lines) {
@@ -15,53 +10,24 @@ function fail(lines) {
   process.exit(1);
 }
 
-if (!existsSync(ENV_PATH)) {
-  fail([
-    "",
-    "[mcp-ai-relay] .env.local is missing.",
-    "",
-    "  cp .env.example .env.local",
-    "  # then set AI_RELAY_AUTH_TOKEN (required) and AI_RELAY_API_KEY (optional)",
-    "  # token: openssl rand -hex 32",
-    "",
-  ]);
-}
-
-const raw = readFileSync(ENV_PATH, "utf8");
-const dotenv = Object.fromEntries(
-  raw
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith("#") && line.includes("="))
-    .map((line) => {
-      const idx = line.indexOf("=");
-      const k = line.slice(0, idx).trim();
-      let v = line.slice(idx + 1).trim();
-      if (
-        (v.startsWith('"') && v.endsWith('"')) ||
-        (v.startsWith("'") && v.endsWith("'"))
-      ) {
-        v = v.slice(1, -1);
-      }
-      return [k, v];
-    }),
-);
-
-const missing = REQUIRED.filter((key) => !dotenv[key]);
+const missing = REQUIRED.filter((k) => !process.env[k]);
 if (missing.length > 0) {
   fail([
     "",
-    `[mcp-ai-relay] .env.local missing required values: ${missing.join(", ")}`,
+    `[mcp-ai-relay] missing required env: ${missing.join(", ")}`,
     "",
-    "  Edit .env.local and set:",
+    "  Set in .env.local (auto-loaded by pnpm scripts):",
     ...missing.map((k) => `    ${k}=...`),
+    "",
+    "  Or export in your shell:",
+    ...missing.map((k) => `    export ${k}=...`),
     "",
     "  Generate AI_RELAY_AUTH_TOKEN if needed:  openssl rand -hex 32",
     "",
   ]);
 }
 
-if (Buffer.byteLength(dotenv.AI_RELAY_AUTH_TOKEN, "utf8") < 32) {
+if (Buffer.byteLength(process.env.AI_RELAY_AUTH_TOKEN, "utf8") < 32) {
   fail([
     "",
     "[mcp-ai-relay] AI_RELAY_AUTH_TOKEN must be at least 32 bytes.",

--- a/scripts/mcp-inspect.mjs
+++ b/scripts/mcp-inspect.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // CLI wrapper around `npx @modelcontextprotocol/inspector --cli` for ad-hoc
-// MCP smoke checks against /api/mcp. Inputs (priority: flag > env > .env.local
-// > default):
+// MCP smoke checks against /api/mcp. Inputs (priority: flag > env (incl.
+// --env-file-if-exists=.env.local) > default):
 //
 //   --url=<URL>      MCP_URL              http://localhost:8787/api/mcp
-//   --token=<TOK>    AI_RELAY_AUTH_TOKEN  (required, falls back to .env.local)
+//   --token=<TOK>    AI_RELAY_AUTH_TOKEN  (required)
 //   --tool=<NAME>    MCP_TOOL             openai_chat
 //   --model=<NAME>   MCP_MODEL            gpt-4o-mini
 //   --message=<TXT>  MCP_MESSAGE          ping
@@ -18,31 +18,6 @@
 //   MCP_URL=https://relay.example.com/api/mcp AI_RELAY_AUTH_TOKEN=... pnpm inspect
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
-
-function loadDotenv() {
-  const p = resolve(process.cwd(), ".env.local");
-  if (!existsSync(p)) return {};
-  return Object.fromEntries(
-    readFileSync(p, "utf8")
-      .split("\n")
-      .map((l) => l.trim())
-      .filter((l) => l && !l.startsWith("#") && l.includes("="))
-      .map((l) => {
-        const i = l.indexOf("=");
-        const k = l.slice(0, i).trim();
-        let v = l.slice(i + 1).trim();
-        if (
-          (v.startsWith('"') && v.endsWith('"')) ||
-          (v.startsWith("'") && v.endsWith("'"))
-        ) {
-          v = v.slice(1, -1);
-        }
-        return [k, v];
-      }),
-  );
-}
 
 const flags = Object.fromEntries(
   process.argv
@@ -54,21 +29,12 @@ const flags = Object.fromEntries(
     }),
 );
 
-const dotenv = loadDotenv();
-
 const URL_BASE =
-  flags.url ??
-  process.env.MCP_URL ??
-  dotenv.MCP_URL ??
-  "http://localhost:8787/api/mcp";
-const TOKEN =
-  flags.token ?? process.env.AI_RELAY_AUTH_TOKEN ?? dotenv.AI_RELAY_AUTH_TOKEN;
-const TOOL =
-  flags.tool ?? process.env.MCP_TOOL ?? dotenv.MCP_TOOL ?? "openai_chat";
-const MODEL =
-  flags.model ?? process.env.MCP_MODEL ?? dotenv.MCP_MODEL ?? "gpt-4o-mini";
-const MESSAGE =
-  flags.message ?? process.env.MCP_MESSAGE ?? dotenv.MCP_MESSAGE ?? "ping";
+  flags.url ?? process.env.MCP_URL ?? "http://localhost:8787/api/mcp";
+const TOKEN = flags.token ?? process.env.AI_RELAY_AUTH_TOKEN;
+const TOOL = flags.tool ?? process.env.MCP_TOOL ?? "openai_chat";
+const MODEL = flags.model ?? process.env.MCP_MODEL ?? "gpt-4o-mini";
+const MESSAGE = flags.message ?? process.env.MCP_MESSAGE ?? "ping";
 const METHOD = flags.method ?? "tools/call";
 
 if (!TOKEN) {

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -12,39 +12,11 @@
 //   C6 (cancellation)     — relies on visual inspection of the OpenAI usage
 //      page; stays manual per QA-MCP-INSPECTOR.md.
 
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
-
-const ENV_PATH = resolve(process.cwd(), ".env.local");
-
-if (!existsSync(ENV_PATH)) {
-  console.error("[verify] .env.local missing — run `pnpm dev` once to surface setup steps.");
-  process.exit(1);
-}
-
-const raw = readFileSync(ENV_PATH, "utf8");
-const dotenv = Object.fromEntries(
-  raw
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith("#") && line.includes("="))
-    .map((line) => {
-      const idx = line.indexOf("=");
-      const k = line.slice(0, idx).trim();
-      let v = line.slice(idx + 1).trim();
-      if (
-        (v.startsWith('"') && v.endsWith('"')) ||
-        (v.startsWith("'") && v.endsWith("'"))
-      ) {
-        v = v.slice(1, -1);
-      }
-      return [k, v];
-    }),
-);
-
-const TOKEN = dotenv.AI_RELAY_AUTH_TOKEN;
+const TOKEN = process.env.AI_RELAY_AUTH_TOKEN;
 if (!TOKEN) {
-  console.error("[verify] AI_RELAY_AUTH_TOKEN missing in .env.local");
+  console.error(
+    "[verify] AI_RELAY_AUTH_TOKEN missing — set in .env.local (auto-loaded by `pnpm verify`) or export in your shell",
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
Closes #58

## Summary

Replace hand-rolled dotenv parsers in 3 scripts (`scripts/check-dev-env.mjs`, `scripts/verify.mjs`, `scripts/mcp-inspect.mjs`) with Node 20.10+'s `--env-file-if-exists=.env.local`. Bump `engines.node` lower bound to `>=20.10.0`. Add `pnpm check-env` script (was previously invoked by `pre*` hooks removed in #57).

#57 already absorbed the other 2 items in #58: removed `pre*` SDK rebuild hooks and collapsed `compose.yml` to image-only. This PR closes the remaining slice.

## Verification

- `pnpm typecheck` PASS
- `pnpm lint` PASS
- `pnpm test` PASS (166/166)
- `pnpm test:integration` PASS (40/40)
- `pnpm -r build` PASS
- `pnpm check-env` PASS with `.env.local`; FAIL with clear dual-hint message without
- Grep `Object\.fromEntries` in `scripts/` → 0 matches relating to dotenv
- No new package deps

## Behavior change (minor)

Scripts now succeed if env vars are set directly without `.env.local` (was: hard-fail on missing file). Failure mode shifts from "file absent" to "var absent" — same UX, simpler code, broader compatibility (CI, direct exports).

`evidence-mode: none` per project CLAUDE.md.