### PR TITLE
Add committed smoke checks for examples

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -1,0 +1,44 @@
+name: Examples Smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "packages/ai-relay/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/examples-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "packages/ai-relay/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/examples-smoke.yml"
+
+jobs:
+  examples-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm build:sdk
+
+      - name: Run example smoke checks
+        run: pnpm examples:smoke

--- a/examples/cloudflare-workers/scripts/smoke.sh
+++ b/examples/cloudflare-workers/scripts/smoke.sh
@@ -21,6 +21,14 @@ URL="http://localhost:${PORT}/sse"
 DEV_VARS="${EXAMPLE_DIR}/.dev.vars"
 WRANGLER_LOG="$(mktemp -t cf-smoke-wrangler.XXXXXX)"
 WRANGLER_PID=""
+if command -v pnpm >/dev/null 2>&1; then
+  PNPM=(pnpm)
+elif command -v corepack >/dev/null 2>&1; then
+  PNPM=(corepack pnpm)
+else
+  echo "[smoke] FAIL: pnpm or corepack is required"
+  exit 1
+fi
 
 cleanup() {
   if [ -n "$WRANGLER_PID" ] && kill -0 "$WRANGLER_PID" 2>/dev/null; then
@@ -56,7 +64,7 @@ fi
 
 # 2. Boot wrangler dev in background.
 echo "[smoke] booting wrangler dev on port $PORT (log: $WRANGLER_LOG)"
-pnpm exec wrangler dev --port "$PORT" --ip 127.0.0.1 >"$WRANGLER_LOG" 2>&1 &
+"${PNPM[@]}" exec wrangler dev --port "$PORT" --ip 127.0.0.1 >"$WRANGLER_LOG" 2>&1 &
 WRANGLER_PID=$!
 
 # Poll for readiness up to ~60s.

--- a/examples/multi-upstream/package.json
+++ b/examples/multi-upstream/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "One MCP server registering multiple upstreams (OpenAI + Azure + local LLM) as distinct tools.",
   "scripts": {
+    "smoke": "bash scripts/smoke.sh",
     "start": "tsx server.ts"
   },
   "dependencies": {

--- a/examples/multi-upstream/scripts/smoke.mjs
+++ b/examples/multi-upstream/scripts/smoke.mjs
@@ -1,0 +1,148 @@
+import http from "node:http";
+import { once } from "node:events";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StdioClientTransport,
+  getDefaultEnvironment,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const VALID_INPUT = {
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "route this request" }],
+};
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function withTimeout(promise, label) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(`${label} timed out`)), 10_000);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startMockOpenAI(replyText) {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const body = await readBody(req);
+    requests.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      body: JSON.parse(body),
+    });
+
+    if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unexpected smoke-test route" }));
+      return;
+    }
+
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.write(
+      `data: ${JSON.stringify({ choices: [{ delta: { content: replyText } }] })}\n\n`,
+    );
+    res.write(
+      `data: ${JSON.stringify({
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })}\n\n`,
+    );
+    res.end("data: [DONE]\n\n");
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const { port } = server.address();
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close: () => new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+function getText(result) {
+  return result.content?.find((part) => part.type === "text")?.text;
+}
+
+async function main() {
+  const upstreamA = await startMockOpenAI("from A");
+  const upstreamB = await startMockOpenAI("from B");
+  const transport = new StdioClientTransport({
+    command: "corepack",
+    args: ["pnpm", "exec", "tsx", "server.ts"],
+    cwd: process.cwd(),
+    env: {
+      ...getDefaultEnvironment(),
+      AZURE_OPENAI_KEY: "smoke-azure-key",
+      AZURE_OPENAI_BASE_URL: upstreamA.baseURL,
+      LOCAL_LLM_BASE_URL: upstreamB.baseURL,
+      LOCAL_LLM_KEY: "smoke-local-key",
+    },
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "multi-upstream-smoke", version: "0.0.0" });
+
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  try {
+    await withTimeout(client.connect(transport), "initialize");
+
+    const list = await withTimeout(client.listTools(), "tools/list");
+    const names = list.tools.map((tool) => tool.name).sort();
+    assert(
+      names.includes("azure_chat") && names.includes("local_llm"),
+      `expected azure_chat and local_llm in tools/list, saw ${names.join(", ")}; stderr:\n${stderr}`,
+    );
+
+    const resultA = await withTimeout(
+      client.callTool({ name: "azure_chat", arguments: VALID_INPUT }),
+      "azure_chat call",
+    );
+    const resultB = await withTimeout(
+      client.callTool({ name: "local_llm", arguments: VALID_INPUT }),
+      "local_llm call",
+    );
+
+    assert(resultA.isError !== true, `azure_chat returned an error: ${JSON.stringify(resultA)}`);
+    assert(resultB.isError !== true, `local_llm returned an error: ${JSON.stringify(resultB)}`);
+    assert(getText(resultA) === "from A", `unexpected azure_chat text: ${JSON.stringify(resultA)}`);
+    assert(getText(resultB) === "from B", `unexpected local_llm text: ${JSON.stringify(resultB)}`);
+    assert(upstreamA.requests.length === 1, `expected one A request, saw ${upstreamA.requests.length}`);
+    assert(upstreamB.requests.length === 1, `expected one B request, saw ${upstreamB.requests.length}`);
+    assert(upstreamA.requests[0]?.authorization === "Bearer smoke-azure-key", "A used the wrong key");
+    assert(upstreamB.requests[0]?.authorization === "Bearer smoke-local-key", "B used the wrong key");
+
+    console.log("=== PASS ===");
+  } finally {
+    await client.close();
+    await upstreamA.close();
+    await upstreamB.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/multi-upstream/scripts/smoke.sh
+++ b/examples/multi-upstream/scripts/smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+node scripts/smoke.mjs

--- a/examples/stdio/package.json
+++ b/examples/stdio/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Single-tool stdio MCP server for Claude Desktop direct registration.",
   "scripts": {
+    "smoke": "bash scripts/smoke.sh",
     "start": "tsx server.ts"
   },
   "dependencies": {

--- a/examples/stdio/scripts/smoke.mjs
+++ b/examples/stdio/scripts/smoke.mjs
@@ -1,0 +1,144 @@
+import http from "node:http";
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StdioClientTransport,
+  getDefaultEnvironment,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const VALID_INPUT = {
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "say hello" }],
+};
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function withTimeout(promise, label) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(`${label} timed out`)), 10_000);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function startMockOpenAI(replyText) {
+  const requests = [];
+  const server = http.createServer(async (req, res) => {
+    const body = await readBody(req);
+    requests.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      body: JSON.parse(body),
+    });
+
+    if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unexpected smoke-test route" }));
+      return;
+    }
+
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.write(
+      `data: ${JSON.stringify({ choices: [{ delta: { content: replyText } }] })}\n\n`,
+    );
+    res.write(
+      `data: ${JSON.stringify({
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })}\n\n`,
+    );
+    res.end("data: [DONE]\n\n");
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const { port } = server.address();
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close: () => new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+function getText(result) {
+  return result.content?.find((part) => part.type === "text")?.text;
+}
+
+async function main() {
+  const upstream = await startMockOpenAI("from stdio");
+  const transport = new StdioClientTransport({
+    command: "corepack",
+    args: ["pnpm", "exec", "tsx", "server.ts"],
+    cwd: process.cwd(),
+    env: {
+      ...getDefaultEnvironment(),
+      AI_RELAY_API_KEY: "smoke-openai-key",
+      AI_RELAY_BASE_URL: upstream.baseURL,
+    },
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "stdio-smoke", version: "0.0.0" });
+
+  let stderr = "";
+  transport.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  try {
+    await withTimeout(client.connect(transport), "initialize");
+
+    const list = await withTimeout(client.listTools(), "tools/list");
+    assert(
+      list.tools.some((tool) => tool.name === "openai_chat"),
+      `expected openai_chat in tools/list; stderr:\n${stderr}`,
+    );
+
+    const result = await withTimeout(
+      client.callTool({ name: "openai_chat", arguments: VALID_INPUT }),
+      "tools/call",
+    );
+    assert(result.isError !== true, `openai_chat returned an error: ${JSON.stringify(result)}`);
+    assert(getText(result) === "from stdio", `unexpected tool text: ${JSON.stringify(result)}`);
+    assert(upstream.requests.length === 1, `expected one upstream request, saw ${upstream.requests.length}`);
+    assert(
+      upstream.requests[0]?.authorization === "Bearer smoke-openai-key",
+      "upstream request did not include the configured API key",
+    );
+    assert(upstream.requests[0]?.body?.model === VALID_INPUT.model, "upstream request used the wrong model");
+
+    transport._process?.stdin?.write("{not valid json}\n");
+    await delay(100);
+    assert(transport._process?.exitCode === null, "server exited after malformed JSON");
+    await withTimeout(client.listTools(), "tools/list after malformed JSON");
+
+    console.log("=== PASS ===");
+  } finally {
+    await client.close();
+    await upstream.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/stdio/scripts/smoke.sh
+++ b/examples/stdio/scripts/smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+node scripts/smoke.mjs

--- a/examples/vercel/package.json
+++ b/examples/vercel/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@example/vercel",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Metadata smoke checks for the community-supported Vercel deployment recipe.",
+  "scripts": {
+    "smoke": "bash scripts/smoke.sh"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/examples/vercel/scripts/smoke.mjs
+++ b/examples/vercel/scripts/smoke.mjs
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function main() {
+  const config = JSON.parse(await readFile("vercel.json", "utf8"));
+  assert(config.$schema === "https://openapi.vercel.sh/vercel.json", "vercel.json schema changed");
+  assert(Array.isArray(config.regions), "vercel.json regions must be an array");
+  assert(config.regions.includes("iad1"), "vercel.json must keep the iad1 region");
+  assert(
+    config.functions?.["app/api/**/route.ts"]?.maxDuration === 300,
+    "vercel.json must keep the app/api route maxDuration at 300",
+  );
+
+  const readme = await readFile("README.md", "utf8");
+  for (const snippet of [
+    "community-supported",
+    "no longer a Next.js project",
+    "pnpm add next react react-dom ai-relay",
+    "createMcpHandler",
+    "vercel deploy --prod",
+    "AI_RELAY_API_KEY",
+    "AI_RELAY_AUTH_TOKEN",
+    "maxDuration: 300",
+  ]) {
+    assert(readme.includes(snippet), `README.md is missing: ${snippet}`);
+  }
+
+  console.log("=== PASS ===");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/vercel/scripts/smoke.sh
+++ b/examples/vercel/scripts/smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+node scripts/smoke.mjs

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "pnpm --filter ai-relay build && vitest run --passWithNoTests",
     "test:unit": "pnpm --filter ai-relay test",
     "test:integration": "pnpm --filter ai-relay build && vitest run --project integration --passWithNoTests",
+    "examples:smoke": "pnpm --filter @example/stdio smoke && pnpm --filter @example/multi-upstream smoke && pnpm --filter @example/vercel smoke && pnpm --filter @example/cloudflare-workers smoke",
     "verify": "node --env-file-if-exists=.env.local scripts/verify.mjs",
     "inspect": "node --env-file-if-exists=.env.local scripts/mcp-inspect.mjs",
     "check-env": "node --env-file-if-exists=.env.local scripts/check-dev-env.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,8 @@ importers:
         specifier: ^4.19.0
         version: 4.21.0
 
+  examples/vercel: {}
+
   packages/ai-relay:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
Fixes #73.

This adds committed smoke checks for the stdio, multi-upstream, and Vercel examples, plus a root `examples:smoke` script and a dedicated workflow.

The stdio check starts the example MCP server over stdio against a local chat-completion mock, exercises `tools/list`, `tools/call`, and confirms the server stays up after malformed JSON. The multi-upstream check uses two local mock upstreams for `azure_chat` and `local_llm` and verifies each route returns the expected text. The Vercel check stays metadata-only by validating `vercel.json` and the deployment snippets in the README.

I also made the existing Cloudflare smoke script tolerate environments where pnpm is available through Corepack.

Verified with:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter ai-relay build`
- `corepack pnpm --filter @example/stdio smoke`
- `corepack pnpm --filter @example/multi-upstream smoke`
- `corepack pnpm --filter @example/vercel smoke`
- `git diff --check`

Local note: `corepack pnpm --filter @example/cloudflare-workers smoke` gets past pnpm discovery with this patch, but this Windows/Node 24 checkout is missing the `workerd.exe` binary from the existing Wrangler dependency install. The new workflow runs the combined smoke command on Ubuntu Node 20.