### PR TITLE
test(cli): real automated stdio MCP harness [Epic #69]

### DIFF
--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -314,6 +314,11 @@ limited to `node:async_hooks`.
 
 ---
 
+## Testing
+
+CLI spawn-harness coverage (real subprocess + mocked upstream) lives in
+[`tests/cli/README.md`](./tests/cli/README.md).
+
 ## License
 
 MIT.

--- a/packages/ai-relay/tests/cli/README.md
+++ b/packages/ai-relay/tests/cli/README.md
@@ -1,0 +1,90 @@
+# CLI spawn harness
+
+Real-subprocess test coverage for the `ai-relay` one-shot CLI
+(`packages/ai-relay/src/bin/run.ts` → built to `dist/bin/cli.js`).
+
+## One-shot vs stdio MCP
+
+The bin is intentionally **one-shot**: parse argv → read stdin once →
+invoke the tool handler → write JSON to stdout → exit. It does NOT
+speak the long-lived stdio MCP protocol. See
+`packages/ai-relay/README.md:82-88` and `examples/stdio/server.ts`
+for the long-lived stdio pattern.
+
+These tests verify behavior in the same shape as a real user pipeline
+(`echo … | ai-relay openai chat -m gpt-4o-mini`) by spawning the
+compiled bin under `node` and feeding it through OS pipes. MSW cannot
+intercept requests from a spawned child, so a local HTTP server in
+`mock-openai.ts` stands in for the OpenAI API and is selected via
+`AI_RELAY_BASE_URL`.
+
+## Files
+
+- `spawn-harness.ts` — small wrapper around `child_process.spawn`. Hides
+  the build-on-first-call dance, sanitizes `AI_RELAY_*` out of the
+  parent env, supports chunked stdin and signal injection, enforces a
+  hard timeout that escalates to `SIGKILL`.
+- `mock-openai.ts` — kernel-assigned-port HTTP server that records
+  requests and lets a test set per-case responses (status, body, delay,
+  hang).
+- `spawn.test.ts` — happy paths (H-\*), error/exit-code mapping (E-\*),
+  argv/env handling (A-\*), and lifecycle/secret cases (R-\*).
+
+## Harness API
+
+```ts
+import { runCli } from "./spawn-harness.js";
+import { startMockOpenAI, defaultSseBody } from "./mock-openai.js";
+
+const mock = await startMockOpenAI();
+mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
+
+const r = await runCli({
+  args: ["openai", "chat", "-m", "gpt-4o-mini", "ping"],
+  env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+});
+// r: { status, signal, stdout, stderr, durationMs }
+```
+
+`SpawnOpts` also supports `input` (one-shot stdin write), `inputStream`
+(chunked), `killAfterMs` + `killSignal`, and `timeoutMs` (default
+10 s; on expiry the child is `SIGKILL`-ed and `status === null`).
+
+## Adding a test
+
+1. Pick a behavior zone (happy / edge / error / lifecycle).
+2. Reset `mock.requests` and call `mock.setResponse(...)` for the
+   case-specific upstream behavior.
+3. Call `runCli` with `args` + `env`. Assert on `r.status`, parsed
+   `r.stdout`, and `r.stderr`.
+4. Never assert on `toBeTruthy()` alone — assert exact codes, exact
+   substrings, and exact JSON shape.
+
+## Why not MSW for the bin
+
+MSW patches `globalThis.fetch` in the test process. A spawned child has
+its own process and its own `fetch`, so MSW handlers never see the
+child's requests. The local HTTP server is the simplest deterministic
+substitute.
+
+## Divergence from issue body
+
+- **Error codes use underscores, not hyphens.** The actual mapping in
+  `packages/ai-relay/src/openai/chat.ts:130-170` returns `auth`,
+  `rate_limited`, `bad_request`, `upstream_error`, `context_length`,
+  `content_policy`. The issue body suggested hyphenated forms
+  (`rate-limited`, `upstream-server-error`); tests assert the real
+  underscore-form codes.
+- **No dedicated `timeout` error code.** Request timeouts surface as
+  an `OpenAI.APIError` with no status, which maps to `upstream_error`
+  (`chat.ts:162-164`). E-4 asserts that.
+- **E-7 exits 1, not 2.** `schema.parse` runs inside the handler
+  before the `runOnce` try/catch. A `ZodError` propagates up through
+  `run()` (no try/catch around `bundle.handler(...)` in `run.ts:163`)
+  and is caught by the top-level `.then(..., err => process.exit(1))`
+  in `cli.ts:13-16`. The error message is written to stderr by the
+  same handler. Test asserts status 1 and that the ZodError surfaces.
+- **H-4 / H-5 are negative assertions.** `parse.ts:37-45` enumerates
+  the value flags — `--name` and `--description` are not in the set,
+  so they exit 2 with `unknown flag: --<key>`. Tests document this as
+  the current contract.

--- a/packages/ai-relay/tests/cli/mock-openai.ts
+++ b/packages/ai-relay/tests/cli/mock-openai.ts
@@ -1,0 +1,100 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+export interface RecordedRequest {
+  authorization: string | undefined;
+  body: Record<string, unknown>;
+  rawBody: string;
+}
+
+export interface MockResponse {
+  status: number;
+  body: string;
+  delayMs?: number;
+  hang?: boolean;
+}
+
+export interface MockOpenAI {
+  url: string;
+  baseURL: string;
+  requests: RecordedRequest[];
+  setResponse(handler: (req: RecordedRequest) => MockResponse): void;
+  close(): Promise<void>;
+}
+
+export function defaultSseBody(text: string): string {
+  return [
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text }, finish_reason: "stop" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ].join("");
+}
+
+export async function startMockOpenAI(): Promise<MockOpenAI> {
+  const recorded: RecordedRequest[] = [];
+  let responder: (req: RecordedRequest) => MockResponse = () => ({
+    status: 200,
+    body: defaultSseBody("ok"),
+  });
+
+  const httpServer: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const text = Buffer.concat(chunks).toString("utf8");
+      let body: Record<string, unknown> = {};
+      try {
+        body = JSON.parse(text) as Record<string, unknown>;
+      } catch {
+        body = {};
+      }
+      const recordedReq: RecordedRequest = {
+        authorization: req.headers.authorization,
+        body,
+        rawBody: text,
+      };
+      recorded.push(recordedReq);
+      const out = responder(recordedReq);
+
+      const send = () => {
+        if (out.hang) return;
+        res.statusCode = out.status;
+        if (out.status === 200) {
+          res.setHeader("content-type", "text/event-stream");
+        } else {
+          res.setHeader("content-type", "application/json");
+        }
+        res.end(out.body);
+      };
+
+      if (out.delayMs && out.delayMs > 0) {
+        setTimeout(send, out.delayMs);
+      } else {
+        send();
+      }
+    });
+  });
+
+  await new Promise<void>((resolveListen) => {
+    httpServer.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("listen failed");
+  const url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    baseURL: `${url}/v1`,
+    requests: recorded,
+    setResponse(h) {
+      responder = h;
+    },
+    async close() {
+      httpServer.closeAllConnections?.();
+      await new Promise<void>((r, j) => httpServer.close((e) => (e ? j(e) : r())));
+    },
+  };
+}

--- a/packages/ai-relay/tests/cli/spawn-harness.ts
+++ b/packages/ai-relay/tests/cli/spawn-harness.ts
@@ -1,0 +1,147 @@
+import { type ChildProcessWithoutNullStreams, execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SDK_DIR = resolve(__dirname, "..", "..");
+const BIN_PATH = resolve(SDK_DIR, "dist", "bin", "cli.js");
+
+let buildPromise: Promise<void> | null = null;
+
+export interface SpawnResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+export interface SpawnOpts {
+  args: readonly string[];
+  env?: Record<string, string | undefined>;
+  input?: string;
+  inputStream?: (stdin: NodeJS.WritableStream) => Promise<void>;
+  killAfterMs?: number;
+  killSignal?: NodeJS.Signals;
+  timeoutMs?: number;
+}
+
+export function getBinPath(): string {
+  return BIN_PATH;
+}
+
+export async function ensureBuilt(): Promise<void> {
+  if (existsSync(BIN_PATH)) return;
+  if (!buildPromise) {
+    buildPromise = (async () => {
+      execFileSync("pnpm", ["--filter", "ai-relay", "build"], {
+        cwd: resolve(SDK_DIR, "..", ".."),
+        stdio: "pipe",
+      });
+    })();
+  }
+  await buildPromise;
+}
+
+function sanitizedEnv(overrides?: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const base: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("AI_RELAY_")) continue;
+    base[k] = v;
+  }
+  if (overrides) {
+    for (const [k, v] of Object.entries(overrides)) {
+      base[k] = v;
+    }
+  }
+  return base as NodeJS.ProcessEnv;
+}
+
+function writeInput(child: ChildProcessWithoutNullStreams, opts: SpawnOpts): Promise<void> {
+  if (opts.input !== undefined) {
+    return new Promise<void>((resolveWrite, rejectWrite) => {
+      child.stdin.on("error", rejectWrite);
+      child.stdin.end(opts.input, () => resolveWrite());
+    });
+  }
+  if (opts.inputStream) {
+    return opts.inputStream(child.stdin).then(
+      () =>
+        new Promise<void>((resolveEnd, rejectEnd) => {
+          child.stdin.on("error", rejectEnd);
+          child.stdin.end(() => resolveEnd());
+        }),
+    );
+  }
+  return new Promise<void>((resolveEnd, rejectEnd) => {
+    child.stdin.on("error", rejectEnd);
+    child.stdin.end(() => resolveEnd());
+  });
+}
+
+export async function runCli(opts: SpawnOpts): Promise<SpawnResult> {
+  await ensureBuilt();
+
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const start = performance.now();
+
+  return new Promise<SpawnResult>((resolvePromise, rejectPromise) => {
+    const child = spawn("node", [BIN_PATH, ...opts.args], {
+      env: sanitizedEnv(opts.env),
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    child.stdout.on("data", (c: Buffer) => {
+      stdout += c.toString("utf8");
+    });
+    child.stderr.on("data", (c: Buffer) => {
+      stderr += c.toString("utf8");
+    });
+
+    const hardTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    let killTimer: NodeJS.Timeout | undefined;
+    if (opts.killAfterMs !== undefined) {
+      killTimer = setTimeout(() => {
+        child.kill(opts.killSignal ?? "SIGTERM");
+      }, opts.killAfterMs);
+    }
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(hardTimer);
+      if (killTimer) clearTimeout(killTimer);
+      rejectPromise(err);
+    });
+
+    child.on("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(hardTimer);
+      if (killTimer) clearTimeout(killTimer);
+      const durationMs = performance.now() - start;
+      resolvePromise({
+        status: timedOut ? null : code,
+        signal: timedOut ? "SIGKILL" : signal,
+        stdout,
+        stderr,
+        durationMs,
+      });
+    });
+
+    writeInput(child, opts).catch(() => {
+      // EPIPE on closed stdin is expected for negative-path tests.
+    });
+  });
+}

--- a/packages/ai-relay/tests/cli/spawn.test.ts
+++ b/packages/ai-relay/tests/cli/spawn.test.ts
@@ -1,0 +1,327 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { defaultSseBody, type MockOpenAI, startMockOpenAI } from "./mock-openai.js";
+import { ensureBuilt, runCli } from "./spawn-harness.js";
+
+let mock: MockOpenAI;
+
+beforeAll(async () => {
+  await ensureBuilt();
+  mock = await startMockOpenAI();
+}, 180_000);
+
+afterAll(async () => {
+  if (mock) await mock.close();
+});
+
+beforeEach(() => {
+  mock.requests.length = 0;
+  mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
+});
+
+function happyEnv(): Record<string, string> {
+  return { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL };
+}
+
+describe("A: Positive — Happy Path Scenarios", () => {
+  it("H-1: positional plain text against mocked upstream → exit 0", async () => {
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "ping"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(false);
+    expect(out.content[0].text).toBe("hello world");
+    expect(out.structuredContent.model).toBe("gpt-4o-mini");
+  });
+
+  it("H-2: stdin JSON → exit 0 + result on stdout", async () => {
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("hi back") }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      input: '{"messages":[{"role":"user","content":"hi"}]}',
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(false);
+    expect(Array.isArray(out.content)).toBe(true);
+    expect(typeof out.content[0].text).toBe("string");
+  });
+
+  it("H-3: positional plain text desugared into messages[role=user]", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    expect(mock.requests).toHaveLength(1);
+    expect(mock.requests[0]?.body).toMatchObject({
+      messages: [{ role: "user", content: "hi" }],
+    });
+  });
+
+  it("H-4: --name flag is NOT supported → exit 2", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--name", "foo", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/unknown flag: --name/);
+  });
+
+  it("H-5: --description flag is NOT supported → exit 2", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--description", "x", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/unknown flag: --description/);
+  });
+});
+
+describe("C: Negative — Error / Exit Codes", () => {
+  it("E-1: upstream 401 → exit 1 + isError + code 'auth'", async () => {
+    mock.setResponse(() => ({
+      status: 401,
+      body: JSON.stringify({ error: { message: "no auth" } }),
+    }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("auth");
+  });
+
+  it("E-2: upstream 429 → exit 1 + code 'rate_limited'", async () => {
+    mock.setResponse(() => ({
+      status: 429,
+      body: JSON.stringify({ error: { message: "slow down" } }),
+    }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("rate_limited");
+  });
+
+  it("E-3: upstream 500 → exit 1 + code 'upstream_error'", async () => {
+    mock.setResponse(() => ({
+      status: 500,
+      body: JSON.stringify({ error: { message: "boom" } }),
+    }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("E-4: --timeout exceeded → exit 1 + code 'upstream_error'", async () => {
+    mock.setResponse(() => ({ status: 200, body: "", hang: true }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--timeout", "200", "hi"],
+      env: happyEnv(),
+      timeoutMs: 5_000,
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("E-5: connection refused → exit 1 + isError + code 'upstream_error'", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: "http://127.0.0.1:1/v1" },
+      timeoutMs: 10_000,
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("E-6: invalid JSON on stdin (leading '{') → exit 2 + 'not valid JSON' on stderr", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      input: "{not-valid-json",
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("not valid JSON");
+  });
+
+  it("E-7: messages is not an array → exit 1 + ZodError on stderr", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      input: '{"messages":"not-an-array"}',
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/ZodError|Invalid input|messages/i);
+  });
+});
+
+describe("B: Argv / Env handling", () => {
+  it("A-1: no args → exit 2 + usage on stderr", async () => {
+    const r = await runCli({ args: [], env: {} });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/usage:|--model|provider/i);
+  });
+
+  it("A-2: unknown provider/tool → exit 2", async () => {
+    const r = await runCli({
+      args: ["nope", "chat", "-m", "x", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("unknown nope/chat");
+  });
+
+  it("A-3: openai chat without AI_RELAY_API_KEY → exit 2 mentioning apiKey", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: {},
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("apiKey");
+  });
+
+  it("A-4: --help → exit 0 + 'Usage: ai-relay' on stdout + no upstream call", async () => {
+    const before = mock.requests.length;
+    const r = await runCli({ args: ["--help"], env: {} });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("Usage: ai-relay");
+    expect(mock.requests.length).toBe(before);
+  });
+
+  it("A-5: --version → exit 0 + semver on stdout", async () => {
+    const r = await runCli({ args: ["--version"], env: {} });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("A-6: env-only happy path (no flags besides -m) → exit 0", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(false);
+  });
+});
+
+describe("D: Resilience / Lifecycle", () => {
+  it("R-1: closed stdin + no positional → exit 2 within 1 s", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      timeoutMs: 1_000,
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/empty stdin|requires input/);
+    expect(r.durationMs).toBeLessThan(1_000);
+  });
+
+  it("R-2: SIGTERM during slow upstream → child exits within 2 s", async () => {
+    mock.setResponse(() => ({ status: 200, body: "", hang: true }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+      killAfterMs: 200,
+      killSignal: "SIGTERM",
+      timeoutMs: 5_000,
+    });
+    const terminated = r.signal === "SIGTERM" || (r.status !== null && r.status !== 0);
+    expect(terminated).toBe(true);
+    expect(r.durationMs).toBeLessThan(3_000);
+  });
+
+  it("R-3: SIGINT during slow upstream → child exits within 2 s", async () => {
+    mock.setResponse(() => ({ status: 200, body: "", hang: true }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+      killAfterMs: 200,
+      killSignal: "SIGINT",
+      timeoutMs: 5_000,
+    });
+    const terminated = r.signal === "SIGINT" || (r.status !== null && r.status !== 0);
+    expect(terminated).toBe(true);
+    expect(r.durationMs).toBeLessThan(3_000);
+  });
+
+  it("R-4: stdout is JSON-only, stderr is not JSON", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    expect(() => JSON.parse(r.stdout.trim())).not.toThrow();
+    const lines = r.stdout.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    if (r.stderr.trim().length > 0) {
+      expect(() => JSON.parse(r.stderr.trim())).toThrow();
+    }
+  });
+
+  it("R-5: ~64 KB JSON input via chunked stdin → upstream receives full content", async () => {
+    const big = "x".repeat(64 * 1024);
+    const payload = JSON.stringify({ messages: [{ role: "user", content: big }] });
+    let seenLen = 0;
+    mock.setResponse((req) => {
+      const messages = (req.body as { messages?: Array<{ content?: string }> }).messages;
+      seenLen = messages?.[0]?.content?.length ?? 0;
+      return { status: 200, body: defaultSseBody("ok") };
+    });
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      inputStream: async (stdin) => {
+        const chunkSize = 8 * 1024;
+        for (let i = 0; i < payload.length; i += chunkSize) {
+          const chunk = payload.slice(i, i + chunkSize);
+          await new Promise<void>((resolveWrite, rejectWrite) => {
+            stdin.write(chunk, (err) => (err ? rejectWrite(err) : resolveWrite()));
+          });
+        }
+      },
+      timeoutMs: 15_000,
+    });
+    expect(r.status).toBe(0);
+    expect(seenLen).toBe(big.length);
+  });
+
+  it("R-6a: failing --env path does not echo AI_RELAY_API_KEY", async () => {
+    const canary = "leak-canary-XYZ";
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--env", "/no/such.env", "hi"],
+      env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r.status).toBe(2);
+    expect(r.stdout).not.toContain(canary);
+    expect(r.stderr).not.toContain(canary);
+  });
+
+  it("R-6b: happy path does not echo AI_RELAY_API_KEY on stderr", async () => {
+    const canary = "leak-canary-HAPPY";
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain(canary);
+  });
+});

--- a/packages/ai-relay/tests/integration/bin-tarball.test.ts
+++ b/packages/ai-relay/tests/integration/bin-tarball.test.ts
@@ -231,4 +231,37 @@ describe("ai-relay bin — installed tarball", () => {
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
+
+  it("T-1: full one-shot round-trip — positional, stdin JSON, plain text", async () => {
+    mock.requests.length = 0;
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
+
+    const r1 = await runBin(["openai", "chat", "-m", "gpt-4o-mini", "ping"], {
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r1.status).toBe(0);
+    const out1 = JSON.parse(r1.stdout.trim());
+    expect(out1.isError).toBe(false);
+    expect(out1.content[0].text).toBe("hello world");
+
+    mock.requests.length = 0;
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
+    const r2 = await runBin(["openai", "chat", "-m", "gpt-4o-mini"], {
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+      input: '{"messages":[{"role":"user","content":"hi"}]}',
+    });
+    expect(r2.status).toBe(0);
+    expect(mock.requests[0]?.body).toMatchObject({
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    mock.requests.length = 0;
+    const r3 = await runBin(["openai", "chat", "-m", "gpt-4o-mini", "plain-text-input"], {
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r3.status).toBe(0);
+    expect(mock.requests[0]?.body).toMatchObject({
+      messages: [{ role: "user", content: "plain-text-input" }],
+    });
+  });
 });

--- a/packages/ai-relay/vitest.config.ts
+++ b/packages/ai-relay/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
     // spawn npm pack + npm install in a temp dir and exercise the
     // installed bin end-to-end, catching packaging regressions that
     // unit tests can't see.
-    include: ["tests/unit/**/*.test.ts", "tests/integration/**/*.test.ts"],
+    include: [
+      "tests/unit/**/*.test.ts",
+      "tests/integration/**/*.test.ts",
+      "tests/cli/**/*.test.ts",
+    ],
     setupFiles: ["./tests/setup-env.ts"],
     environment: "node",
     pool: "threads",


### PR DESCRIPTION
Closes #71.

## Summary

Adds an automated real-subprocess test harness for the `ai-relay` CLI
(`packages/ai-relay/src/bin/run.ts`). The existing test pyramid covered:

- `cli.test.ts` — argv parser units
- `run.test.ts` — `run()` exercised in-process (no real subprocess)
- `bin-tarball.test.ts` — install-from-tarball smoke (5 cases, happy path only)

Missing: end-to-end via real `child_process.spawn` + line-buffered stdin/stdout
against a mocked OpenAI fixture. That is what this PR adds — the CLI is now
exercised exactly as `npx ai-relay` users invoke it.

Per `packages/ai-relay/README.md:82-88`, the CLI is **intentionally one-shot**
(argv → stdin once → handler → JSON stdout → exit) and is NOT a long-lived
stdio MCP server. The real stdio MCP surface is `examples/stdio/server.ts`,
covered by sub-issue #73.

## Changes

| File | Change |
|---|---|
| `packages/ai-relay/tests/cli/spawn-harness.ts` | New — reusable spawn helper (`runCli`, `ensureBuilt`, `getBinPath`). Sanitizes `AI_RELAY_*` from parent env, supports chunked stdin, signal injection, SIGKILL fallback on timeout. |
| `packages/ai-relay/tests/cli/mock-openai.ts` | New — local HTTP mock OpenAI server (port 0, recordable requests, configurable responder). MSW cannot intercept spawned children, so we need real HTTP. |
| `packages/ai-relay/tests/cli/spawn.test.ts` | New — 25 tests: H-1..H-5 happy, E-1..E-7 error/exit-code, A-1..A-6 argv/env, R-1..R-6b resilience + secret redaction. |
| `packages/ai-relay/tests/cli/README.md` | New — harness purpose, one-shot vs stdio MCP distinction, divergence-from-issue-body section. |
| `packages/ai-relay/tests/integration/bin-tarball.test.ts` | +T-1: full one-shot round-trip (positional + stdin JSON + plain text) against the installed tarball bin. |
| `packages/ai-relay/vitest.config.ts` | Include `tests/cli/**/*.test.ts`. |
| `packages/ai-relay/README.md` | Cross-link to `tests/cli/README.md`. |

## Divergences from issue body (asserted as actual behavior)

The issue body's assumptions were spot-checked against `packages/ai-relay/src/openai/chat.ts`,
`run.ts`, and `parse.ts`. Five mismatches were documented in `tests/cli/README.md`'s
"Divergence" section and the tests assert the real behavior:

1. **Error codes use underscores, not hyphens** (`chat.ts:130-170`): `auth`,
   `rate_limited`, `bad_request`, `upstream_error`, `context_length`,
   `content_policy`.
2. **No dedicated `timeout` code** — request timeouts produce
   `OpenAI.APIError` with `status === undefined`, which maps to `upstream_error`
   (`chat.ts:162-164`).
3. **E-7 (zod validation failure) exits 1, not 2.** `schema.parse` runs inside
   the handler at `chat.ts:192`; `run.ts:163` doesn't try/catch around
   `bundle.handler`, so `ZodError` propagates to `cli.ts:13-16`'s
   `.then(..., err => process.exit(1))`.
4. **H-4/H-5 inverted to negative.** `parse.ts:37-45` does not list `--name` or
   `--description` in `VALUE_FLAGS`; the CLI exits 2 with `unknown flag: --<key>`.
5. **E-6 adjustment.** Original `not-valid-json{` starts with `n` and goes down
   the plain-text path. Adjusted to `{not-valid-json` to actually exercise the
   JSON-parse error branch (`run.ts:175-182`).

No behavior changes — this is a test-coverage PR only.

## Test plan

- [x] `pnpm --filter ai-relay build` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm lint` — exit 0 (36 files clean)
- [x] `pnpm --filter ai-relay test` — exit 0 (152 passed; +25 spawn + T-1 = +26 new)
- [x] `pnpm test:integration` — exit 0 (40 passed)
- [ ] MCP Inspector — N/A (no MCP server changes; CLI test coverage only)

🤖 Implemented via `/dev 71` pipeline.

## Evidence

<details>
<summary>Verify (TIA) — affected specs</summary>

| Spec | Result |
|---|---|
| `packages/ai-relay/tests/cli/spawn.test.ts` | 25/25 pass |
| `packages/ai-relay/tests/integration/bin-tarball.test.ts` | 6/6 pass (incl. new T-1) |
| Full `ai-relay` vitest suite | 152/152 pass |

</details>

<details>
<summary>Review verdict</summary>

**APPROVED** — 0 CRITICAL · 0 HIGH · 3 MEDIUM · 4 LOW · 3 INFO

Non-blocking findings (recorded for follow-up):
- M-1: T-1 in `bin-tarball.test.ts` overlaps with S1/S3 — could exercise stdin+positional conflict path instead.
- M-2: `spawn-harness.ts` uses block-list (`AI_RELAY_*`) for env sanitization; allow-list would also intercept proxy/NODE_OPTIONS leakage.
- M-3: `spawn.test.ts` module-scoped mock relies on serial execution — worth a one-line hidden-constraint comment.
- L-1..L-4: minor nits (duplicate `ensureBuilt`, JSON.parse default-assign style, optional chain on Node 20 baseline, README "signal injection" oversell).

</details>

<details>
<summary>MCP Inspector check</summary>

N/A — this PR adds test coverage only. No MCP server / CLI behavior changes; the inspector surface is unchanged.

</details>

## v1 non-goal self-check

- [x] No Responses API tools added
- [x] No embeddings / image tools
- [x] No OAuth 2.1 added
- [x] No rate limiting added
- [x] No token / dollar budget counters
- [x] No external observability hooks
- [x] No progress notifications
- [x] No tool/function-calling pass-through
- [x] No SSE / Redis transport changes
