### PR TITLE
chore(sdk): Phase 1-4 finalization — first real npm publish (0.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tsconfig.tsbuildinfo
 .claude/
 .vercel
 packages/*/dist
+
+# Wrangler local dev cache (Cloudflare Workers smoke tests)
+.wrangler/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ packages/*/dist
 
 # Wrangler local dev cache (Cloudflare Workers smoke tests)
 .wrangler/
+
+# Cloudflare Workers local dev secrets
+.dev.vars

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,10 +1,10 @@
-# mcp-ai-relay
+# ai-relay
 
 > OpenAI Chat Completions (및 OpenAI 호환 업스트림)을 Model Context Protocol 도구로 노출하는 MCP 릴레이입니다.
 
 > English: [README.md](./README.md)
 
-`mcp-ai-relay`를 사용하면 모든 [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
+`ai-relay`를 사용하면 모든 [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
 호스트가 OpenAI 호환 채팅 모델을 도구처럼 호출할 수 있습니다. 동일한 SDK가
 서로 교체 가능한 4개의 사용 표면을 제공하므로 — 배포 방식에 맞는 것을 고르세요.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -118,7 +118,7 @@ await server.connect(new StdioServerTransport());
 
 ## 상태
 
-**v0.1.0** (npm SDK) / **v1 릴레이 앱** — 도구 1개 `openai_chat`,
+**v0.2.0** (npm SDK) / **v1 릴레이 앱** — 도구 1개 `openai_chat`,
 Bearer 토큰 인증, Streamable HTTP 트랜스포트. v2 백로그(Responses API,
 OAuth 2.1, rate limiting, budget caps, observability)는
 [`doc/ARCHITECTURE.ko.md` §11](./doc/ARCHITECTURE.ko.md#11-v2-백로그)에

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# mcp-ai-relay
+# ai-relay
 
 > An MCP relay that exposes OpenAI Chat Completions (and any OpenAI-compatible upstream) as a Model Context Protocol tool.
 
 > 한국어: [README.ko.md](./README.ko.md)
 
-`mcp-ai-relay` lets any [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
+`ai-relay` lets any [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
 host call OpenAI-compatible chat models as if they were tools. The same SDK
 ships four interchangeable surfaces — pick the one that fits how you want to
 deploy.
@@ -119,7 +119,7 @@ Full runnable versions live in [`examples/stdio/`](./examples/stdio/),
 
 ## Status
 
-**v0.1.0** (npm SDK) / **v1 relay app** — single tool `openai_chat`,
+**v0.2.0** (npm SDK) / **v1 relay app** — single tool `openai_chat`,
 bearer token authentication, Streamable HTTP transport. The v2 backlog
 (Responses API, OAuth 2.1, rate limiting, budget caps, observability) is
 tracked in

--- a/examples/cloudflare-workers/.dev.vars.example
+++ b/examples/cloudflare-workers/.dev.vars.example
@@ -1,0 +1,5 @@
+# Wrangler local dev reads .dev.vars (gitignored). Copy this file to .dev.vars
+# and fill in. For production, use `wrangler secret put <NAME>`.
+AI_RELAY_API_KEY="sk-test-..."
+# AI_RELAY_BASE_URL="https://your-openai-compatible.example.com/v1"
+AI_RELAY_AUTH_TOKEN="<32-byte-hex; generate via: openssl rand -hex 32>"

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -26,6 +26,32 @@ registers the SDK's tool in `init()` and adds a bearer-token gate.
 > stack adopts zod@4. Track upstream:
 > https://github.com/cloudflare/agents
 
+## Local development
+
+1. Copy `.dev.vars.example` to `.dev.vars` and fill in real values
+   (`.dev.vars` is gitignored).
+2. `pnpm install`
+3. `pnpm dev` (runs `wrangler dev` on `http://localhost:8787` by default).
+4. Hit it with the bearer token from `.dev.vars`:
+   ```bash
+   TOKEN=$(grep AI_RELAY_AUTH_TOKEN .dev.vars | cut -d'"' -f2)
+   curl -N -H "Authorization: Bearer $TOKEN" \
+     -H 'Accept: text/event-stream' \
+     http://localhost:8787/sse
+   ```
+   Expect HTTP 200 plus an SSE stream whose first frame is
+   `event: endpoint` pointing at `/sse/message?sessionId=...` (the
+   `agents/mcp` handshake). Without the bearer header the same endpoint
+   returns `401`. Subsequent JSON-RPC messages are POSTed to the
+   `/sse/message?sessionId=...` URL announced by that first frame.
+
+For an automated end-to-end smoke (boots wrangler, asserts both the
+no-auth 401 and the authenticated non-401 path), run:
+
+```bash
+pnpm smoke
+```
+
 ## Run from this monorepo
 
 ```bash

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -14,6 +14,18 @@ registers the SDK's tool in `init()` and adds a bearer-token gate.
 > `OpenAIRelay extends McpAgent` and `serveSSE("/sse")` calls per
 > Cloudflare's latest docs.
 
+> **Note (zod cross-major in this example)**
+>
+> `ai-relay@0.2.0` ships `zod@^4`, but `agents@^0.0.50` (Cloudflare's
+> agent runtime) transitively pulls `@ai-sdk/*` which requires `zod@^3`.
+> pnpm resolves both versions side-by-side. The SDK's tool input schemas
+> stay on zod@4; the `agents` runtime uses its own zod@3 instance for
+> its internal types. There is no schema-instance crossing between them
+> (the `McpAgent` boundary serializes to MCP wire format), so the dual
+> resolution is functionally safe but unavoidable until Cloudflare's
+> stack adopts zod@4. Track upstream:
+> https://github.com/cloudflare/agents
+
 ## Run from this monorepo
 
 ```bash

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -8,7 +8,8 @@ registers the SDK's tool in `init()` and adds a bearer-token gate.
 
 > **Note on framework dependencies**: The `agents` package is
 > Cloudflare's official MCP-on-Workers framework. Its API is still
-> evolving in 2026 — this example targets `agents@^0.0.40`. If your
+> evolving in 2026 — this example targets `agents@>=0.0.50 <0.1.0`
+> (the version range that ships the `agents/mcp` subpath). If your
 > deployment uses a different framework version, adapt the
 > `OpenAIRelay extends McpAgent` and `serveSSE("/sse")` calls per
 > Cloudflare's latest docs.

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26",
     "ai-relay": "workspace:*",
-    "agents": "^0.0.40",
+    "agents": ">=0.0.50 <0.1.0",
     "openai": "^6"
   },
   "devDependencies": {

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -6,7 +6,8 @@
   "description": "Cloudflare Workers MCP server using the SDK + agents/mcp framework.",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "smoke": "bash scripts/smoke.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26",

--- a/examples/cloudflare-workers/scripts/smoke.sh
+++ b/examples/cloudflare-workers/scripts/smoke.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Real smoke test for the Cloudflare Workers example.
+#
+# Boots `wrangler dev` on a non-default port, then asserts:
+#   1. GET /sse without auth        → HTTP 401 (bearer gate works negatively)
+#   2. GET /sse with valid bearer   → HTTP 200 + SSE body containing
+#      `event: endpoint` and `/sse/message?sessionId=` (proves the
+#      `agents/mcp` McpAgent.serveSSE handler ran AND issued a valid
+#      session endpoint, i.e. the MCP server actually handled the request)
+#
+# Exits 0 only when BOTH assertions hold; ends output with `=== PASS ===`.
+
+set -u
+set -o pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$EXAMPLE_DIR"
+
+PORT="${SMOKE_PORT:-8788}"
+URL="http://localhost:${PORT}/sse"
+DEV_VARS="${EXAMPLE_DIR}/.dev.vars"
+WRANGLER_LOG="$(mktemp -t cf-smoke-wrangler.XXXXXX)"
+WRANGLER_PID=""
+
+cleanup() {
+  if [ -n "$WRANGLER_PID" ] && kill -0 "$WRANGLER_PID" 2>/dev/null; then
+    kill "$WRANGLER_PID" 2>/dev/null || true
+    # Wrangler spawns workerd; give it a moment then force-kill stragglers on the port.
+    sleep 1
+    if command -v lsof >/dev/null 2>&1; then
+      pids=$(lsof -ti tcp:"$PORT" 2>/dev/null || true)
+      if [ -n "$pids" ]; then
+        echo "$pids" | xargs kill -9 2>/dev/null || true
+      fi
+    fi
+  fi
+  rm -f "$WRANGLER_LOG"
+}
+trap cleanup EXIT INT TERM
+
+# 1. Ensure .dev.vars exists with a deterministic test token.
+if [ ! -f "$DEV_VARS" ]; then
+  echo "[smoke] .dev.vars missing, generating one for the test run"
+  TEST_TOKEN="$(openssl rand -hex 32)"
+  cat >"$DEV_VARS" <<EOF
+AI_RELAY_API_KEY="test-key"
+AI_RELAY_AUTH_TOKEN="${TEST_TOKEN}"
+EOF
+fi
+
+TOKEN="$(grep '^AI_RELAY_AUTH_TOKEN=' "$DEV_VARS" | cut -d'"' -f2)"
+if [ -z "$TOKEN" ]; then
+  echo "[smoke] FAIL: could not read AI_RELAY_AUTH_TOKEN from $DEV_VARS"
+  exit 1
+fi
+
+# 2. Boot wrangler dev in background.
+echo "[smoke] booting wrangler dev on port $PORT (log: $WRANGLER_LOG)"
+pnpm exec wrangler dev --port "$PORT" --ip 127.0.0.1 >"$WRANGLER_LOG" 2>&1 &
+WRANGLER_PID=$!
+
+# Poll for readiness up to ~60s.
+ready=0
+for i in $(seq 1 60); do
+  if grep -qE "Ready on http://(localhost|127\.0\.0\.1):${PORT}" "$WRANGLER_LOG" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$WRANGLER_PID" 2>/dev/null; then
+    echo "[smoke] FAIL: wrangler exited before becoming ready"
+    echo "----- wrangler log -----"
+    cat "$WRANGLER_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [ "$ready" -ne 1 ]; then
+  echo "[smoke] FAIL: wrangler did not report Ready within 60s"
+  echo "----- wrangler log -----"
+  cat "$WRANGLER_LOG"
+  exit 1
+fi
+
+# Give workerd one more beat to bind the listener.
+sleep 1
+
+fail=0
+
+# 3. Assert 1: no-auth → 401.
+echo "[smoke] assert 1: GET $URL without auth → expect 401"
+NOAUTH_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$URL" || echo "000")
+echo "[smoke]   status=$NOAUTH_STATUS"
+if [ "$NOAUTH_STATUS" != "401" ]; then
+  echo "[smoke] FAIL assert 1: expected 401, got $NOAUTH_STATUS"
+  fail=1
+fi
+
+# 4. Assert 2: GET /sse with bearer → 200 + SSE body announcing the
+#    `/sse/message?sessionId=...` endpoint. `serveSSE("/sse")` from
+#    `agents/mcp` opens the stream on GET and emits the endpoint as the
+#    first SSE event; receiving it proves the bearer gate accepted the
+#    token AND the McpAgent handler ran.
+echo "[smoke] assert 2: GET $URL with bearer → expect 200 + SSE 'event: endpoint' /sse/message"
+AUTH_BODY_FILE="$(mktemp -t cf-smoke-body.XXXXXX)"
+AUTH_STATUS=$(curl -s -N --max-time 5 -o "$AUTH_BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H 'Accept: text/event-stream' \
+  "$URL" || true)
+
+# Read at most ~4 KB of the body (SSE stream stays open; we only need
+# the first frame which contains the endpoint event).
+AUTH_BODY="$(head -c 4096 "$AUTH_BODY_FILE" 2>/dev/null || true)"
+rm -f "$AUTH_BODY_FILE"
+
+# curl --max-time exits non-zero (28) on the SSE timeout we expect; the
+# response status was already captured before the body stalled. Only
+# treat an empty status as a real failure.
+if [ -z "$AUTH_STATUS" ]; then
+  AUTH_STATUS="000"
+fi
+
+echo "[smoke]   status=$AUTH_STATUS"
+echo "[smoke]   body (first 4 KB):"
+echo "$AUTH_BODY" | sed 's/^/[smoke]     /'
+
+if [ "$AUTH_STATUS" = "401" ]; then
+  echo "[smoke] FAIL assert 2: bearer gate rejected a valid token (got 401)"
+  fail=1
+elif [ "$AUTH_STATUS" != "200" ]; then
+  echo "[smoke] FAIL assert 2: expected 200, got $AUTH_STATUS"
+  fail=1
+fi
+
+case "$AUTH_BODY" in
+  *"event: endpoint"*"/sse/message?sessionId="*) ;;
+  *)
+    echo "[smoke] FAIL assert 2: SSE body did not contain 'event: endpoint' + '/sse/message?sessionId='"
+    fail=1
+    ;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+  echo "----- wrangler log (tail) -----"
+  tail -n 80 "$WRANGLER_LOG" || true
+  echo "[smoke] === FAIL ==="
+  exit 1
+fi
+
+echo "[smoke] === PASS ==="

--- a/examples/cloudflare-workers/wrangler.toml
+++ b/examples/cloudflare-workers/wrangler.toml
@@ -20,4 +20,4 @@ new_sqlite_classes = ["OpenAIRelay"]
 # Secrets (set via `wrangler secret put AI_RELAY_API_KEY`):
 #   AI_RELAY_API_KEY        — required
 #   AI_RELAY_BASE_URL       — optional override
-#   RELAY_AUTH_TOKEN      — bearer token for the gate (32+ bytes)
+#   AI_RELAY_AUTH_TOKEN     — bearer token for the gate (32+ bytes)

--- a/examples/vercel/README.md
+++ b/examples/vercel/README.md
@@ -1,6 +1,6 @@
 # Vercel deployment (community-supported)
 
-The official deploy path for `mcp-ai-relay` is the Docker image at
+The official deploy path for `ai-relay` is the Docker image at
 `ghcr.io/ragingwind/ai-relay` (see `doc/DEPLOY.md`). This directory keeps
 a Vercel deployment recipe for users who prefer that surface.
 
@@ -15,7 +15,7 @@ shipped before it became framework-agnostic. The interesting parts:
 
 ## How to use it
 
-`mcp-ai-relay` is no longer a Next.js project, so you cannot deploy
+`ai-relay` is no longer a Next.js project, so you cannot deploy
 this repository directly to Vercel. Instead, build a thin Next.js
 project that consumes the published `ai-relay` SDK:
 

--- a/packages/ai-relay/CHANGELOG.md
+++ b/packages/ai-relay/CHANGELOG.md
@@ -29,6 +29,12 @@ shipped to the registry and exists for historical reference only.
   (`--openai-completion`) and the standalone `mcp-ai-relay` stdio bin
   alias have been removed.
 
+### Changed
+
+- `zod` runtime dep floor bumped `^4.3.6` → `^4.4.3` (#35). No API
+  change; ensures consumers pull a version with the latest validator
+  fixes.
+
 ### Removed
 
 - `OPENAI_*` env vars (replaced by `RelayConfig` per #60)

--- a/packages/ai-relay/CHANGELOG.md
+++ b/packages/ai-relay/CHANGELOG.md
@@ -6,7 +6,53 @@ the project adheres to [Semantic Versioning](https://semver.org/) once
 v1.0 ships. Pre-v1.0 minor bumps may include breaking changes — read
 this file before upgrading.
 
-## [0.1.0] — Unreleased
+## [0.2.0] — 2026-05-11
+
+First version actually published to npm. The `[0.1.0]` entry below was never
+shipped to the registry and exists for historical reference only.
+
+### Changed (BREAKING)
+
+- **Package name** — published as `ai-relay` (unscoped). The repo previously
+  drafted `@ragingwind/mcp-ai-relay` (#51) and `@ragingwind/ai-relay` (#54)
+  before settling on the unscoped form. Consumers install via
+  `npm install ai-relay`.
+  > _If npm rejected the unscoped name at publish time, the actual published
+  > name is `@ragingwind/ai-relay` — see `package.json` `name`._
+- **Config model (#60)** — single `RelayConfig` shape consumed via
+  `loadConfig()`. The 0.1.0-era `OPENAI_*` env schema (`OPENAI_API_KEY`,
+  `OPENAI_BASE_URL`, `OPENAI_MAX_OUTPUT_TOKENS_CEILING`,
+  `OPENAI_REQUEST_TIMEOUT_MS`) and the HTTP-only env schema have been
+  removed.
+- **CLI form (#61)** — one-shot `<provider> <tool>` form:
+  `npx ai-relay openai completion-chat`. The previous flag form
+  (`--openai-completion`) and the standalone `mcp-ai-relay` stdio bin
+  alias have been removed.
+
+### Removed
+
+- `OPENAI_*` env vars (replaced by `RelayConfig` per #60)
+- `mcp-ai-relay` stdio bin alias (collapsed into the single `ai-relay` bin per #61)
+
+### Tested against
+
+| Peer | Version |
+|---|---|
+| `@modelcontextprotocol/sdk` | `^1.26` |
+| `openai` | `^6` (currently `6.37.x`) |
+| `node` | `>=20.10` |
+
+### Migration from 0.1.0 (repo-only consumers)
+
+| Old | New |
+|---|---|
+| `npx mcp-ai-relay --openai-completion` | `npx ai-relay openai completion-chat` |
+| `OPENAI_API_KEY=…` env-only | `RelayConfig` via `loadConfig()` |
+| `import … from '@ragingwind/mcp-ai-relay'` | `import … from 'ai-relay'` |
+
+## [0.1.0] — Never released, superseded by 0.2.0
+
+> See 0.2.0 above for the actual first release.
 
 First public release. Extracts the durable, framework-agnostic core of
 [mcp-ai-relay](https://github.com/ragingwind/mcp-ai-relay) into a

--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -12,7 +12,7 @@ for shell pipelines and quick experimentation. The
 ships a Vercel/Next.js HTTP MCP server built on this package; see its
 README for deployment paths.
 
-> **v0.1.0** ships only the OpenAI provider. Future provider subpaths
+> **v0.2.0** ships only the OpenAI provider. Future provider subpaths
 > (`./anthropic`, `./gemini`, `./ai-gateway`) will land under their own
 > directories without breaking existing `./openai` consumers.
 

--- a/packages/ai-relay/package.json
+++ b/packages/ai-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-relay",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Provider-agnostic MCP relay SDK — embed Chat Completions and (future) Anthropic Messages, Gemini, and unified-gateway tools in any MCP server.",
   "license": "MIT",
   "author": "Jimmy Moon <ragingwind@gmail.com>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,16 +69,16 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
-        version: 1.26.0(zod@4.4.3)
+        version: 1.26.0(zod@3.25.76)
       agents:
-        specifier: ^0.0.40
-        version: 0.0.40(@cloudflare/workers-types@4.20260507.1)
+        specifier: '>=0.0.50 <0.1.0'
+        version: 0.0.113(@cloudflare/workers-types@4.20260507.1)
       ai-relay:
         specifier: workspace:*
         version: link:../../packages/ai-relay
       openai:
         specifier: ^6
-        version: 6.37.0(ws@8.18.0)(zod@4.4.3)
+        version: 6.37.0(ws@8.18.0)(zod@3.25.76)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240924.0
@@ -132,6 +132,40 @@ importers:
         version: 4.4.3
 
 packages:
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: npm:empty-npm-package@1.0.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@babel/runtime-corejs3@7.29.2':
+    resolution: {integrity: sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.4.14':
     resolution: {integrity: sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==}
@@ -903,6 +937,10 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1073,6 +1111,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1118,8 +1159,20 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  agents@0.0.40:
-    resolution: {integrity: sha512-KTp4VQqf/OKLnZz2dduifS5WjxrG6+F/zRybJnQZBKOehESvXVd9R8bj+bNwlu8ns8Ab3nCJ0xZlijPnPyH+6g==}
+  agents@0.0.113:
+    resolution: {integrity: sha512-PnUjSwFGYMcOWTcewo4NJZqN8gU2u1LFD17OhOzc83LZHa01P2o/qjLOVT338jWPzkPalXTj0RO19s0Lgyl6Ig==}
+    peerDependencies:
+      react: npm:empty-npm-package@1.0.0
+
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: npm:empty-npm-package@1.0.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1222,6 +1275,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js-pure@3.49.0:
+    resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -1251,9 +1307,16 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1316,9 +1379,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  event-target-shim@6.0.2:
-    resolution: {integrity: sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==}
-    engines: {node: '>=10.13.0'}
+  event-target-polyfill@0.0.4:
+    resolution: {integrity: sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -1454,11 +1516,22 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -1492,13 +1565,24 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mimetext@3.0.28:
+    resolution: {integrity: sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==}
 
   miniflare@4.20260504.0:
     resolution: {integrity: sha512-HeI/HLx+rbeo/UB4qb6NsNcFdUVD7xDzyCexZJTVtFMlfpfexUKEDmdeTRRpzeHrJseZFGua+v9JO1kfPublUw==}
@@ -1582,13 +1666,13 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  partyserver@0.0.65:
-    resolution: {integrity: sha512-7Kuwm1vX+p1wSL6gW0/nnehZOXYQWNp7Ywushh6n+90tRjtK303unyonQuWlDvZBM3s9GBaVpQA5x3LZ0CLUHw==}
+  partyserver@0.0.72:
+    resolution: {integrity: sha512-mYkCQ6Q4KBIy4lFFuA6upmvNeD/FC+CQVTd4V3DYU6nsitKVI3NXxBrNNvmIxJLSwk3JQzYcEOPBkebB7ITVpQ==}
     peerDependencies:
       '@cloudflare/workers-types': ^4.20240729.0
 
-  partysocket@0.0.0-548c226:
-    resolution: {integrity: sha512-sPY8fFu+Y6um9E2K9Hf2s1UFm9JD+sg5bawJZGX/NZG8ZW/ZkQ6XP1uDlfXqdCFg8FwTM4BojKuIZfKHf31n3g==}
+  partysocket@1.1.5:
+    resolution: {integrity: sha512-8uw9foq9bij4sKLCtTSHvyqMrMTQ5FJjrHc7BjoM2s95Vu7xYCN63ABpI7OZHC7ZMP5xaom/A+SsoFPXmTV6ZQ==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1665,6 +1749,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1749,9 +1836,18 @@ packages:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: npm:empty-npm-package@1.0.0
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1823,6 +1919,11 @@ packages:
 
   until-async@3.0.2:
     resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: npm:empty-npm-package@1.0.0
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1959,10 +2060,46 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      swr: 2.4.1
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@babel/runtime-corejs3@7.29.2':
+    dependencies:
+      core-js-pure: 3.49.0
+
+  '@babel/runtime@7.29.2': {}
 
   '@biomejs/biome@2.4.14':
     optionalDependencies:
@@ -2394,6 +2531,28 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.26.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.15)
@@ -2435,6 +2594,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -2553,6 +2714,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@25.6.0':
@@ -2611,14 +2774,30 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agents@0.0.40(@cloudflare/workers-types@4.20260507.1):
+  agents@0.0.113(@cloudflare/workers-types@4.20260507.1):
     dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      ai: 4.3.19(zod@3.25.76)
       cron-schedule: 5.0.4
+      mimetext: 3.0.28
       nanoid: 5.1.11
-      partyserver: 0.0.65(@cloudflare/workers-types@4.20260507.1)
-      partysocket: 0.0.0-548c226
+      partyserver: 0.0.72(@cloudflare/workers-types@4.20260507.1)
+      partysocket: 1.1.5
+      zod: 3.25.76
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - '@cloudflare/workers-types'
+      - supports-color
+
+  ai@4.3.19(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -2709,6 +2888,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js-pure@3.49.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -2730,7 +2911,11 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  diff-match-patch@1.0.5: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2850,7 +3035,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  event-target-shim@6.0.2: {}
+  event-target-polyfill@0.0.4: {}
 
   eventsource-parser@3.0.8: {}
 
@@ -3003,9 +3188,19 @@ snapshots:
 
   jose@6.2.3: {}
 
+  js-base64@3.7.8: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
 
   kleur@4.1.5: {}
 
@@ -3028,11 +3223,24 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mimetext@3.0.28:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@babel/runtime-corejs3': 7.29.2
+      js-base64: 3.7.8
+      mime-types: 2.1.35
 
   miniflare@4.20260504.0:
     dependencies:
@@ -3098,6 +3306,11 @@ snapshots:
       ws: 8.18.0
       zod: 4.4.3
 
+  openai@6.37.0(ws@8.18.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.0
+      zod: 3.25.76
+
   openai@6.37.0(ws@8.18.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.18.0
@@ -3107,14 +3320,14 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  partyserver@0.0.65(@cloudflare/workers-types@4.20260507.1):
+  partyserver@0.0.72(@cloudflare/workers-types@4.20260507.1):
     dependencies:
       '@cloudflare/workers-types': 4.20260507.1
       nanoid: 5.1.11
 
-  partysocket@0.0.0-548c226:
+  partysocket@1.1.5:
     dependencies:
-      event-target-shim: 6.0.2
+      event-target-polyfill: 0.0.4
 
   path-key@3.1.1: {}
 
@@ -3215,6 +3428,8 @@ snapshots:
       - supports-color
 
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@7.7.4: {}
 
@@ -3338,7 +3553,14 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  swr@2.4.1:
+    dependencies:
+      dequal: 2.0.3
+      use-sync-external-store: 1.6.0
+
   tagged-tag@1.0.0: {}
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 
@@ -3395,6 +3617,8 @@ snapshots:
   unpipe@1.0.0: {}
 
   until-async@3.0.2: {}
+
+  use-sync-external-store@1.6.0: {}
 
   vary@1.1.2: {}
 
@@ -3533,8 +3757,14 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
Closes #44

> **Update 2026-05-11 (post-merge split)**: Original plan was to publish to npm in FINALIZE
> immediately after this PR merged. After the cf-workers false-PASS discovery, that step has
> been split out:
> - **Test-coverage Epic** #69 runs first (4 sub-issues: #70 SDK, #71 CLI, #72 Docker, #73 examples)
> - **`ai-relay@0.2.0` publish** is tracked in #68 and held until the Epic completes green
>
> If the Epic surfaces SDK source bugs, the published version may end up being `0.2.x` or `0.3.0`
> instead of `0.2.0` — `#68` does not pin a specific version.

First real npm publish *prep* for the `ai-relay` SDK at version 0.2.0. The 0.1.0 tag never
shipped to npm — Phase 3 (#42) closed having shipped publish *infrastructure* only.
Four BREAKING changes accumulated since 0.1.0; this PR bumps to 0.2.0, rewrites the
CHANGELOG to reflect actual current API, and validates all 4 examples.

## Commits

1. `chore(sdk): bump to 0.2.0; rewrite CHANGELOG; clear stale narrative`
2. `chore(examples): align with 0.2.0 SDK API`
3. `chore(repo): gitignore .wrangler/ (cf-workers dev cache)`
4. `chore(sdk): address review iter1 — KO version bump, CHANGELOG zod entry, cf-workers zod note`
5. `chore(examples/cf-workers): fix env name + add real smoke + dev vars` *(post-approval fix)*

## SC verdict (BUILD stage — SC-1..SC-7)

| SC | Criterion | Result |
|---|---|---|
| SC-1 | `package.json` version = `0.2.0` | PASS |
| SC-2 | CHANGELOG `[0.2.0]` entry present | PASS |
| SC-3 | CHANGELOG `[0.1.0]` re-headed | PASS |
| SC-4 | No stale `mcp-ai-relay` bin refs in active docs | PASS |
| SC-5 | `pnpm build` clean | PASS |
| SC-6 | Test suite 166/166 (matches baseline) | PASS |
| SC-7 | All 4 examples smoked | PASS (stdio, multi-upstream, cloudflare-workers, vercel) |

Remaining SC-8..SC-11 (tarball allowlist, npm publish, post-publish smoke, tag) **moved to #68**.

## Notable changes

- `examples/cloudflare-workers/package.json` — bumped `agents` from `^0.0.40` to `>=0.0.50 <0.1.0`. The 0.0.40 release lacks the `./mcp` subpath export needed by `McpAgent`, breaking the example. README version range note updated to match.
- `examples/vercel/README.md` — rebrand `mcp-ai-relay` → `ai-relay` (no functional change).
- `.gitignore` — added `.wrangler/` so cf-workers smoke runs don't dirty `git status`.
- **cf-workers smoke fix (commit 5)**: original BUILD smoke was a false PASS — both no-auth and bearer-auth curls returned 401 because (a) `wrangler.toml` had stale `RELAY_AUTH_TOKEN` comment while `src/index.ts` reads `AI_RELAY_AUTH_TOKEN`, and (b) the smoke never created `.dev.vars`. Fixed: real `pnpm smoke` script asserting both negative (no-auth=401) and positive (bearer=200 + `event: endpoint` SSE frame). This false-PASS forced the Epic #69.

## Follow-ups

- **Test-coverage Epic** #69 — 4 sub-issues addressing the false-PASS class of gap across all surfaces:
  - #70 — SDK: publish contract + runtime matrix + edge case gaps (ships shared `tests/fixtures/mock-openai/`)
  - #71 — CLI: real automated stdio MCP harness via `child_process.spawn`
  - #72 — Docker: committed smoke + image size regression check
  - #73 — Examples: committed `pnpm smoke` for stdio + multi-upstream + vercel
- **#68 — `ai-relay@0.2.0` publish**: held until Epic #69 green
- **#39 — SDK umbrella**: closes via #68

## Refs

- Closes #44
- Follow-up Epic: #69 (sub-issues: #70, #71, #72, #73)
- Held by Epic: #68 (publish)
- Closes via #68: #39 (umbrella)
