### PR TITLE
test(app): committed docker smoke + image-size regression guard

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,45 @@
+name: docker-smoke
+
+on:
+  pull_request:
+    branches: [main, 'epic/**']
+    paths:
+      - 'app/**'
+      - 'examples/docker/**'
+      - 'pnpm-lock.yaml'
+      - 'tests/fixtures/mock-openai/**'
+      - 'app/scripts/docker-smoke.sh'
+      - '.github/workflows/docker-smoke.yml'
+  push:
+    branches: [main, 'epic/**']
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Docker smoke
+        run: pnpm docker:smoke
+
+  smoke-multiarch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'docker-multiarch')
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Multi-arch build (B-3)
+        env:
+          DOCKER_SMOKE_MULTIARCH: '1'
+        run: bash app/scripts/docker-smoke.sh

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ image). For local-build development, use `compose.dev.yml`:
 docker compose -f compose.dev.yml up --build
 ```
 
+### Verification
+
+Before publishing or trusting a local build, run the committed smoke
+harness against the distroless runner image:
+
+```bash
+pnpm docker:smoke
+```
+
+`pnpm docker:smoke` invokes [`app/scripts/docker-smoke.sh`](./app/scripts/docker-smoke.sh),
+which builds the image and runs build-correctness + runtime assertions
+(image-size budget, distroless invariants, bearer auth, MCP `initialize`
++ `tools/call` round-trip). See [`app/scripts/README.md`](./app/scripts/README.md)
+for the assertion catalog and tunable env vars.
+
 ---
 
 ## Quick start — embed the SDK

--- a/app/scripts/README.md
+++ b/app/scripts/README.md
@@ -1,0 +1,82 @@
+# app/scripts
+
+Operational tooling that exercises the published shape of the `app/`
+Hono runner image (`ghcr.io/ragingwind/ai-relay`).
+
+---
+
+## `docker-smoke.sh`
+
+Self-contained shell smoke test for the distroless runtime image. Verifies
+build correctness, runtime invariants, and an image-size budget — meant to
+catch regressions before tagging a release. Run it locally before opening
+a PR that touches `app/**`, `Dockerfile`, or the deploy bundle layout.
+
+### Local invocation
+
+```bash
+pnpm docker:smoke
+```
+
+Or directly:
+
+```bash
+bash app/scripts/docker-smoke.sh
+```
+
+The script auto-skips with `[SKIP] docker not available` when Docker is
+absent (no failure exit code), so it is safe to wire into `pnpm test`-style
+flows on dev machines without Docker.
+
+### Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `IMAGE_TAG` | `ai-relay:smoke` | Tag used for `docker build` + `docker run`. |
+| `DOCKER_SIZE_BUDGET_BYTES` | `157286400` | B-2 budget (default 150 MB). Compared against `docker image inspect Size` (NOT `docker images SIZE`). |
+| `DOCKER_SMOKE_MULTIARCH` | unset | Set `=1` to enable B-3 multi-arch buildx. Slow; off by default. |
+| `MOCK_PORT` | dynamic | Mock OpenAI fixture port. Auto-picked when unset (the mock prints `LISTENING port=N`). |
+| `SMOKE_HOST_PORT` | `18787` | Published host port for the container under test. |
+
+### Assertions
+
+Each assertion logs `[PASS] <id> ...` or `[FAIL] <id> ...` and contributes
+to a final `summary: passed=N failed=M` line. Any `[FAIL]` produces a
+non-zero exit code.
+
+| ID | What | Notes |
+|---|---|---|
+| B-1 | `docker build -f app/Dockerfile -t $IMAGE_TAG .` succeeds (single arch). | First failure short-circuits the rest. |
+| B-2 | Image content size < `DOCKER_SIZE_BUDGET_BYTES`. | Uses `docker image inspect --format '{{.Size}}'`, NOT the rounded `docker images` SIZE column. |
+| B-3 | Multi-arch buildx (linux/amd64 + linux/arm64) succeeds. | Opt-in via `DOCKER_SMOKE_MULTIARCH=1`. Fails loud if buildx is missing while opted in. |
+| B-4 | No `.node` native bindings under `/app/node_modules`. | Distroless has no shell — invoked via `node -e`. |
+| R-1 | HEALTHCHECK reports `healthy` within 60 s. | Dockerfile sets `--interval=30s --start-period=10s --retries=3`. On timeout, prints last 30 lines of `docker logs`. |
+| R-2 | Container `Config.User` is `nonroot` or `65532`. | Distroless symbolizes uid 65532 as `nonroot`. |
+| R-3 | `docker exec ... sh -c true` exits non-zero. | Distroless invariant: no shell present. |
+| R-4 | `GET /healthz` returns body containing `ok`. | |
+| R-5 | `POST /api/mcp` (no bearer) returns 401. | Sends MCP `initialize` JSON-RPC. |
+| R-6 | `POST /api/mcp` (with bearer) returns body containing `"protocolVersion"`. | Same `initialize` request. |
+| R-7 | `tools/call` for `openai_chat` returns the mock canned reply (`smoke-canned-reply`). | |
+| R-8 | `docker stop --time=10` returns within 7 s and exit code is 0 or 143. | 143 = 128 + SIGTERM(15). |
+| R-9 | `docker run --rm <image>` with no env vars exits non-zero AND mentions `AI_RELAY_API_KEY` or `AI_RELAY_AUTH_TOKEN`. | Validates the env-validation error path. |
+
+### Adding a new assertion
+
+The script tracks failures with two counters (`PASS_COUNT`, `FAIL_COUNT`)
+and helpers `pass "<id> <description>"` / `fail "<id> <description>"`. To
+add a new assertion:
+
+1. Pick the next free id (`B-5`, `R-10`, …).
+2. Add an `--- <id>: <name> ---` echo banner.
+3. Run the check; call `pass` or `fail` based on the outcome.
+4. Document the new id in the table above.
+
+The script intentionally runs every assertion (no `set -e`) so the summary
+reflects the full picture even when an early assertion fails.
+
+### Cross-platform notes
+
+- `host.docker.internal:host-gateway` works on Linux Docker 20.10+ and
+  macOS Docker Desktop. CI uses `ubuntu-latest`, dev typically uses macOS.
+- The script avoids GNU-only flags so it runs on both BSD and GNU
+  userlands.

--- a/app/scripts/README.md
+++ b/app/scripts/README.md
@@ -37,6 +37,7 @@ flows on dev machines without Docker.
 | `DOCKER_SMOKE_MULTIARCH` | unset | Set `=1` to enable B-3 multi-arch buildx. Slow; off by default. |
 | `MOCK_PORT` | dynamic | Mock OpenAI fixture port. Auto-picked when unset (the mock prints `LISTENING port=N`). |
 | `SMOKE_HOST_PORT` | `18787` | Published host port for the container under test. |
+| `RUN_DOCKER_SMOKE` | unset | Set to any non-empty value to enable the `tests/integration/docker.test.ts` vitest wrapper inside `pnpm test`. The dedicated `pnpm docker:smoke` always runs the script regardless of this flag. |
 
 ### Assertions
 

--- a/app/scripts/docker-smoke.sh
+++ b/app/scripts/docker-smoke.sh
@@ -251,13 +251,19 @@ fi
 # R-6: POST /api/mcp with bearer -> 200 + protocolVersion
 # ===========================================================================
 echo "--- R-6: POST /api/mcp initialize with bearer -> 200 + protocolVersion ---"
-init_resp=$(curl -s \
+# mcp-handler v1.1+ uses Streamable HTTP — the response sets a
+# Mcp-Session-Id header that subsequent requests (R-7) MUST echo back.
+# We capture the headers via `-D` so the session id propagates to R-7.
+init_headers=$(mktemp)
+init_resp=$(curl -s -D "$init_headers" \
   "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
   -X POST \
   -H 'content-type: application/json' \
   -H 'accept: application/json, text/event-stream' \
   -H "authorization: Bearer ${SMOKE_BEARER}" \
   -d "$init_body")
+SESSION_ID=$(grep -i '^Mcp-Session-Id:' "$init_headers" | awk '{print $2}' | tr -d '\r\n')
+rm -f "$init_headers"
 if echo "$init_resp" | grep -q '"protocolVersion"'; then
   pass "R-6 authenticated initialize returned protocolVersion"
 else
@@ -269,12 +275,15 @@ fi
 # ===========================================================================
 echo "--- R-7: tools/call openai_chat -> canned reply ---"
 call_body='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"openai_chat","arguments":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}}}'
+# Mcp-Session-Id is required for stateful MCP transport — without it the
+# server treats this as an out-of-session request and returns no result.
 call_resp=$(curl -s \
   "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
   -X POST \
   -H 'content-type: application/json' \
   -H 'accept: application/json, text/event-stream' \
   -H "authorization: Bearer ${SMOKE_BEARER}" \
+  -H "Mcp-Session-Id: ${SESSION_ID}" \
   -d "$call_body")
 if echo "$call_resp" | grep -q "smoke-canned-reply"; then
   pass "R-7 tools/call returned mock canned reply"

--- a/app/scripts/docker-smoke.sh
+++ b/app/scripts/docker-smoke.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# docker-smoke.sh — committed publish-shape smoke for the app/ Hono runner image.
+#
+# Verifies build correctness (B-1..B-4) and runtime behavior (R-1..R-9)
+# of the distroless image produced by app/Dockerfile. Every assertion is
+# reported as `[PASS]` or `[FAIL]` and a non-zero exit code is returned
+# when any assertion fails. Multi-arch (B-3) is gated behind
+# DOCKER_SMOKE_MULTIARCH=1 because it is slow.
+#
+# Env vars (defaults shown):
+#   IMAGE_TAG=ai-relay:smoke              build/run tag
+#   DOCKER_SIZE_BUDGET_BYTES=157286400    image-size guard (150 MB)
+#   DOCKER_SMOKE_MULTIARCH=                set =1 to enable B-3
+#   MOCK_PORT=                             mock OpenAI port (auto when unset)
+#   SMOKE_HOST_PORT=18787                 published host port for the container
+#
+# host.docker.internal:host-gateway is supported on Linux Docker 20.10+ and
+# macOS Docker Desktop — the CI runner (ubuntu-latest) and dev machines both
+# satisfy this.
+#
+# Shell mode: `set -u` only — we deliberately do NOT `set -e` so every
+# assertion runs and contributes to the pass/fail summary.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Resolve REPO_ROOT regardless of cwd. The script lives at
+# <repo>/app/scripts/docker-smoke.sh.
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO_ROOT"
+
+IMAGE_TAG=${IMAGE_TAG:-ai-relay:smoke}
+DOCKER_SIZE_BUDGET_BYTES=${DOCKER_SIZE_BUDGET_BYTES:-$((150 * 1024 * 1024))}
+SMOKE_HOST_PORT=${SMOKE_HOST_PORT:-18787}
+CONTAINER_NAME=ai-relay-smoke
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "[PASS] $*"
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  echo "[FAIL] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Skip path: docker absent → exit 0 with [SKIP] (local-dev fallback).
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[SKIP] docker not available — install Docker to run this smoke"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup trap: stop+remove container, kill mock pid.
+MOCK_PID=""
+cleanup() {
+  local exit_code=$?
+  if [ -n "${MOCK_PID:-}" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ===========================================================================
+# B-1: docker build single-arch
+# ===========================================================================
+echo "--- B-1: docker build (single arch) ---"
+if docker build -f app/Dockerfile -t "$IMAGE_TAG" . ; then
+  pass "B-1 docker build single-arch (tag=$IMAGE_TAG)"
+else
+  fail "B-1 docker build single-arch (tag=$IMAGE_TAG)"
+  echo "B-1 failed; remaining assertions will be skipped"
+  echo ""
+  echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+  exit 1
+fi
+
+# ===========================================================================
+# B-2: image content size guard
+#   docker image inspect Size = uncompressed on-disk content size in bytes.
+#   This is NOT the `docker images` SIZE column rounded to MB.
+# ===========================================================================
+echo "--- B-2: image-size budget ---"
+size_bytes=$(docker image inspect --format '{{.Size}}' "$IMAGE_TAG" 2>/dev/null || echo "0")
+size_mb=$(( size_bytes / 1024 / 1024 ))
+budget_mb=$(( DOCKER_SIZE_BUDGET_BYTES / 1024 / 1024 ))
+if [ "$size_bytes" -gt 0 ] && [ "$size_bytes" -lt "$DOCKER_SIZE_BUDGET_BYTES" ]; then
+  pass "B-2 image size ${size_mb} MB < ${budget_mb} MB budget (measured via 'docker image inspect Size', NOT 'docker images SIZE')"
+else
+  fail "B-2 image size ${size_mb} MB exceeds ${budget_mb} MB budget (measured via 'docker image inspect Size' = ${size_bytes} bytes; compare against DOCKER_SIZE_BUDGET_BYTES=${DOCKER_SIZE_BUDGET_BYTES})"
+fi
+
+# ===========================================================================
+# B-3: multi-arch buildx (linux/amd64 + linux/arm64) — opt-in
+# ===========================================================================
+if [ "${DOCKER_SMOKE_MULTIARCH:-}" = "1" ]; then
+  echo "--- B-3: multi-arch buildx (DOCKER_SMOKE_MULTIARCH=1) ---"
+  if ! docker buildx version >/dev/null 2>&1; then
+    fail "B-3 multi-arch build — docker buildx is unavailable"
+  elif docker buildx build --platform linux/amd64,linux/arm64 -f app/Dockerfile . ; then
+    pass "B-3 multi-arch build (linux/amd64,linux/arm64)"
+  else
+    fail "B-3 multi-arch build (linux/amd64,linux/arm64)"
+  fi
+else
+  echo "--- B-3: multi-arch buildx — skipped (set DOCKER_SMOKE_MULTIARCH=1 to enable) ---"
+fi
+
+# ===========================================================================
+# B-4: no native bindings (.node) in the deploy bundle
+#   Distroless has no shell — invoke node directly.
+# ===========================================================================
+echo "--- B-4: no native .node bindings in /app/node_modules ---"
+native_out=$(docker run --rm --entrypoint=/nodejs/bin/node "$IMAGE_TAG" -e "import('node:fs').then(fs=>{const out=fs.readdirSync('/app/node_modules',{recursive:true,withFileTypes:true}).filter(d=>d.isFile()&&d.name.endsWith('.node')).map(d=>d.parentPath+'/'+d.name);process.stdout.write(out.join('\\n'));process.exit(out.length?1:0);})" 2>&1)
+native_rc=$?
+if [ "$native_rc" -eq 0 ]; then
+  pass "B-4 no .node native bindings under /app/node_modules"
+else
+  fail "B-4 found .node native bindings under /app/node_modules:"
+  echo "$native_out" | sed 's/^/        /'
+fi
+
+# ===========================================================================
+# Mock OpenAI fixture launch
+# ===========================================================================
+echo "--- launching mock OpenAI fixture ---"
+mock_log=$(mktemp -t ai-relay-mock.XXXXXX)
+node tests/fixtures/mock-openai/server.mjs --port="${MOCK_PORT:-0}" >"$mock_log" 2>&1 &
+MOCK_PID=$!
+# Wait up to 5s for the LISTENING line.
+mock_port=""
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if grep -q '^LISTENING port=' "$mock_log" 2>/dev/null; then
+    mock_port=$(sed -n 's/^LISTENING port=\([0-9]*\).*/\1/p' "$mock_log" | head -n1)
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "$mock_port" ]; then
+  fail "mock OpenAI fixture failed to start within 5s; mock log:"
+  sed 's/^/        /' "$mock_log"
+  echo ""
+  echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+  exit 1
+fi
+echo "mock OpenAI listening on 127.0.0.1:${mock_port} (pid=${MOCK_PID})"
+
+# ===========================================================================
+# Container launch
+# ===========================================================================
+echo "--- launching container ---"
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+SMOKE_BEARER=$(printf 'x%.0s' $(seq 1 32))
+if ! docker run -d \
+  --name="$CONTAINER_NAME" \
+  -e AI_RELAY_API_KEY=smoke-key \
+  -e AI_RELAY_AUTH_TOKEN="$SMOKE_BEARER" \
+  -e AI_RELAY_BASE_URL="http://host.docker.internal:${mock_port}/v1" \
+  --add-host=host.docker.internal:host-gateway \
+  -p "${SMOKE_HOST_PORT}:8787" \
+  "$IMAGE_TAG" >/dev/null ; then
+  fail "container failed to launch"
+  echo ""
+  echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+  exit 1
+fi
+
+# ===========================================================================
+# R-1: HEALTHCHECK reaches healthy within 60s
+#   Dockerfile config: --interval=30s --start-period=10s --retries=3
+# ===========================================================================
+echo "--- R-1: HEALTHCHECK -> healthy within 60s ---"
+healthy=0
+for _ in $(seq 1 60); do
+  status=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+  if [ "$status" = "healthy" ]; then
+    healthy=1
+    break
+  fi
+  sleep 1
+done
+if [ "$healthy" -eq 1 ]; then
+  pass "R-1 container reported healthy"
+else
+  fail "R-1 container did not reach healthy within 60s (last status=$status)"
+  echo "        last 30 lines of docker logs:"
+  docker logs --tail 30 "$CONTAINER_NAME" 2>&1 | sed 's/^/        /'
+fi
+
+# ===========================================================================
+# R-2: container runs as nonroot (uid 65532)
+# ===========================================================================
+echo "--- R-2: container User = nonroot / 65532 ---"
+user=$(docker inspect --format '{{.Config.User}}' "$CONTAINER_NAME" 2>/dev/null || echo "")
+case "$user" in
+  nonroot|65532)
+    pass "R-2 container User=$user"
+    ;;
+  *)
+    fail "R-2 expected nonroot or 65532, got '$user'"
+    ;;
+esac
+
+# ===========================================================================
+# R-3: distroless invariant — no shell present
+# ===========================================================================
+echo "--- R-3: no shell in container (distroless invariant) ---"
+if docker exec "$CONTAINER_NAME" sh -c true >/dev/null 2>&1; then
+  fail "R-3 container has a shell (sh -c true succeeded) — image is not distroless"
+else
+  pass "R-3 no shell available in container"
+fi
+
+# ===========================================================================
+# R-4: GET /healthz -> 200 ok
+# ===========================================================================
+echo "--- R-4: GET /healthz -> 200 ok ---"
+healthz_body=$(curl -fsS "http://localhost:${SMOKE_HOST_PORT}/healthz" 2>&1 || true)
+if echo "$healthz_body" | grep -q "ok"; then
+  pass "R-4 /healthz returned body containing 'ok'"
+else
+  fail "R-4 /healthz response did not contain 'ok' (got: $healthz_body)"
+fi
+
+# ===========================================================================
+# R-5: POST /api/mcp without bearer -> 401
+# ===========================================================================
+echo "--- R-5: POST /api/mcp without bearer -> 401 ---"
+init_body='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+unauth_code=$(curl -s -o /dev/null -w '%{http_code}' \
+  "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+  -X POST \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d "$init_body")
+if [ "$unauth_code" = "401" ]; then
+  pass "R-5 unauthenticated initialize -> 401"
+else
+  fail "R-5 expected 401 without bearer, got $unauth_code"
+fi
+
+# ===========================================================================
+# R-6: POST /api/mcp with bearer -> 200 + protocolVersion
+# ===========================================================================
+echo "--- R-6: POST /api/mcp initialize with bearer -> 200 + protocolVersion ---"
+init_resp=$(curl -s \
+  "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+  -X POST \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "authorization: Bearer ${SMOKE_BEARER}" \
+  -d "$init_body")
+if echo "$init_resp" | grep -q '"protocolVersion"'; then
+  pass "R-6 authenticated initialize returned protocolVersion"
+else
+  fail "R-6 authenticated initialize did not return protocolVersion"
+fi
+
+# ===========================================================================
+# R-7: tools/call openai_chat -> mock canned reply present
+# ===========================================================================
+echo "--- R-7: tools/call openai_chat -> canned reply ---"
+call_body='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"openai_chat","arguments":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}}}'
+call_resp=$(curl -s \
+  "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+  -X POST \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "authorization: Bearer ${SMOKE_BEARER}" \
+  -d "$call_body")
+if echo "$call_resp" | grep -q "smoke-canned-reply"; then
+  pass "R-7 tools/call returned mock canned reply"
+else
+  fail "R-7 tools/call did not return canned reply"
+fi
+
+# ===========================================================================
+# R-8: graceful shutdown — docker stop returns within 7s with exit 0 or 143
+# ===========================================================================
+echo "--- R-8: docker stop -> graceful exit within 7s ---"
+stop_start=$(date +%s)
+docker stop --time=10 "$CONTAINER_NAME" >/dev/null 2>&1 || true
+stop_end=$(date +%s)
+stop_elapsed=$(( stop_end - stop_start ))
+exit_code=$(docker inspect --format '{{.State.ExitCode}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+if [ "$stop_elapsed" -lt 7 ] && { [ "$exit_code" = "0" ] || [ "$exit_code" = "143" ]; }; then
+  pass "R-8 graceful stop in ${stop_elapsed}s (exit=${exit_code})"
+else
+  fail "R-8 stop took ${stop_elapsed}s, exit=${exit_code} (expected <7s and exit 0 or 143)"
+fi
+
+# ===========================================================================
+# R-9: missing required env vars -> non-zero exit + actionable error
+# ===========================================================================
+echo "--- R-9: missing env -> non-zero exit + mentions AI_RELAY_API_KEY/AI_RELAY_AUTH_TOKEN ---"
+# Capture both stdout+stderr AND the docker run exit code without piping to
+# `head` — a pipeline's $? is the rightmost command's exit, which would
+# always be 0 from `head`. Truncate after the fact with parameter expansion.
+env_out=$(docker run --rm "$IMAGE_TAG" 2>&1)
+env_rc=$?
+env_out_head=$(printf '%s\n' "$env_out" | head -20)
+if [ "$env_rc" -ne 0 ] && printf '%s' "$env_out" | grep -qE "AI_RELAY_API_KEY|AI_RELAY_AUTH_TOKEN"; then
+  pass "R-9 missing env -> exit $env_rc and error mentions required key(s)"
+else
+  fail "R-9 missing env: exit=$env_rc, output:"
+  printf '%s\n' "$env_out_head" | sed 's/^/        /'
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/app/scripts/docker-smoke.sh
+++ b/app/scripts/docker-smoke.sh
@@ -151,7 +151,7 @@ if [ -z "$mock_port" ]; then
   echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
   exit 1
 fi
-echo "mock OpenAI listening on 127.0.0.1:${mock_port} (pid=${MOCK_PID})"
+echo "mock OpenAI listening on 0.0.0.0:${mock_port} (pid=${MOCK_PID})"
 
 # ===========================================================================
 # Container launch
@@ -263,10 +263,6 @@ init_resp=$(curl -s -D "$init_headers" \
   -H "authorization: Bearer ${SMOKE_BEARER}" \
   -d "$init_body")
 SESSION_ID=$(grep -i '^Mcp-Session-Id:' "$init_headers" | awk '{print $2}' | tr -d '\r\n')
-echo "        DEBUG: init response headers ↓"
-sed 's/^/          /' "$init_headers"
-echo "        DEBUG: init body (first 400 chars): ${init_resp:0:400}"
-echo "        DEBUG: SESSION_ID='${SESSION_ID}' (empty = stateless mcp-handler, fallback below)"
 rm -f "$init_headers"
 if echo "$init_resp" | grep -q '"protocolVersion"'; then
   pass "R-6 authenticated initialize returned protocolVersion"
@@ -279,24 +275,30 @@ fi
 # ===========================================================================
 echo "--- R-7: tools/call openai_chat -> canned reply ---"
 call_body='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"openai_chat","arguments":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}}}'
-# Mcp-Session-Id is required for stateful MCP transport — without it the
-# server treats this as an out-of-session request and returns no result.
-call_resp=$(curl -s \
-  "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
-  -X POST \
-  -H 'content-type: application/json' \
-  -H 'accept: application/json, text/event-stream' \
-  -H "authorization: Bearer ${SMOKE_BEARER}" \
-  -H "Mcp-Session-Id: ${SESSION_ID}" \
-  -d "$call_body")
-echo "        DEBUG: tools/call body (first 800 chars): ${call_resp:0:800}"
-echo "        DEBUG: container logs tail (last 30 lines):"
-docker logs --tail 30 "$CONTAINER_NAME" 2>&1 | sed 's/^/          /'
-echo "        DEBUG: mock fixture pid=$mock_pid alive? $(kill -0 "$mock_pid" 2>/dev/null && echo yes || echo no)"
+# Pass Mcp-Session-Id only when the server returned one (stateful mode).
+# mcp-handler runs stateless by default — no header to forward.
+if [ -n "$SESSION_ID" ]; then
+  call_resp=$(curl -s \
+    "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+    -X POST \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "authorization: Bearer ${SMOKE_BEARER}" \
+    -H "Mcp-Session-Id: ${SESSION_ID}" \
+    -d "$call_body")
+else
+  call_resp=$(curl -s \
+    "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+    -X POST \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "authorization: Bearer ${SMOKE_BEARER}" \
+    -d "$call_body")
+fi
 if echo "$call_resp" | grep -q "smoke-canned-reply"; then
   pass "R-7 tools/call returned mock canned reply"
 else
-  fail "R-7 tools/call did not return canned reply"
+  fail "R-7 tools/call did not return canned reply (response: ${call_resp:0:300})"
 fi
 
 # ===========================================================================

--- a/app/scripts/docker-smoke.sh
+++ b/app/scripts/docker-smoke.sh
@@ -263,6 +263,10 @@ init_resp=$(curl -s -D "$init_headers" \
   -H "authorization: Bearer ${SMOKE_BEARER}" \
   -d "$init_body")
 SESSION_ID=$(grep -i '^Mcp-Session-Id:' "$init_headers" | awk '{print $2}' | tr -d '\r\n')
+echo "        DEBUG: init response headers ↓"
+sed 's/^/          /' "$init_headers"
+echo "        DEBUG: init body (first 400 chars): ${init_resp:0:400}"
+echo "        DEBUG: SESSION_ID='${SESSION_ID}' (empty = stateless mcp-handler, fallback below)"
 rm -f "$init_headers"
 if echo "$init_resp" | grep -q '"protocolVersion"'; then
   pass "R-6 authenticated initialize returned protocolVersion"
@@ -285,6 +289,10 @@ call_resp=$(curl -s \
   -H "authorization: Bearer ${SMOKE_BEARER}" \
   -H "Mcp-Session-Id: ${SESSION_ID}" \
   -d "$call_body")
+echo "        DEBUG: tools/call body (first 800 chars): ${call_resp:0:800}"
+echo "        DEBUG: container logs tail (last 30 lines):"
+docker logs --tail 30 "$CONTAINER_NAME" 2>&1 | sed 's/^/          /'
+echo "        DEBUG: mock fixture pid=$mock_pid alive? $(kill -0 "$mock_pid" 2>/dev/null && echo yes || echo no)"
 if echo "$call_resp" | grep -q "smoke-canned-reply"; then
   pass "R-7 tools/call returned mock canned reply"
 else

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -79,8 +79,19 @@ const isDirectRun =
   typeof process.argv[1] === "string" && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isDirectRun) {
-  serve({ fetch: app.fetch, port: env.AI_RELAY_PORT }, (info) => {
+  const server = serve({ fetch: app.fetch, port: env.AI_RELAY_PORT }, (info) => {
     // Single-line startup log — no secrets, only port + endpoint.
     console.log(`mcp-ai-relay listening on http://localhost:${info.port}/api/mcp`);
   });
+
+  // Container orchestrators (Docker, Kubernetes) send SIGTERM before SIGKILL.
+  // Without an explicit handler the process is killed at the grace-period
+  // boundary (Docker default 10 s) and exits 137. Closing the listener stops
+  // accepting new connections and lets in-flight requests finish.
+  const shutdown = () => {
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 5000).unref();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
 }

--- a/doc/DEPLOY.ko.md
+++ b/doc/DEPLOY.ko.md
@@ -242,6 +242,12 @@ docker run --rm -p 8787:3000 --env-file .env.production mcp-ai-relay
 
 ### 4.3 검증 체크리스트
 
+**배포 전에 `pnpm docker:smoke`를 실행해** 빌드 정합성, 런타임 헬스, distroless 불변
+조건(셸 없음, non-root uid 65532), 이미지 크기 예산을 확인합니다. 회귀가
+발생하면 하네스가 non-zero 종료 — 어설션 카탈로그와 환경변수
+(이미지 태그, 크기 예산, 멀티아치 opt-in)는
+[`app/scripts/README.md`](../app/scripts/README.md) 참고.
+
 HEALTHCHECK:
 
 ```bash

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -162,6 +162,12 @@ defaults.
 
 ### 3.4 Verification checklist
 
+**Before deploying, run `pnpm docker:smoke`** to verify build correctness,
+runtime health, distroless invariants (no shell, non-root uid 65532), and
+the image-size budget. The harness exits non-zero on any regression — see
+[`app/scripts/README.md`](../app/scripts/README.md) for the assertion
+catalog and tunable env vars (image tag, size budget, multi-arch opt-in).
+
 - [ ] `docker compose up -d` (or `docker run`) starts without error.
 - [ ] HEALTHCHECK reports healthy within ~30 s of start:
       ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "dev": "node scripts/check-dev-env.mjs && pnpm -r --filter ai-relay build && pnpm -F app dev",
+    "docker:smoke": "bash app/scripts/docker-smoke.sh",
     "build": "pnpm -r build",
     "build:sdk": "pnpm --filter ai-relay build",
     "start": "pnpm -F app start",

--- a/tests/fixtures/mock-openai/server.mjs
+++ b/tests/fixtures/mock-openai/server.mjs
@@ -111,7 +111,10 @@ const server = createServer((req, res) => {
   res.end(JSON.stringify({ error: { message: "not found" } }));
 });
 
-server.listen(port, "127.0.0.1", () => {
+// Bind 0.0.0.0 so the docker-smoke harness can reach this fixture from
+// inside the container via host.docker.internal. 127.0.0.1 would only
+// be reachable from the host's loopback interface.
+server.listen(port, "0.0.0.0", () => {
   const addr = server.address();
   const boundPort = typeof addr === "object" && addr ? addr.port : port;
   process.stdout.write(`LISTENING port=${boundPort}\n`);

--- a/tests/fixtures/mock-openai/server.mjs
+++ b/tests/fixtures/mock-openai/server.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Minimal OpenAI Chat Completions mock for the docker smoke harness.
+//
+// Usage:
+//   node tests/fixtures/mock-openai/server.mjs --port=0
+//   node tests/fixtures/mock-openai/server.mjs --port=18080
+//
+// Contract for the docker-smoke harness:
+//   - Exits 0 on SIGTERM/SIGINT.
+//   - Prints exactly one line `LISTENING port=<N>` to stdout once the
+//     listener is bound. The harness greps stdout for this token to
+//     discover the port (`--port=0` lets the OS pick a free port).
+//   - Returns the OpenAI v1 chat-completion JSON shape; the assistant
+//     content is the literal token `smoke-canned-reply` so callers can
+//     assert on it.
+//
+// Per project CLAUDE.md §4: never log request/response bodies.
+
+import { createServer } from "node:http";
+
+const portArg = process.argv.find((a) => a.startsWith("--port="));
+const port = Number(portArg ? portArg.slice("--port=".length) : 0);
+
+const CANNED_REPLY = "smoke-canned-reply";
+
+function chatCompletionResponse(model) {
+  return {
+    id: "chatcmpl-smoke-0001",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: typeof model === "string" && model.length > 0 ? model : "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: CANNED_REPLY },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+  };
+}
+
+function streamChunk(model, delta, finishReason, usage) {
+  const obj = {
+    id: "chatcmpl-smoke-0001",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: typeof model === "string" && model.length > 0 ? model : "gpt-4o-mini",
+    choices:
+      delta !== null
+        ? [
+            {
+              index: 0,
+              delta: delta,
+              finish_reason: finishReason,
+            },
+          ]
+        : [],
+    ...(usage ? { usage } : {}),
+  };
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+const server = createServer((req, res) => {
+  if (req.method === "POST" && req.url === "/v1/chat/completions") {
+    let body = "";
+    let bodyLen = 0;
+    req.on("data", (chunk) => {
+      bodyLen += chunk.length;
+      if (bodyLen < 16384) body += chunk.toString("utf8");
+    });
+    req.on("end", () => {
+      // Match `"model":"..."` and `"stream":true` without parsing the body.
+      const modelMatch = body.match(/"model"\s*:\s*"([^"]+)"/);
+      const model = modelMatch ? modelMatch[1] : "";
+      const wantsStream = /"stream"\s*:\s*true/.test(body);
+      if (wantsStream) {
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(streamChunk(model, { role: "assistant", content: "" }, null, null));
+        res.write(streamChunk(model, { content: CANNED_REPLY }, null, null));
+        res.write(streamChunk(model, {}, "stop", null));
+        res.write(
+          streamChunk(model, null, null, {
+            prompt_tokens: 1,
+            completion_tokens: 3,
+            total_tokens: 4,
+          }),
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      } else {
+        const payload = JSON.stringify(chatCompletionResponse(model));
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(payload),
+        });
+        res.end(payload);
+      }
+    });
+    req.on("error", () => {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "mock upstream read error" } }));
+    });
+    return;
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: { message: "not found" } }));
+});
+
+server.listen(port, "127.0.0.1", () => {
+  const addr = server.address();
+  const boundPort = typeof addr === "object" && addr ? addr.port : port;
+  process.stdout.write(`LISTENING port=${boundPort}\n`);
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+  // Force-exit if shutdown hangs (in-flight request held the socket).
+  setTimeout(() => process.exit(0), 1000).unref();
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/tests/integration/docker.test.ts
+++ b/tests/integration/docker.test.ts
@@ -3,6 +3,10 @@
 // Self-skips when Docker is unavailable (so this stays cheap on dev
 // machines without Docker). The script itself prints PASS/FAIL per
 // assertion; we only assert on its exit code.
+//
+// Also gated behind RUN_DOCKER_SMOKE because the underlying docker build
+// + smoke run takes several minutes; opt in explicitly to keep
+// `pnpm test` snappy on machines that have Docker installed.
 
 import { execSync, spawn } from "node:child_process";
 import { resolve } from "node:path";
@@ -22,7 +26,9 @@ function hasDocker(): boolean {
   }
 }
 
-describe.skipIf(!hasDocker())("docker smoke", () => {
+const SHOULD_RUN = !!process.env.RUN_DOCKER_SMOKE;
+
+describe.skipIf(!SHOULD_RUN || !hasDocker())("docker smoke", () => {
   it(
     "app/scripts/docker-smoke.sh exits 0",
     async () => {

--- a/tests/integration/docker.test.ts
+++ b/tests/integration/docker.test.ts
@@ -1,0 +1,44 @@
+// Integration wrapper around app/scripts/docker-smoke.sh.
+//
+// Self-skips when Docker is unavailable (so this stays cheap on dev
+// machines without Docker). The script itself prints PASS/FAIL per
+// assertion; we only assert on its exit code.
+
+import { execSync, spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..");
+const SCRIPT = resolve(REPO_ROOT, "app", "scripts", "docker-smoke.sh");
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!hasDocker())("docker smoke", () => {
+  it(
+    "app/scripts/docker-smoke.sh exits 0",
+    async () => {
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        const child = spawn("bash", [SCRIPT], {
+          cwd: REPO_ROOT,
+          stdio: "inherit",
+          env: process.env,
+        });
+        child.on("error", rejectPromise);
+        child.on("exit", (code) => {
+          expect(code).toBe(0);
+          resolvePromise();
+        });
+      });
+    },
+    5 * 60 * 1000,
+  );
+});


### PR DESCRIPTION
Closes #72.

## Summary

Adds a committed Docker smoke harness for the distroless `ai-relay` image so future Dockerfile / dep / Hono changes cannot silently regress the publish-shape image. Closes Layer 0 of Epic #69 (cross-surface coverage initiative).

The smoke covers:
- **Build correctness** (B-1..B-4) — single-arch build succeeds, image content size < 150 MB measured by `docker image inspect Size` (NOT `docker images SIZE`), no native `.node` bindings in the deploy bundle, optional multi-arch behind `DOCKER_SMOKE_MULTIARCH=1`.
- **Runtime behavior** (R-1..R-9) — HEALTHCHECK reaches `healthy`, container runs as `nonroot` (uid 65532), distroless invariant (no shell), `/healthz` 200, bearer auth (`401` without, `200` with), MCP `initialize` + `tools/call openai_chat` round-trip via a mocked OpenAI upstream, graceful SIGTERM exit < 7 s, missing-env exits non-zero with a clear error.

## Why now

PR #66 (#64) verified the distroless swap end-to-end **but only via ad-hoc orchestrator BUILD smoke that wasn't committed**. Without a checked-in regression guard, future Dockerfile changes (dep bumps, base-image bumps, Hono refactors) can silently break things.

PR #66 also surfaced repeated confusion between Docker Desktop's cache-inclusive `docker images SIZE` (currently ~233 MB) vs the registry-shipped `docker image inspect Size` (46 MB). The committed smoke uses the right metric and includes a regression guard.

## Changes

| File | Change |
|---|---|
| `app/scripts/docker-smoke.sh` | NEW — POSIX bash harness, B-1..B-4 + R-1..R-9, exits non-zero on any regression. |
| `app/scripts/README.md` | NEW — assertion catalog + env-var matrix (incl. `RUN_DOCKER_SMOKE`). |
| `tests/fixtures/mock-openai/server.mjs` | NEW — minimal OpenAI Chat Completions mock; placeholder until Epic sub-issue #70 ships the shared fixture. |
| `tests/integration/docker.test.ts` | NEW — vitest wrapper, gated behind `RUN_DOCKER_SMOKE=1` AND `hasDocker()`. |
| `.github/workflows/docker-smoke.yml` | NEW — path-filtered CI workflow + opt-in multi-arch job. |
| `package.json` | MODIFIED — `pnpm docker:smoke` script. |
| `app/src/index.ts` | MODIFIED — explicit `SIGTERM`/`SIGINT` handlers (required for R-8; `@hono/node-server`'s `serve()` does not install one and the container exits 137 at Docker's 10 s grace boundary). |
| `README.md` / `doc/DEPLOY.md` / `doc/DEPLOY.ko.md` | MODIFIED — verification note. |

## Test plan

- [x] `pnpm build` — exit 0 (SDK + app)
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm lint` — exit 0 (`biome check .`, 35 files clean)
- [x] `pnpm docker:smoke` — `passed=12 failed=0` (single-arch); image content size **46 MB / 150 MB budget**
- [x] TIA (VERIFY stage) — 0 regressions vs `epic/69-test-coverage` baseline; SIGTERM handler proven end-to-end by R-8
- [ ] CI — `docker-smoke` workflow on this PR
- [ ] CI — multi-arch job (gated; runs on push-to-epic or `docker-multiarch` label)
- [ ] Manual negative test — temporarily add a fat dep, confirm B-2 catches it (per acceptance criterion in the issue)

## Evidence

<details><summary>docker-smoke.sh end-to-end output (BUILD stage)</summary>

```
[PASS] B-1 docker build single-arch (tag=ai-relay:smoke)
[PASS] B-2 image size 46 MB < 150 MB budget (measured via 'docker image inspect Size', NOT 'docker images SIZE')
--- B-3: multi-arch buildx — skipped (set DOCKER_SMOKE_MULTIARCH=1 to enable) ---
[PASS] B-4 no .node native bindings under /app/node_modules
[PASS] R-1 container reported healthy
[PASS] R-2 container User=nonroot
[PASS] R-3 no shell available in container
[PASS] R-4 /healthz returned body containing 'ok'
[PASS] R-5 unauthenticated initialize -> 401
[PASS] R-6 authenticated initialize returned protocolVersion
[PASS] R-7 tools/call returned mock canned reply
[PASS] R-8 graceful stop in 0s (exit=0)
[PASS] R-9 missing env -> exit 1 and error mentions required key(s)
summary: passed=12 failed=0
```

</details>

<details><summary>Reviewer verdict (REVIEW stage)</summary>

**APPROVED** — 0 CRITICAL, 0 HIGH, 1 MEDIUM (M-1 — addressed in commit `cc60845`: gate the vitest wrapper behind `RUN_DOCKER_SMOKE=1`), 4 LOW/INFO.

Per-surface review notes cover: shell failure semantics (`set -u` only, `FAIL_COUNT` tally, non-zero exit), EXIT trap cleanup, image-size metric correctness, mock-fixture compliance with project rule §4 ("never log OpenAI/MCP response bodies"), SIGTERM handler justification, CI workflow conventions, and POSIX portability. See PR comment for the full report.

</details>

<details><summary>TIA report (VERIFY stage)</summary>

**Verdict**: PASS — 0 regressions.

Affected specs:
- `tests/integration/route.test.ts` — 5 failures, **all pre-existing baseline** (verified by running on a fresh clone of `epic/69-test-coverage`; Δ = 0).
- `tests/integration/app-env.test.ts` — PASS.
- `tests/integration/docker.test.ts` — gated; with `RUN_DOCKER_SMOKE=1` runs end-to-end (PASS); without it, correctly skipped.
- `app/src/index.ts` SIGTERM handler — not reachable from vitest specs (gated by `isDirectRun`); proven end-to-end by docker-smoke R-8.

</details>

## Notes

- R-7 asserts the live registered tool name `openai_chat`. The issue body uses the older `completion_chat` (renamed in PR #55).
- Image-size budget is overridable: `DOCKER_SIZE_BUDGET_BYTES=200000000 pnpm docker:smoke`.
- The vitest wrapper (`tests/integration/docker.test.ts`) is opt-in: `RUN_DOCKER_SMOKE=1 pnpm test`. Default `pnpm test` skips it so the loop stays fast on Docker-having dev machines.
- 34 pre-existing baseline test failures across the SDK + integration suites on Node v22 (project pin: `>=20.10.0 <21.0.0`) are independent of this change — verified by running `pnpm test` on a clean HEAD before applying. Out of scope for this sub-issue; recommend a separate tracking issue.

🤖 Implemented via `/dev 72` pipeline.
