### PR TITLE
test(epic): cross-surface coverage initiative — SDK + CLI + Docker + examples (closes #69)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,45 @@
+name: docker-smoke
+
+on:
+  pull_request:
+    branches: [main, 'epic/**']
+    paths:
+      - 'app/**'
+      - 'examples/docker/**'
+      - 'pnpm-lock.yaml'
+      - 'tests/fixtures/mock-openai/**'
+      - 'app/scripts/docker-smoke.sh'
+      - '.github/workflows/docker-smoke.yml'
+  push:
+    branches: [main, 'epic/**']
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Docker smoke
+        run: pnpm docker:smoke
+
+  smoke-multiarch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'docker-multiarch')
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Multi-arch build (B-3)
+        env:
+          DOCKER_SMOKE_MULTIARCH: '1'
+        run: bash app/scripts/docker-smoke.sh

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -1,0 +1,39 @@
+name: examples-smoke
+
+on:
+  pull_request:
+    paths:
+      - "examples/**"
+      - "packages/ai-relay/**"
+      - ".github/workflows/examples-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "packages/ai-relay/**"
+      - ".github/workflows/examples-smoke.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SKIP_CF_SMOKE: "1"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm --filter ai-relay build
+
+      - name: Run examples smoke
+        run: pnpm examples:smoke

--- a/.github/workflows/runtime-matrix.yml
+++ b/.github/workflows/runtime-matrix.yml
@@ -1,0 +1,121 @@
+name: Runtime Matrix
+
+on:
+  pull_request:
+    branches: [main, "epic/**"]
+  push:
+    branches: [main, "epic/**"]
+
+jobs:
+  node-matrix:
+    name: Smoke (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.10.0", "20.x", "22.x", "24.x"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm --filter ai-relay build
+
+      - name: Pack SDK
+        working-directory: packages/ai-relay
+        run: |
+          mkdir -p /tmp/pack
+          pnpm pack --pack-destination /tmp/pack
+          ls -la /tmp/pack
+
+      - name: Install tarball into smoke fixture
+        working-directory: tests/runtime-fixtures/smoke-node
+        run: npm install --no-audit --no-fund /tmp/pack/ai-relay-*.tgz
+
+      - name: Run smoke
+        working-directory: tests/runtime-fixtures/smoke-node
+        run: node smoke.mjs
+
+  bun-smoke:
+    name: Smoke (Bun)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm --filter ai-relay build
+
+      - name: Pack SDK
+        working-directory: packages/ai-relay
+        run: |
+          mkdir -p /tmp/pack
+          pnpm pack --pack-destination /tmp/pack
+
+      - name: Install tarball into Bun smoke fixture
+        working-directory: tests/runtime-fixtures/smoke-bun
+        run: npm install --no-audit --no-fund /tmp/pack/ai-relay-*.tgz
+
+      - name: Run smoke (Bun)
+        working-directory: tests/runtime-fixtures/smoke-bun
+        run: bun run smoke.mjs
+
+  esm-only-cjs-require:
+    name: ESM-only / CJS require assertion
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20.x", "22.x"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm --filter ai-relay build
+
+      - name: Pack SDK
+        working-directory: packages/ai-relay
+        run: |
+          mkdir -p /tmp/pack
+          pnpm pack --pack-destination /tmp/pack
+
+      - name: Install tarball into CJS fixture
+        working-directory: tests/runtime-fixtures/cjs-require
+        run: npm install --no-audit --no-fund /tmp/pack/ai-relay-*.tgz
+
+      - name: Run CJS require smoke
+        working-directory: tests/runtime-fixtures/cjs-require
+        run: node smoke.cjs

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ image). For local-build development, use `compose.dev.yml`:
 docker compose -f compose.dev.yml up --build
 ```
 
+### Verification
+
+Before publishing or trusting a local build, run the committed smoke
+harness against the distroless runner image:
+
+```bash
+pnpm docker:smoke
+```
+
+`pnpm docker:smoke` invokes [`app/scripts/docker-smoke.sh`](./app/scripts/docker-smoke.sh),
+which builds the image and runs build-correctness + runtime assertions
+(image-size budget, distroless invariants, bearer auth, MCP `initialize`
++ `tools/call` round-trip). See [`app/scripts/README.md`](./app/scripts/README.md)
+for the assertion catalog and tunable env vars.
+
 ---
 
 ## Quick start — embed the SDK

--- a/app/scripts/README.md
+++ b/app/scripts/README.md
@@ -1,0 +1,83 @@
+# app/scripts
+
+Operational tooling that exercises the published shape of the `app/`
+Hono runner image (`ghcr.io/ragingwind/ai-relay`).
+
+---
+
+## `docker-smoke.sh`
+
+Self-contained shell smoke test for the distroless runtime image. Verifies
+build correctness, runtime invariants, and an image-size budget — meant to
+catch regressions before tagging a release. Run it locally before opening
+a PR that touches `app/**`, `Dockerfile`, or the deploy bundle layout.
+
+### Local invocation
+
+```bash
+pnpm docker:smoke
+```
+
+Or directly:
+
+```bash
+bash app/scripts/docker-smoke.sh
+```
+
+The script auto-skips with `[SKIP] docker not available` when Docker is
+absent (no failure exit code), so it is safe to wire into `pnpm test`-style
+flows on dev machines without Docker.
+
+### Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `IMAGE_TAG` | `ai-relay:smoke` | Tag used for `docker build` + `docker run`. |
+| `DOCKER_SIZE_BUDGET_BYTES` | `157286400` | B-2 budget (default 150 MB). Compared against `docker image inspect Size` (NOT `docker images SIZE`). |
+| `DOCKER_SMOKE_MULTIARCH` | unset | Set `=1` to enable B-3 multi-arch buildx. Slow; off by default. |
+| `MOCK_PORT` | dynamic | Mock OpenAI fixture port. Auto-picked when unset (the mock prints `LISTENING port=N`). |
+| `SMOKE_HOST_PORT` | `18787` | Published host port for the container under test. |
+| `RUN_DOCKER_SMOKE` | unset | Set to any non-empty value to enable the `tests/integration/docker.test.ts` vitest wrapper inside `pnpm test`. The dedicated `pnpm docker:smoke` always runs the script regardless of this flag. |
+
+### Assertions
+
+Each assertion logs `[PASS] <id> ...` or `[FAIL] <id> ...` and contributes
+to a final `summary: passed=N failed=M` line. Any `[FAIL]` produces a
+non-zero exit code.
+
+| ID | What | Notes |
+|---|---|---|
+| B-1 | `docker build -f app/Dockerfile -t $IMAGE_TAG .` succeeds (single arch). | First failure short-circuits the rest. |
+| B-2 | Image content size < `DOCKER_SIZE_BUDGET_BYTES`. | Uses `docker image inspect --format '{{.Size}}'`, NOT the rounded `docker images` SIZE column. |
+| B-3 | Multi-arch buildx (linux/amd64 + linux/arm64) succeeds. | Opt-in via `DOCKER_SMOKE_MULTIARCH=1`. Fails loud if buildx is missing while opted in. |
+| B-4 | No `.node` native bindings under `/app/node_modules`. | Distroless has no shell — invoked via `node -e`. |
+| R-1 | HEALTHCHECK reports `healthy` within 60 s. | Dockerfile sets `--interval=30s --start-period=10s --retries=3`. On timeout, prints last 30 lines of `docker logs`. |
+| R-2 | Container `Config.User` is `nonroot` or `65532`. | Distroless symbolizes uid 65532 as `nonroot`. |
+| R-3 | `docker exec ... sh -c true` exits non-zero. | Distroless invariant: no shell present. |
+| R-4 | `GET /healthz` returns body containing `ok`. | |
+| R-5 | `POST /api/mcp` (no bearer) returns 401. | Sends MCP `initialize` JSON-RPC. |
+| R-6 | `POST /api/mcp` (with bearer) returns body containing `"protocolVersion"`. | Same `initialize` request. |
+| R-7 | `tools/call` for `openai_chat` returns the mock canned reply (`smoke-canned-reply`). | |
+| R-8 | `docker stop --time=10` returns within 7 s and exit code is 0 or 143. | 143 = 128 + SIGTERM(15). |
+| R-9 | `docker run --rm <image>` with no env vars exits non-zero AND mentions `AI_RELAY_API_KEY` or `AI_RELAY_AUTH_TOKEN`. | Validates the env-validation error path. |
+
+### Adding a new assertion
+
+The script tracks failures with two counters (`PASS_COUNT`, `FAIL_COUNT`)
+and helpers `pass "<id> <description>"` / `fail "<id> <description>"`. To
+add a new assertion:
+
+1. Pick the next free id (`B-5`, `R-10`, …).
+2. Add an `--- <id>: <name> ---` echo banner.
+3. Run the check; call `pass` or `fail` based on the outcome.
+4. Document the new id in the table above.
+
+The script intentionally runs every assertion (no `set -e`) so the summary
+reflects the full picture even when an early assertion fails.
+
+### Cross-platform notes
+
+- `host.docker.internal:host-gateway` works on Linux Docker 20.10+ and
+  macOS Docker Desktop. CI uses `ubuntu-latest`, dev typically uses macOS.
+- The script avoids GNU-only flags so it runs on both BSD and GNU
+  userlands.

--- a/app/scripts/docker-smoke.sh
+++ b/app/scripts/docker-smoke.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# docker-smoke.sh — committed publish-shape smoke for the app/ Hono runner image.
+#
+# Verifies build correctness (B-1..B-4) and runtime behavior (R-1..R-9)
+# of the distroless image produced by app/Dockerfile. Every assertion is
+# reported as `[PASS]` or `[FAIL]` and a non-zero exit code is returned
+# when any assertion fails. Multi-arch (B-3) is gated behind
+# DOCKER_SMOKE_MULTIARCH=1 because it is slow.
+#
+# Env vars (defaults shown):
+#   IMAGE_TAG=ai-relay:smoke              build/run tag
+#   DOCKER_SIZE_BUDGET_BYTES=157286400    image-size guard (150 MB)
+#   DOCKER_SMOKE_MULTIARCH=                set =1 to enable B-3
+#   MOCK_PORT=                             mock OpenAI port (auto when unset)
+#   SMOKE_HOST_PORT=18787                 published host port for the container
+#
+# host.docker.internal:host-gateway is supported on Linux Docker 20.10+ and
+# macOS Docker Desktop — the CI runner (ubuntu-latest) and dev machines both
+# satisfy this.
+#
+# Shell mode: `set -u` only — we deliberately do NOT `set -e` so every
+# assertion runs and contributes to the pass/fail summary.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Resolve REPO_ROOT regardless of cwd. The script lives at
+# <repo>/app/scripts/docker-smoke.sh.
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+cd "$REPO_ROOT"
+
+IMAGE_TAG=${IMAGE_TAG:-ai-relay:smoke}
+DOCKER_SIZE_BUDGET_BYTES=${DOCKER_SIZE_BUDGET_BYTES:-$((150 * 1024 * 1024))}
+SMOKE_HOST_PORT=${SMOKE_HOST_PORT:-18787}
+CONTAINER_NAME=ai-relay-smoke
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "[PASS] $*"
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  echo "[FAIL] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Skip path: docker absent → exit 0 with [SKIP] (local-dev fallback).
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[SKIP] docker not available — install Docker to run this smoke"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup trap: stop+remove container, kill mock pid.
+MOCK_PID=""
+cleanup() {
+  local exit_code=$?
+  if [ -n "${MOCK_PID:-}" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ===========================================================================
+# B-1: docker build single-arch
+# ===========================================================================
+echo "--- B-1: docker build (single arch) ---"
+if docker build -f app/Dockerfile -t "$IMAGE_TAG" . ; then
+  pass "B-1 docker build single-arch (tag=$IMAGE_TAG)"
+else
+  fail "B-1 docker build single-arch (tag=$IMAGE_TAG)"
+  echo "B-1 failed; remaining assertions will be skipped"
+  echo ""
+  echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+  exit 1
+fi
+
+# ===========================================================================
+# B-2: image content size guard
+#   docker image inspect Size = uncompressed on-disk content size in bytes.
+#   This is NOT the `docker images` SIZE column rounded to MB.
+# ===========================================================================
+echo "--- B-2: image-size budget ---"
+size_bytes=$(docker image inspect --format '{{.Size}}' "$IMAGE_TAG" 2>/dev/null || echo "0")
+size_mb=$(( size_bytes / 1024 / 1024 ))
+budget_mb=$(( DOCKER_SIZE_BUDGET_BYTES / 1024 / 1024 ))
+if [ "$size_bytes" -gt 0 ] && [ "$size_bytes" -lt "$DOCKER_SIZE_BUDGET_BYTES" ]; then
+  pass "B-2 image size ${size_mb} MB < ${budget_mb} MB budget (measured via 'docker image inspect Size', NOT 'docker images SIZE')"
+else
+  fail "B-2 image size ${size_mb} MB exceeds ${budget_mb} MB budget (measured via 'docker image inspect Size' = ${size_bytes} bytes; compare against DOCKER_SIZE_BUDGET_BYTES=${DOCKER_SIZE_BUDGET_BYTES})"
+fi
+
+# ===========================================================================
+# B-3: multi-arch buildx (linux/amd64 + linux/arm64) — opt-in
+# ===========================================================================
+if [ "${DOCKER_SMOKE_MULTIARCH:-}" = "1" ]; then
+  echo "--- B-3: multi-arch buildx (DOCKER_SMOKE_MULTIARCH=1) ---"
+  if ! docker buildx version >/dev/null 2>&1; then
+    fail "B-3 multi-arch build — docker buildx is unavailable"
+  elif docker buildx build --platform linux/amd64,linux/arm64 -f app/Dockerfile . ; then
+    pass "B-3 multi-arch build (linux/amd64,linux/arm64)"
+  else
+    fail "B-3 multi-arch build (linux/amd64,linux/arm64)"
+  fi
+else
+  echo "--- B-3: multi-arch buildx — skipped (set DOCKER_SMOKE_MULTIARCH=1 to enable) ---"
+fi
+
+# ===========================================================================
+# B-4: no native bindings (.node) in the deploy bundle
+#   Distroless has no shell — invoke node directly.
+# ===========================================================================
+echo "--- B-4: no native .node bindings in /app/node_modules ---"
+native_out=$(docker run --rm --entrypoint=/nodejs/bin/node "$IMAGE_TAG" -e "import('node:fs').then(fs=>{const out=fs.readdirSync('/app/node_modules',{recursive:true,withFileTypes:true}).filter(d=>d.isFile()&&d.name.endsWith('.node')).map(d=>d.parentPath+'/'+d.name);process.stdout.write(out.join('\\n'));process.exit(out.length?1:0);})" 2>&1)
+native_rc=$?
+if [ "$native_rc" -eq 0 ]; then
+  pass "B-4 no .node native bindings under /app/node_modules"
+else
+  fail "B-4 found .node native bindings under /app/node_modules:"
+  echo "$native_out" | sed 's/^/        /'
+fi
+
+# ===========================================================================
+# Mock OpenAI fixture launch
+# ===========================================================================
+echo "--- launching mock OpenAI fixture ---"
+mock_log=$(mktemp -t ai-relay-mock.XXXXXX)
+node tests/fixtures/mock-openai/server.mjs --port="${MOCK_PORT:-0}" >"$mock_log" 2>&1 &
+MOCK_PID=$!
+# Wait up to 5s for the LISTENING line.
+mock_port=""
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if grep -q '^LISTENING port=' "$mock_log" 2>/dev/null; then
+    mock_port=$(sed -n 's/^LISTENING port=\([0-9]*\).*/\1/p' "$mock_log" | head -n1)
+    break
+  fi
+  sleep 0.5
+done
+if [ -z "$mock_port" ]; then
+  fail "mock OpenAI fixture failed to start within 5s; mock log:"
+  sed 's/^/        /' "$mock_log"
+  echo ""
+  echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+  exit 1
+fi
+echo "mock OpenAI listening on 0.0.0.0:${mock_port} (pid=${MOCK_PID})"
+
+# ===========================================================================
+# Container launch
+# ===========================================================================
+echo "--- launching container ---"
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+SMOKE_BEARER=$(printf 'x%.0s' $(seq 1 32))
+if ! docker run -d \
+  --name="$CONTAINER_NAME" \
+  -e AI_RELAY_API_KEY=smoke-key \
+  -e AI_RELAY_AUTH_TOKEN="$SMOKE_BEARER" \
+  -e AI_RELAY_BASE_URL="http://host.docker.internal:${mock_port}/v1" \
+  --add-host=host.docker.internal:host-gateway \
+  -p "${SMOKE_HOST_PORT}:8787" \
+  "$IMAGE_TAG" >/dev/null ; then
+  fail "container failed to launch"
+  echo ""
+  echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+  exit 1
+fi
+
+# ===========================================================================
+# R-1: HEALTHCHECK reaches healthy within 60s
+#   Dockerfile config: --interval=30s --start-period=10s --retries=3
+# ===========================================================================
+echo "--- R-1: HEALTHCHECK -> healthy within 60s ---"
+healthy=0
+for _ in $(seq 1 60); do
+  status=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+  if [ "$status" = "healthy" ]; then
+    healthy=1
+    break
+  fi
+  sleep 1
+done
+if [ "$healthy" -eq 1 ]; then
+  pass "R-1 container reported healthy"
+else
+  fail "R-1 container did not reach healthy within 60s (last status=$status)"
+  echo "        last 30 lines of docker logs:"
+  docker logs --tail 30 "$CONTAINER_NAME" 2>&1 | sed 's/^/        /'
+fi
+
+# ===========================================================================
+# R-2: container runs as nonroot (uid 65532)
+# ===========================================================================
+echo "--- R-2: container User = nonroot / 65532 ---"
+user=$(docker inspect --format '{{.Config.User}}' "$CONTAINER_NAME" 2>/dev/null || echo "")
+case "$user" in
+  nonroot|65532)
+    pass "R-2 container User=$user"
+    ;;
+  *)
+    fail "R-2 expected nonroot or 65532, got '$user'"
+    ;;
+esac
+
+# ===========================================================================
+# R-3: distroless invariant — no shell present
+# ===========================================================================
+echo "--- R-3: no shell in container (distroless invariant) ---"
+if docker exec "$CONTAINER_NAME" sh -c true >/dev/null 2>&1; then
+  fail "R-3 container has a shell (sh -c true succeeded) — image is not distroless"
+else
+  pass "R-3 no shell available in container"
+fi
+
+# ===========================================================================
+# R-4: GET /healthz -> 200 ok
+# ===========================================================================
+echo "--- R-4: GET /healthz -> 200 ok ---"
+healthz_body=$(curl -fsS "http://localhost:${SMOKE_HOST_PORT}/healthz" 2>&1 || true)
+if echo "$healthz_body" | grep -q "ok"; then
+  pass "R-4 /healthz returned body containing 'ok'"
+else
+  fail "R-4 /healthz response did not contain 'ok' (got: $healthz_body)"
+fi
+
+# ===========================================================================
+# R-5: POST /api/mcp without bearer -> 401
+# ===========================================================================
+echo "--- R-5: POST /api/mcp without bearer -> 401 ---"
+init_body='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+unauth_code=$(curl -s -o /dev/null -w '%{http_code}' \
+  "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+  -X POST \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d "$init_body")
+if [ "$unauth_code" = "401" ]; then
+  pass "R-5 unauthenticated initialize -> 401"
+else
+  fail "R-5 expected 401 without bearer, got $unauth_code"
+fi
+
+# ===========================================================================
+# R-6: POST /api/mcp with bearer -> 200 + protocolVersion
+# ===========================================================================
+echo "--- R-6: POST /api/mcp initialize with bearer -> 200 + protocolVersion ---"
+# mcp-handler v1.1+ uses Streamable HTTP — the response sets a
+# Mcp-Session-Id header that subsequent requests (R-7) MUST echo back.
+# We capture the headers via `-D` so the session id propagates to R-7.
+init_headers=$(mktemp)
+init_resp=$(curl -s -D "$init_headers" \
+  "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+  -X POST \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "authorization: Bearer ${SMOKE_BEARER}" \
+  -d "$init_body")
+SESSION_ID=$(grep -i '^Mcp-Session-Id:' "$init_headers" | awk '{print $2}' | tr -d '\r\n')
+rm -f "$init_headers"
+if echo "$init_resp" | grep -q '"protocolVersion"'; then
+  pass "R-6 authenticated initialize returned protocolVersion"
+else
+  fail "R-6 authenticated initialize did not return protocolVersion"
+fi
+
+# ===========================================================================
+# R-7: tools/call openai_chat -> mock canned reply present
+# ===========================================================================
+echo "--- R-7: tools/call openai_chat -> canned reply ---"
+call_body='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"openai_chat","arguments":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}}}'
+# Pass Mcp-Session-Id only when the server returned one (stateful mode).
+# mcp-handler runs stateless by default — no header to forward.
+if [ -n "$SESSION_ID" ]; then
+  call_resp=$(curl -s \
+    "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+    -X POST \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "authorization: Bearer ${SMOKE_BEARER}" \
+    -H "Mcp-Session-Id: ${SESSION_ID}" \
+    -d "$call_body")
+else
+  call_resp=$(curl -s \
+    "http://localhost:${SMOKE_HOST_PORT}/api/mcp" \
+    -X POST \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -H "authorization: Bearer ${SMOKE_BEARER}" \
+    -d "$call_body")
+fi
+if echo "$call_resp" | grep -q "smoke-canned-reply"; then
+  pass "R-7 tools/call returned mock canned reply"
+else
+  fail "R-7 tools/call did not return canned reply (response: ${call_resp:0:300})"
+fi
+
+# ===========================================================================
+# R-8: graceful shutdown — docker stop returns within 7s with exit 0 or 143
+# ===========================================================================
+echo "--- R-8: docker stop -> graceful exit within 7s ---"
+stop_start=$(date +%s)
+docker stop --time=10 "$CONTAINER_NAME" >/dev/null 2>&1 || true
+stop_end=$(date +%s)
+stop_elapsed=$(( stop_end - stop_start ))
+exit_code=$(docker inspect --format '{{.State.ExitCode}}' "$CONTAINER_NAME" 2>/dev/null || echo "missing")
+if [ "$stop_elapsed" -lt 7 ] && { [ "$exit_code" = "0" ] || [ "$exit_code" = "143" ]; }; then
+  pass "R-8 graceful stop in ${stop_elapsed}s (exit=${exit_code})"
+else
+  fail "R-8 stop took ${stop_elapsed}s, exit=${exit_code} (expected <7s and exit 0 or 143)"
+fi
+
+# ===========================================================================
+# R-9: missing required env vars -> non-zero exit + actionable error
+# ===========================================================================
+echo "--- R-9: missing env -> non-zero exit + mentions AI_RELAY_API_KEY/AI_RELAY_AUTH_TOKEN ---"
+# Capture both stdout+stderr AND the docker run exit code without piping to
+# `head` — a pipeline's $? is the rightmost command's exit, which would
+# always be 0 from `head`. Truncate after the fact with parameter expansion.
+env_out=$(docker run --rm "$IMAGE_TAG" 2>&1)
+env_rc=$?
+env_out_head=$(printf '%s\n' "$env_out" | head -20)
+if [ "$env_rc" -ne 0 ] && printf '%s' "$env_out" | grep -qE "AI_RELAY_API_KEY|AI_RELAY_AUTH_TOKEN"; then
+  pass "R-9 missing env -> exit $env_rc and error mentions required key(s)"
+else
+  fail "R-9 missing env: exit=$env_rc, output:"
+  printf '%s\n' "$env_out_head" | sed 's/^/        /'
+fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "summary: passed=$PASS_COUNT failed=$FAIL_COUNT"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -79,8 +79,19 @@ const isDirectRun =
   typeof process.argv[1] === "string" && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isDirectRun) {
-  serve({ fetch: app.fetch, port: env.AI_RELAY_PORT }, (info) => {
+  const server = serve({ fetch: app.fetch, port: env.AI_RELAY_PORT }, (info) => {
     // Single-line startup log — no secrets, only port + endpoint.
     console.log(`mcp-ai-relay listening on http://localhost:${info.port}/api/mcp`);
   });
+
+  // Container orchestrators (Docker, Kubernetes) send SIGTERM before SIGKILL.
+  // Without an explicit handler the process is killed at the grace-period
+  // boundary (Docker default 10 s) and exits 137. Closing the listener stops
+  // accepting new connections and lets in-flight requests finish.
+  const shutdown = () => {
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 5000).unref();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
 }

--- a/doc/DEPLOY.ko.md
+++ b/doc/DEPLOY.ko.md
@@ -242,6 +242,12 @@ docker run --rm -p 8787:3000 --env-file .env.production mcp-ai-relay
 
 ### 4.3 검증 체크리스트
 
+**배포 전에 `pnpm docker:smoke`를 실행해** 빌드 정합성, 런타임 헬스, distroless 불변
+조건(셸 없음, non-root uid 65532), 이미지 크기 예산을 확인합니다. 회귀가
+발생하면 하네스가 non-zero 종료 — 어설션 카탈로그와 환경변수
+(이미지 태그, 크기 예산, 멀티아치 opt-in)는
+[`app/scripts/README.md`](../app/scripts/README.md) 참고.
+
 HEALTHCHECK:
 
 ```bash

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -162,6 +162,12 @@ defaults.
 
 ### 3.4 Verification checklist
 
+**Before deploying, run `pnpm docker:smoke`** to verify build correctness,
+runtime health, distroless invariants (no shell, non-root uid 65532), and
+the image-size budget. The harness exits non-zero on any regression — see
+[`app/scripts/README.md`](../app/scripts/README.md) for the assertion
+catalog and tunable env vars (image tag, size budget, multi-arch opt-in).
+
 - [ ] `docker compose up -d` (or `docker run`) starts without error.
 - [ ] HEALTHCHECK reports healthy within ~30 s of start:
       ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Examples
+
+Each example ships a committed smoke test that runs without network access
+and ends with `=== PASS ===` on success.
+
+| Example | Pattern | Smoke command |
+|---|---|---|
+| [`stdio/`](./stdio) | Single-tool stdio MCP server for Claude Desktop | `pnpm --filter @example/stdio smoke` |
+| [`multi-upstream/`](./multi-upstream) | One MCP server, multiple OpenAI-compatible upstreams | `pnpm --filter @example/multi-upstream smoke` |
+| [`cloudflare-workers/`](./cloudflare-workers) | Remote MCP over SSE on Workers (`agents/mcp`) | `pnpm --filter @example/cloudflare-workers smoke` |
+| [`vercel/`](./vercel) | Community-supported Vercel deploy recipe | `bash examples/vercel/scripts/smoke.sh` |
+
+Run all of them sequentially from the repo root:
+
+```bash
+pnpm examples:smoke
+```
+
+The Cloudflare Workers smoke needs `wrangler` and is skipped when
+`SKIP_CF_SMOKE=1`; CI sets this because `wrangler dev` is heavy and
+network-bound.

--- a/examples/multi-upstream/README.md
+++ b/examples/multi-upstream/README.md
@@ -55,11 +55,27 @@ time. To prove isolation, switch the `LOCAL_LLM_BASE_URL` mid-test to
 something that always 503s and verify the `openai_chat` tool keeps
 working independently.
 
+## Verification
+
+Run the committed smoke test from the repo root:
+
+```bash
+pnpm --filter @example/multi-upstream smoke
+```
+
+It boots two inline mock OpenAI HTTP servers on distinct ephemeral ports
+(sentinel `from-upstream-A` and `from-upstream-B`), spawns `server.ts`
+wired to mock A via `AI_RELAY_BASE_URL` and to mock B via
+`LOCAL_LLM_BASE_URL`, and asserts that `tools/call openai_chat` and
+`tools/call local_llm` each round-trip the correct sentinel. Ends with
+`=== PASS ===`.
+
 ## Configuration
 
 | Var | Effect |
 |---|---|
 | `AI_RELAY_API_KEY` | Registers `openai_chat` against OpenAI proper |
+| `AI_RELAY_BASE_URL` | Optional base URL override for `openai_chat` |
 | `AZURE_OPENAI_KEY` + `AZURE_AI_RELAY_BASE_URL` | Registers `azure_chat` |
 | `LOCAL_LLM_BASE_URL` | Registers `local_llm` (default ceiling 8192) |
 | `LOCAL_LLM_KEY` | Optional auth for the local LLM endpoint |

--- a/examples/multi-upstream/package.json
+++ b/examples/multi-upstream/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "One MCP server registering multiple upstreams (OpenAI + Azure + local LLM) as distinct tools.",
   "scripts": {
-    "start": "tsx server.ts"
+    "start": "tsx server.ts",
+    "smoke": "bash scripts/smoke.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26",

--- a/examples/multi-upstream/scripts/smoke.mjs
+++ b/examples/multi-upstream/scripts/smoke.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+
+const SENTINEL_A = "from-upstream-A";
+const SENTINEL_B = "from-upstream-B";
+
+function sseFrame(obj) {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+function makeMockOpenAI(sentinel) {
+  return createServer((req, res) => {
+    if (req.method === "POST" && req.url && req.url.endsWith("/chat/completions")) {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        res.write(
+          sseFrame({
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created,
+            model: "gpt-4o-mini",
+            choices: [{ index: 0, delta: { role: "assistant", content: sentinel }, finish_reason: null }],
+          }),
+        );
+        res.write(
+          sseFrame({
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created,
+            model: "gpt-4o-mini",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+      return;
+    }
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+}
+
+async function listen(server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return server.address().port;
+}
+
+class JsonRpcDriver {
+  constructor(child) {
+    this.child = child;
+    this.buffer = "";
+    this.pending = new Map();
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => this.#onData(chunk));
+  }
+
+  #onData(chunk) {
+    this.buffer += chunk;
+    let idx = this.buffer.indexOf("\n");
+    while (idx !== -1) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.length > 0) {
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id !== undefined && this.pending.has(msg.id)) {
+            const resolver = this.pending.get(msg.id);
+            this.pending.delete(msg.id);
+            resolver(msg);
+          }
+        } catch {}
+      }
+      idx = this.buffer.indexOf("\n");
+    }
+  }
+
+  send(payload) {
+    this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  request(method, params, id) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`timeout waiting for ${method} id=${id}`));
+      }, 10_000);
+      this.pending.set(id, (msg) => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+      this.send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  notify(method, params) {
+    this.send({ jsonrpc: "2.0", method, params });
+  }
+}
+
+function fail(id, reason) {
+  console.error(`[smoke] FAIL ${id}: ${reason}`);
+  console.error("[smoke] === FAIL ===");
+  process.exit(1);
+}
+
+async function main() {
+  const mockA = makeMockOpenAI(SENTINEL_A);
+  const mockB = makeMockOpenAI(SENTINEL_B);
+  const portA = await listen(mockA);
+  const portB = await listen(mockB);
+  const baseA = `http://127.0.0.1:${portA}/v1`;
+  const baseB = `http://127.0.0.1:${portB}/v1`;
+  console.error(`[smoke] mock A (openai_chat): ${baseA}`);
+  console.error(`[smoke] mock B (local_llm):   ${baseB}`);
+
+  const exampleDir = new URL("..", import.meta.url).pathname;
+  const child = spawn("pnpm", ["--filter", "@example/multi-upstream", "start"], {
+    env: {
+      ...process.env,
+      AI_RELAY_API_KEY: "test-a",
+      AI_RELAY_BASE_URL: baseA,
+      LOCAL_LLM_BASE_URL: baseB,
+      LOCAL_LLM_KEY: "test-b",
+    },
+    cwd: exampleDir,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const stderrChunks = [];
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (c) => stderrChunks.push(c));
+
+  const cleanup = () => {
+    try {
+      child.kill("SIGTERM");
+    } catch {}
+    try {
+      mockA.close();
+    } catch {}
+    try {
+      mockB.close();
+    } catch {}
+  };
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+
+  let earlyExit = false;
+  child.on("exit", (code, signal) => {
+    earlyExit = true;
+    console.error(`[smoke] child exited code=${code} signal=${signal}`);
+  });
+
+  await delay(1000);
+  if (earlyExit) {
+    console.error("----- child stderr -----");
+    console.error(stderrChunks.join(""));
+    fail("M-1", "child exited before initialize");
+  }
+
+  const driver = new JsonRpcDriver(child);
+  await driver.request(
+    "initialize",
+    {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "smoke", version: "0.0.0" },
+    },
+    1,
+  );
+  driver.notify("notifications/initialized", {});
+
+  // M-1: stderr contains "registered 2 tool(s)."
+  const stderrText = stderrChunks.join("");
+  if (!stderrText.includes("registered 2 tool(s).")) {
+    fail("M-1", `stderr missing 'registered 2 tool(s).'; got: ${stderrText.slice(0, 300)}`);
+  }
+
+  // M-2: tools/list returns openai_chat + local_llm
+  const listResp = await driver.request("tools/list", {}, 2);
+  const toolNames = (listResp.result?.tools ?? []).map((t) => t.name);
+  if (!toolNames.includes("openai_chat") || !toolNames.includes("local_llm")) {
+    fail("M-2", `expected openai_chat + local_llm, got ${toolNames.join(",")}`);
+  }
+
+  // M-3: tools/call openai_chat returns SENTINEL_A
+  const callA = await driver.request(
+    "tools/call",
+    {
+      name: "openai_chat",
+      arguments: { model: "gpt-4o-mini", messages: [{ role: "user", content: "ping" }] },
+    },
+    3,
+  );
+  const textA = (callA.result?.content ?? []).map((c) => c.text ?? "").join("");
+  if (!textA.includes(SENTINEL_A)) {
+    fail("M-3", `openai_chat content missing ${SENTINEL_A}; got: ${textA.slice(0, 200)}`);
+  }
+
+  // M-4: tools/call local_llm returns SENTINEL_B
+  const callB = await driver.request(
+    "tools/call",
+    {
+      name: "local_llm",
+      arguments: { model: "local-model", messages: [{ role: "user", content: "ping" }] },
+    },
+    4,
+  );
+  const textB = (callB.result?.content ?? []).map((c) => c.text ?? "").join("");
+  if (!textB.includes(SENTINEL_B)) {
+    fail("M-4", `local_llm content missing ${SENTINEL_B}; got: ${textB.slice(0, 200)}`);
+  }
+
+  console.error("[smoke] === PASS ===");
+  console.log("=== PASS ===");
+  cleanup();
+  await delay(100);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[smoke] driver error: ${err.stack ?? err}`);
+  console.error("[smoke] === FAIL ===");
+  process.exit(1);
+});

--- a/examples/multi-upstream/scripts/smoke.sh
+++ b/examples/multi-upstream/scripts/smoke.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+exec node "${EXAMPLE_DIR}/scripts/smoke.mjs"

--- a/examples/multi-upstream/server.ts
+++ b/examples/multi-upstream/server.ts
@@ -25,6 +25,7 @@ if (process.env.AI_RELAY_API_KEY) {
   registerOpenAIChat(server, {
     name: "openai_chat",
     apiKey: process.env.AI_RELAY_API_KEY,
+    ...(process.env.AI_RELAY_BASE_URL ? { baseURL: process.env.AI_RELAY_BASE_URL } : {}),
     description: "OpenAI Chat Completions — proper",
   });
   registeredCount++;

--- a/examples/stdio/README.md
+++ b/examples/stdio/README.md
@@ -70,6 +70,19 @@ point `command`/`args` at the compiled file.
 Restart Claude Desktop. The `openai_chat` tool will appear in the
 tools selector.
 
+## Verification
+
+Run the committed smoke test from the repo root:
+
+```bash
+pnpm --filter @example/stdio smoke
+```
+
+It boots an inline mock OpenAI HTTP server, spawns `server.ts` over stdio
+with `AI_RELAY_BASE_URL` pointed at the mock, drives `initialize` →
+`tools/list` → `tools/call openai_chat`, and asserts a sentinel string
+round-trips through the relay. Ends with `=== PASS ===`.
+
 ## Configuration
 
 Environment variables read by `server.ts`:

--- a/examples/stdio/package.json
+++ b/examples/stdio/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Single-tool stdio MCP server for Claude Desktop direct registration.",
   "scripts": {
-    "start": "tsx server.ts"
+    "start": "tsx server.ts",
+    "smoke": "bash scripts/smoke.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26",

--- a/examples/stdio/scripts/smoke.mjs
+++ b/examples/stdio/scripts/smoke.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+
+const SENTINEL = "openai-mock-sentinel-abc123";
+
+function sseFrame(obj) {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+function makeMockOpenAI(sentinel) {
+  return createServer((req, res) => {
+    if (req.method === "POST" && req.url && req.url.endsWith("/chat/completions")) {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        res.write(
+          sseFrame({
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created,
+            model: "gpt-4o-mini",
+            choices: [{ index: 0, delta: { role: "assistant", content: sentinel }, finish_reason: null }],
+          }),
+        );
+        res.write(
+          sseFrame({
+            id: "chatcmpl-mock",
+            object: "chat.completion.chunk",
+            created,
+            model: "gpt-4o-mini",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+      return;
+    }
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+}
+
+function startMockOpenAI() {
+  return makeMockOpenAI(SENTINEL);
+}
+
+async function listen(server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  return port;
+}
+
+class JsonRpcDriver {
+  constructor(child) {
+    this.child = child;
+    this.buffer = "";
+    this.pending = new Map();
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => this.#onData(chunk));
+  }
+
+  #onData(chunk) {
+    this.buffer += chunk;
+    let idx = this.buffer.indexOf("\n");
+    while (idx !== -1) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.length > 0) {
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id !== undefined && this.pending.has(msg.id)) {
+            const resolver = this.pending.get(msg.id);
+            this.pending.delete(msg.id);
+            resolver(msg);
+          }
+        } catch {
+          // Ignore non-JSON output (e.g., stderr leaking — actually stderr is separate).
+        }
+      }
+      idx = this.buffer.indexOf("\n");
+    }
+  }
+
+  send(payload) {
+    this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  request(method, params, id) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`timeout waiting for ${method} id=${id}`));
+      }, 10_000);
+      this.pending.set(id, (msg) => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+      this.send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  notify(method, params) {
+    this.send({ jsonrpc: "2.0", method, params });
+  }
+}
+
+function fail(id, reason) {
+  console.error(`[smoke] FAIL ${id}: ${reason}`);
+  console.error("[smoke] === FAIL ===");
+  process.exit(1);
+}
+
+async function main() {
+  const mock = startMockOpenAI();
+  const port = await listen(mock);
+  const baseURL = `http://127.0.0.1:${port}/v1`;
+  console.error(`[smoke] mock OpenAI listening at ${baseURL}`);
+
+  const exampleDir = new URL("..", import.meta.url).pathname;
+  const child = spawn("pnpm", ["--filter", "@example/stdio", "start"], {
+    env: {
+      ...process.env,
+      AI_RELAY_API_KEY: "test",
+      AI_RELAY_BASE_URL: baseURL,
+    },
+    cwd: exampleDir,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const stderrChunks = [];
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (c) => stderrChunks.push(c));
+
+  const cleanup = () => {
+    try {
+      child.kill("SIGTERM");
+    } catch {}
+    try {
+      mock.close();
+    } catch {}
+  };
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+
+  let earlyExit = false;
+  child.on("exit", (code, signal) => {
+    earlyExit = true;
+    console.error(`[smoke] child exited code=${code} signal=${signal}`);
+  });
+
+  await delay(800);
+
+  // S-1: child alive after startup
+  if (earlyExit) {
+    console.error("----- child stderr -----");
+    console.error(stderrChunks.join(""));
+    fail("S-1", "child exited before driver could send initialize");
+  }
+
+  const driver = new JsonRpcDriver(child);
+
+  // S-2: initialize
+  const initResp = await driver.request(
+    "initialize",
+    {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "smoke", version: "0.0.0" },
+    },
+    1,
+  );
+  if (initResp.result?.serverInfo?.name !== "openai-relay-stdio") {
+    fail(
+      "S-2",
+      `expected serverInfo.name=openai-relay-stdio, got ${JSON.stringify(initResp.result?.serverInfo)}`,
+    );
+  }
+  driver.notify("notifications/initialized", {});
+
+  // S-3: tools/list
+  const listResp = await driver.request("tools/list", {}, 2);
+  const toolNames = (listResp.result?.tools ?? []).map((t) => t.name);
+  if (!toolNames.includes("openai_chat")) {
+    fail("S-3", `tools/list missing openai_chat (got ${toolNames.join(",")})`);
+  }
+
+  // S-4: tools/call openai_chat
+  const callResp = await driver.request(
+    "tools/call",
+    {
+      name: "openai_chat",
+      arguments: {
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "ping" }],
+      },
+    },
+    3,
+  );
+  const content = callResp.result?.content ?? [];
+  const text = content.map((c) => c.text ?? "").join("");
+  if (!text.includes(SENTINEL)) {
+    fail("S-4", `tools/call response did not contain sentinel; got: ${text.slice(0, 200)}`);
+  }
+
+  // S-5: send malformed JSON; child should not crash.
+  child.stdin.write("this is not json\n");
+  await delay(500);
+  if (earlyExit) {
+    console.error("----- child stderr -----");
+    console.error(stderrChunks.join(""));
+    fail("S-5", "child exited after receiving malformed JSON line");
+  }
+
+  console.error("[smoke] === PASS ===");
+  console.log("=== PASS ===");
+  cleanup();
+  await delay(100);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[smoke] driver error: ${err.stack ?? err}`);
+  console.error("[smoke] === FAIL ===");
+  process.exit(1);
+});

--- a/examples/stdio/scripts/smoke.sh
+++ b/examples/stdio/scripts/smoke.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+exec node "${EXAMPLE_DIR}/scripts/smoke.mjs"

--- a/examples/vercel/README.md
+++ b/examples/vercel/README.md
@@ -62,6 +62,21 @@ vercel deploy --prod
 Set `AI_RELAY_API_KEY` and `AI_RELAY_AUTH_TOKEN` as Vercel
 environment variables before the first deploy.
 
+## Verification
+
+Run the committed smoke test from the repo root:
+
+```bash
+bash examples/vercel/scripts/smoke.sh
+```
+
+It validates that `vercel.json` parses as JSON and that this README
+neither references dropped env-var or package names from the pre-SDK
+era nor drifts away from the current SDK surface (`ai-relay`,
+`ai-relay/openai`, `registerOpenAIChat`, `verifyBearer`, `loadConfig`).
+The exact dropped-name list lives in `scripts/smoke.sh`. Ends with
+`=== PASS ===`.
+
 ## Why this is community-supported
 
 The Vercel target is no longer covered by this repository's CI or

--- a/examples/vercel/scripts/smoke.sh
+++ b/examples/vercel/scripts/smoke.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$EXAMPLE_DIR"
+
+fail=0
+
+# V-1: vercel.json is valid JSON.
+echo "[smoke] V-1: vercel.json parses as JSON"
+if ! node -e "JSON.parse(require('node:fs').readFileSync('vercel.json','utf8'))"; then
+  echo "[smoke] FAIL V-1: vercel.json is not valid JSON"
+  fail=1
+fi
+
+# V-2: README does not reference dropped APIs.
+echo "[smoke] V-2: README has no dropped API references"
+README="README.md"
+for pattern in "OPENAI_API_KEY" "mcp-ai-relay" "@ragingwind/mcp-ai-relay"; do
+  if grep -F -q "${pattern}" "${README}"; then
+    echo "[smoke] FAIL V-2: README contains dropped reference '${pattern}'"
+    fail=1
+  fi
+done
+
+# V-3: README references the current SDK surface.
+echo "[smoke] V-3: README references current SDK surface"
+for required in "ai-relay" "ai-relay/openai" "registerOpenAIChat" "verifyBearer" "loadConfig"; do
+  if ! grep -F -q "${required}" "${README}"; then
+    echo "[smoke] FAIL V-3: README missing '${required}'"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "[smoke] === FAIL ==="
+  exit 1
+fi
+
+echo "[smoke] === PASS ==="

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "dev": "node scripts/check-dev-env.mjs && pnpm -r --filter ai-relay build && pnpm -F app dev",
+    "docker:smoke": "bash app/scripts/docker-smoke.sh",
     "build": "pnpm -r build",
     "build:sdk": "pnpm --filter ai-relay build",
     "start": "pnpm -F app start",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "test:integration": "pnpm --filter ai-relay build && vitest run --project integration --passWithNoTests",
     "verify": "node --env-file-if-exists=.env.local scripts/verify.mjs",
     "inspect": "node --env-file-if-exists=.env.local scripts/mcp-inspect.mjs",
-    "check-env": "node --env-file-if-exists=.env.local scripts/check-dev-env.mjs"
+    "check-env": "node --env-file-if-exists=.env.local scripts/check-dev-env.mjs",
+    "check-readme-parity": "node scripts/check-readme-parity.mjs",
+    "test:runtime": "node scripts/test-runtime.mjs"
   },
   "dependencies": {
     "ai-relay": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "inspect": "node --env-file-if-exists=.env.local scripts/mcp-inspect.mjs",
     "check-env": "node --env-file-if-exists=.env.local scripts/check-dev-env.mjs",
     "check-readme-parity": "node scripts/check-readme-parity.mjs",
+    "examples:smoke": "node scripts/examples-smoke.mjs",
     "test:runtime": "node scripts/test-runtime.mjs"
   },
   "dependencies": {

--- a/packages/ai-relay/COMPATIBILITY.md
+++ b/packages/ai-relay/COMPATIBILITY.md
@@ -1,0 +1,49 @@
+# `ai-relay` Runtime Compatibility
+
+Last updated: see `git log -1 --format=%ad -- COMPATIBILITY.md`.
+
+## Supported runtimes
+
+| Runtime | Minimum version | Notes |
+|---|---|---|
+| Node.js | **20.10.0** | The `engines.node` field is `>=20`; the workspace pins `>=20.10.0 <21.0.0` for active development, but the SDK itself runs on every Node 20+ minor in CI. |
+| Node.js (LTS / current) | 20.x, 22.x, 24.x | Smoke-tested per minor in `.github/workflows/runtime-matrix.yml`. |
+| Bun | latest stable | Smoke-tested in CI with `oven-sh/setup-bun@v2`. |
+| Cloudflare Workers | with `nodejs_compat` | Required for `AsyncLocalStorage` (request-scope error redaction). Without it, the SDK runs but the 5xx upstream-body redaction silently no-ops. |
+| Deno | not officially supported | Likely works via the `npm:` specifier — untested. |
+
+## Module format
+
+- **ESM-only.** The published `exports` map has only an `import` condition;
+  there is no `require` condition.
+- A `require('ai-relay')` call from CommonJS code is expected to fail with
+  `ERR_REQUIRE_ESM` on Node < 22. On Node 22+ with `require(esm)` enabled,
+  the call may succeed and the documented shape is preserved. Both outcomes
+  are validated by `tests/runtime-fixtures/cjs-require/smoke.cjs`.
+- TypeScript consumers must use `moduleResolution: "bundler"` or
+  `moduleResolution: "nodenext"`. Both are validated against the packed
+  tarball by `packages/ai-relay/tests/integration/pack-contract.test.ts`.
+
+## Public subpaths
+
+| Subpath | Source | Exports |
+|---|---|---|
+| `ai-relay` | `dist/index.js` | `verifyBearer`, `loadConfig`, types |
+| `ai-relay/openai` | `dist/openai/index.js` | `registerOpenAIChat`, `makeOpenAIChatHandler`, `mapOpenAIError`, `createOpenAIClient`, `openAIChatTool` + types |
+| `ai-relay/env` | `dist/config.js` | `loadConfig` + config types |
+| `ai-relay/auth` | `dist/auth.js` | `verifyBearer` |
+
+The root `ai-relay` is intentionally a thin re-export of the common surface.
+Heavier provider-specific code lives under its own subpath.
+
+## Side-effect freeness at import time
+
+- No top-level `process.env` reads.
+- No globals patched.
+- No fetch / network activity at module load.
+- Snapshot-asserted by `tests/runtime-fixtures/smoke-node/smoke.mjs`.
+
+## Adding a new runtime
+
+See `tests/runtime-fixtures/README.md` for the per-cell smoke fixture
+template and the CI workflow contract.

--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -314,6 +314,11 @@ limited to `node:async_hooks`.
 
 ---
 
+## Testing
+
+CLI spawn-harness coverage (real subprocess + mocked upstream) lives in
+[`tests/cli/README.md`](./tests/cli/README.md).
+
 ## License
 
 MIT.

--- a/packages/ai-relay/package.json
+++ b/packages/ai-relay/package.json
@@ -15,6 +15,14 @@
     "./openai": {
       "types": "./dist/openai/index.d.ts",
       "import": "./dist/openai/index.js"
+    },
+    "./env": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js"
+    },
+    "./auth": {
+      "types": "./dist/auth.d.ts",
+      "import": "./dist/auth.js"
     }
   },
   "bin": {

--- a/packages/ai-relay/tests/cli/README.md
+++ b/packages/ai-relay/tests/cli/README.md
@@ -1,0 +1,90 @@
+# CLI spawn harness
+
+Real-subprocess test coverage for the `ai-relay` one-shot CLI
+(`packages/ai-relay/src/bin/run.ts` → built to `dist/bin/cli.js`).
+
+## One-shot vs stdio MCP
+
+The bin is intentionally **one-shot**: parse argv → read stdin once →
+invoke the tool handler → write JSON to stdout → exit. It does NOT
+speak the long-lived stdio MCP protocol. See
+`packages/ai-relay/README.md:82-88` and `examples/stdio/server.ts`
+for the long-lived stdio pattern.
+
+These tests verify behavior in the same shape as a real user pipeline
+(`echo … | ai-relay openai chat -m gpt-4o-mini`) by spawning the
+compiled bin under `node` and feeding it through OS pipes. MSW cannot
+intercept requests from a spawned child, so a local HTTP server in
+`mock-openai.ts` stands in for the OpenAI API and is selected via
+`AI_RELAY_BASE_URL`.
+
+## Files
+
+- `spawn-harness.ts` — small wrapper around `child_process.spawn`. Hides
+  the build-on-first-call dance, sanitizes `AI_RELAY_*` out of the
+  parent env, supports chunked stdin and signal injection, enforces a
+  hard timeout that escalates to `SIGKILL`.
+- `mock-openai.ts` — kernel-assigned-port HTTP server that records
+  requests and lets a test set per-case responses (status, body, delay,
+  hang).
+- `spawn.test.ts` — happy paths (H-\*), error/exit-code mapping (E-\*),
+  argv/env handling (A-\*), and lifecycle/secret cases (R-\*).
+
+## Harness API
+
+```ts
+import { runCli } from "./spawn-harness.js";
+import { startMockOpenAI, defaultSseBody } from "./mock-openai.js";
+
+const mock = await startMockOpenAI();
+mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
+
+const r = await runCli({
+  args: ["openai", "chat", "-m", "gpt-4o-mini", "ping"],
+  env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+});
+// r: { status, signal, stdout, stderr, durationMs }
+```
+
+`SpawnOpts` also supports `input` (one-shot stdin write), `inputStream`
+(chunked), `killAfterMs` + `killSignal`, and `timeoutMs` (default
+10 s; on expiry the child is `SIGKILL`-ed and `status === null`).
+
+## Adding a test
+
+1. Pick a behavior zone (happy / edge / error / lifecycle).
+2. Reset `mock.requests` and call `mock.setResponse(...)` for the
+   case-specific upstream behavior.
+3. Call `runCli` with `args` + `env`. Assert on `r.status`, parsed
+   `r.stdout`, and `r.stderr`.
+4. Never assert on `toBeTruthy()` alone — assert exact codes, exact
+   substrings, and exact JSON shape.
+
+## Why not MSW for the bin
+
+MSW patches `globalThis.fetch` in the test process. A spawned child has
+its own process and its own `fetch`, so MSW handlers never see the
+child's requests. The local HTTP server is the simplest deterministic
+substitute.
+
+## Divergence from issue body
+
+- **Error codes use underscores, not hyphens.** The actual mapping in
+  `packages/ai-relay/src/openai/chat.ts:130-170` returns `auth`,
+  `rate_limited`, `bad_request`, `upstream_error`, `context_length`,
+  `content_policy`. The issue body suggested hyphenated forms
+  (`rate-limited`, `upstream-server-error`); tests assert the real
+  underscore-form codes.
+- **No dedicated `timeout` error code.** Request timeouts surface as
+  an `OpenAI.APIError` with no status, which maps to `upstream_error`
+  (`chat.ts:162-164`). E-4 asserts that.
+- **E-7 exits 1, not 2.** `schema.parse` runs inside the handler
+  before the `runOnce` try/catch. A `ZodError` propagates up through
+  `run()` (no try/catch around `bundle.handler(...)` in `run.ts:163`)
+  and is caught by the top-level `.then(..., err => process.exit(1))`
+  in `cli.ts:13-16`. The error message is written to stderr by the
+  same handler. Test asserts status 1 and that the ZodError surfaces.
+- **H-4 / H-5 are negative assertions.** `parse.ts:37-45` enumerates
+  the value flags — `--name` and `--description` are not in the set,
+  so they exit 2 with `unknown flag: --<key>`. Tests document this as
+  the current contract.

--- a/packages/ai-relay/tests/cli/mock-openai.ts
+++ b/packages/ai-relay/tests/cli/mock-openai.ts
@@ -1,0 +1,100 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+export interface RecordedRequest {
+  authorization: string | undefined;
+  body: Record<string, unknown>;
+  rawBody: string;
+}
+
+export interface MockResponse {
+  status: number;
+  body: string;
+  delayMs?: number;
+  hang?: boolean;
+}
+
+export interface MockOpenAI {
+  url: string;
+  baseURL: string;
+  requests: RecordedRequest[];
+  setResponse(handler: (req: RecordedRequest) => MockResponse): void;
+  close(): Promise<void>;
+}
+
+export function defaultSseBody(text: string): string {
+  return [
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text }, finish_reason: "stop" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ].join("");
+}
+
+export async function startMockOpenAI(): Promise<MockOpenAI> {
+  const recorded: RecordedRequest[] = [];
+  let responder: (req: RecordedRequest) => MockResponse = () => ({
+    status: 200,
+    body: defaultSseBody("ok"),
+  });
+
+  const httpServer: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const text = Buffer.concat(chunks).toString("utf8");
+      let body: Record<string, unknown> = {};
+      try {
+        body = JSON.parse(text) as Record<string, unknown>;
+      } catch {
+        body = {};
+      }
+      const recordedReq: RecordedRequest = {
+        authorization: req.headers.authorization,
+        body,
+        rawBody: text,
+      };
+      recorded.push(recordedReq);
+      const out = responder(recordedReq);
+
+      const send = () => {
+        if (out.hang) return;
+        res.statusCode = out.status;
+        if (out.status === 200) {
+          res.setHeader("content-type", "text/event-stream");
+        } else {
+          res.setHeader("content-type", "application/json");
+        }
+        res.end(out.body);
+      };
+
+      if (out.delayMs && out.delayMs > 0) {
+        setTimeout(send, out.delayMs);
+      } else {
+        send();
+      }
+    });
+  });
+
+  await new Promise<void>((resolveListen) => {
+    httpServer.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("listen failed");
+  const url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    baseURL: `${url}/v1`,
+    requests: recorded,
+    setResponse(h) {
+      responder = h;
+    },
+    async close() {
+      httpServer.closeAllConnections?.();
+      await new Promise<void>((r, j) => httpServer.close((e) => (e ? j(e) : r())));
+    },
+  };
+}

--- a/packages/ai-relay/tests/cli/spawn-harness.ts
+++ b/packages/ai-relay/tests/cli/spawn-harness.ts
@@ -1,0 +1,147 @@
+import { type ChildProcessWithoutNullStreams, execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SDK_DIR = resolve(__dirname, "..", "..");
+const BIN_PATH = resolve(SDK_DIR, "dist", "bin", "cli.js");
+
+let buildPromise: Promise<void> | null = null;
+
+export interface SpawnResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+export interface SpawnOpts {
+  args: readonly string[];
+  env?: Record<string, string | undefined>;
+  input?: string;
+  inputStream?: (stdin: NodeJS.WritableStream) => Promise<void>;
+  killAfterMs?: number;
+  killSignal?: NodeJS.Signals;
+  timeoutMs?: number;
+}
+
+export function getBinPath(): string {
+  return BIN_PATH;
+}
+
+export async function ensureBuilt(): Promise<void> {
+  if (existsSync(BIN_PATH)) return;
+  if (!buildPromise) {
+    buildPromise = (async () => {
+      execFileSync("pnpm", ["--filter", "ai-relay", "build"], {
+        cwd: resolve(SDK_DIR, "..", ".."),
+        stdio: "pipe",
+      });
+    })();
+  }
+  await buildPromise;
+}
+
+function sanitizedEnv(overrides?: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const base: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("AI_RELAY_")) continue;
+    base[k] = v;
+  }
+  if (overrides) {
+    for (const [k, v] of Object.entries(overrides)) {
+      base[k] = v;
+    }
+  }
+  return base as NodeJS.ProcessEnv;
+}
+
+function writeInput(child: ChildProcessWithoutNullStreams, opts: SpawnOpts): Promise<void> {
+  if (opts.input !== undefined) {
+    return new Promise<void>((resolveWrite, rejectWrite) => {
+      child.stdin.on("error", rejectWrite);
+      child.stdin.end(opts.input, () => resolveWrite());
+    });
+  }
+  if (opts.inputStream) {
+    return opts.inputStream(child.stdin).then(
+      () =>
+        new Promise<void>((resolveEnd, rejectEnd) => {
+          child.stdin.on("error", rejectEnd);
+          child.stdin.end(() => resolveEnd());
+        }),
+    );
+  }
+  return new Promise<void>((resolveEnd, rejectEnd) => {
+    child.stdin.on("error", rejectEnd);
+    child.stdin.end(() => resolveEnd());
+  });
+}
+
+export async function runCli(opts: SpawnOpts): Promise<SpawnResult> {
+  await ensureBuilt();
+
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const start = performance.now();
+
+  return new Promise<SpawnResult>((resolvePromise, rejectPromise) => {
+    const child = spawn("node", [BIN_PATH, ...opts.args], {
+      env: sanitizedEnv(opts.env),
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessWithoutNullStreams;
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    child.stdout.on("data", (c: Buffer) => {
+      stdout += c.toString("utf8");
+    });
+    child.stderr.on("data", (c: Buffer) => {
+      stderr += c.toString("utf8");
+    });
+
+    const hardTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    let killTimer: NodeJS.Timeout | undefined;
+    if (opts.killAfterMs !== undefined) {
+      killTimer = setTimeout(() => {
+        child.kill(opts.killSignal ?? "SIGTERM");
+      }, opts.killAfterMs);
+    }
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(hardTimer);
+      if (killTimer) clearTimeout(killTimer);
+      rejectPromise(err);
+    });
+
+    child.on("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(hardTimer);
+      if (killTimer) clearTimeout(killTimer);
+      const durationMs = performance.now() - start;
+      resolvePromise({
+        status: timedOut ? null : code,
+        signal: timedOut ? "SIGKILL" : signal,
+        stdout,
+        stderr,
+        durationMs,
+      });
+    });
+
+    writeInput(child, opts).catch(() => {
+      // EPIPE on closed stdin is expected for negative-path tests.
+    });
+  });
+}

--- a/packages/ai-relay/tests/cli/spawn.test.ts
+++ b/packages/ai-relay/tests/cli/spawn.test.ts
@@ -1,0 +1,327 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { defaultSseBody, type MockOpenAI, startMockOpenAI } from "./mock-openai.js";
+import { ensureBuilt, runCli } from "./spawn-harness.js";
+
+let mock: MockOpenAI;
+
+beforeAll(async () => {
+  await ensureBuilt();
+  mock = await startMockOpenAI();
+}, 180_000);
+
+afterAll(async () => {
+  if (mock) await mock.close();
+});
+
+beforeEach(() => {
+  mock.requests.length = 0;
+  mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
+});
+
+function happyEnv(): Record<string, string> {
+  return { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL };
+}
+
+describe("A: Positive — Happy Path Scenarios", () => {
+  it("H-1: positional plain text against mocked upstream → exit 0", async () => {
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "ping"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(false);
+    expect(out.content[0].text).toBe("hello world");
+    expect(out.structuredContent.model).toBe("gpt-4o-mini");
+  });
+
+  it("H-2: stdin JSON → exit 0 + result on stdout", async () => {
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("hi back") }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      input: '{"messages":[{"role":"user","content":"hi"}]}',
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(false);
+    expect(Array.isArray(out.content)).toBe(true);
+    expect(typeof out.content[0].text).toBe("string");
+  });
+
+  it("H-3: positional plain text desugared into messages[role=user]", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    expect(mock.requests).toHaveLength(1);
+    expect(mock.requests[0]?.body).toMatchObject({
+      messages: [{ role: "user", content: "hi" }],
+    });
+  });
+
+  it("H-4: --name flag is NOT supported → exit 2", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--name", "foo", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/unknown flag: --name/);
+  });
+
+  it("H-5: --description flag is NOT supported → exit 2", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--description", "x", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/unknown flag: --description/);
+  });
+});
+
+describe("C: Negative — Error / Exit Codes", () => {
+  it("E-1: upstream 401 → exit 1 + isError + code 'auth'", async () => {
+    mock.setResponse(() => ({
+      status: 401,
+      body: JSON.stringify({ error: { message: "no auth" } }),
+    }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("auth");
+  });
+
+  it("E-2: upstream 429 → exit 1 + code 'rate_limited'", async () => {
+    mock.setResponse(() => ({
+      status: 429,
+      body: JSON.stringify({ error: { message: "slow down" } }),
+    }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("rate_limited");
+  });
+
+  it("E-3: upstream 500 → exit 1 + code 'upstream_error'", async () => {
+    mock.setResponse(() => ({
+      status: 500,
+      body: JSON.stringify({ error: { message: "boom" } }),
+    }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("E-4: --timeout exceeded → exit 1 + code 'upstream_error'", async () => {
+    mock.setResponse(() => ({ status: 200, body: "", hang: true }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--timeout", "200", "hi"],
+      env: happyEnv(),
+      timeoutMs: 5_000,
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("E-5: connection refused → exit 1 + isError + code 'upstream_error'", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: "http://127.0.0.1:1/v1" },
+      timeoutMs: 10_000,
+    });
+    expect(r.status).toBe(1);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(true);
+    expect(out.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("E-6: invalid JSON on stdin (leading '{') → exit 2 + 'not valid JSON' on stderr", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      input: "{not-valid-json",
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("not valid JSON");
+  });
+
+  it("E-7: messages is not an array → exit 1 + ZodError on stderr", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      input: '{"messages":"not-an-array"}',
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/ZodError|Invalid input|messages/i);
+  });
+});
+
+describe("B: Argv / Env handling", () => {
+  it("A-1: no args → exit 2 + usage on stderr", async () => {
+    const r = await runCli({ args: [], env: {} });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/usage:|--model|provider/i);
+  });
+
+  it("A-2: unknown provider/tool → exit 2", async () => {
+    const r = await runCli({
+      args: ["nope", "chat", "-m", "x", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("unknown nope/chat");
+  });
+
+  it("A-3: openai chat without AI_RELAY_API_KEY → exit 2 mentioning apiKey", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: {},
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("apiKey");
+  });
+
+  it("A-4: --help → exit 0 + 'Usage: ai-relay' on stdout + no upstream call", async () => {
+    const before = mock.requests.length;
+    const r = await runCli({ args: ["--help"], env: {} });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("Usage: ai-relay");
+    expect(mock.requests.length).toBe(before);
+  });
+
+  it("A-5: --version → exit 0 + semver on stdout", async () => {
+    const r = await runCli({ args: ["--version"], env: {} });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("A-6: env-only happy path (no flags besides -m) → exit 0", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.isError).toBe(false);
+  });
+});
+
+describe("D: Resilience / Lifecycle", () => {
+  it("R-1: closed stdin + no positional → exit 2 within 1 s", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      timeoutMs: 1_000,
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/empty stdin|requires input/);
+    expect(r.durationMs).toBeLessThan(1_000);
+  });
+
+  it("R-2: SIGTERM during slow upstream → child exits within 2 s", async () => {
+    mock.setResponse(() => ({ status: 200, body: "", hang: true }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+      killAfterMs: 200,
+      killSignal: "SIGTERM",
+      timeoutMs: 5_000,
+    });
+    const terminated = r.signal === "SIGTERM" || (r.status !== null && r.status !== 0);
+    expect(terminated).toBe(true);
+    expect(r.durationMs).toBeLessThan(3_000);
+  });
+
+  it("R-3: SIGINT during slow upstream → child exits within 2 s", async () => {
+    mock.setResponse(() => ({ status: 200, body: "", hang: true }));
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+      killAfterMs: 200,
+      killSignal: "SIGINT",
+      timeoutMs: 5_000,
+    });
+    const terminated = r.signal === "SIGINT" || (r.status !== null && r.status !== 0);
+    expect(terminated).toBe(true);
+    expect(r.durationMs).toBeLessThan(3_000);
+  });
+
+  it("R-4: stdout is JSON-only, stderr is not JSON", async () => {
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(0);
+    expect(() => JSON.parse(r.stdout.trim())).not.toThrow();
+    const lines = r.stdout.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    if (r.stderr.trim().length > 0) {
+      expect(() => JSON.parse(r.stderr.trim())).toThrow();
+    }
+  });
+
+  it("R-5: ~64 KB JSON input via chunked stdin → upstream receives full content", async () => {
+    const big = "x".repeat(64 * 1024);
+    const payload = JSON.stringify({ messages: [{ role: "user", content: big }] });
+    let seenLen = 0;
+    mock.setResponse((req) => {
+      const messages = (req.body as { messages?: Array<{ content?: string }> }).messages;
+      seenLen = messages?.[0]?.content?.length ?? 0;
+      return { status: 200, body: defaultSseBody("ok") };
+    });
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini"],
+      env: happyEnv(),
+      inputStream: async (stdin) => {
+        const chunkSize = 8 * 1024;
+        for (let i = 0; i < payload.length; i += chunkSize) {
+          const chunk = payload.slice(i, i + chunkSize);
+          await new Promise<void>((resolveWrite, rejectWrite) => {
+            stdin.write(chunk, (err) => (err ? rejectWrite(err) : resolveWrite()));
+          });
+        }
+      },
+      timeoutMs: 15_000,
+    });
+    expect(r.status).toBe(0);
+    expect(seenLen).toBe(big.length);
+  });
+
+  it("R-6a: failing --env path does not echo AI_RELAY_API_KEY", async () => {
+    const canary = "leak-canary-XYZ";
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "--env", "/no/such.env", "hi"],
+      env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r.status).toBe(2);
+    expect(r.stdout).not.toContain(canary);
+    expect(r.stderr).not.toContain(canary);
+  });
+
+  it("R-6b: happy path does not echo AI_RELAY_API_KEY on stderr", async () => {
+    const canary = "leak-canary-HAPPY";
+    const r = await runCli({
+      args: ["openai", "chat", "-m", "gpt-4o-mini", "hi"],
+      env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain(canary);
+  });
+});

--- a/packages/ai-relay/tests/integration/bin-tarball.test.ts
+++ b/packages/ai-relay/tests/integration/bin-tarball.test.ts
@@ -231,4 +231,37 @@ describe("ai-relay bin — installed tarball", () => {
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   });
+
+  it("T-1: full one-shot round-trip — positional, stdin JSON, plain text", async () => {
+    mock.requests.length = 0;
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
+
+    const r1 = await runBin(["openai", "chat", "-m", "gpt-4o-mini", "ping"], {
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r1.status).toBe(0);
+    const out1 = JSON.parse(r1.stdout.trim());
+    expect(out1.isError).toBe(false);
+    expect(out1.content[0].text).toBe("hello world");
+
+    mock.requests.length = 0;
+    mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
+    const r2 = await runBin(["openai", "chat", "-m", "gpt-4o-mini"], {
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+      input: '{"messages":[{"role":"user","content":"hi"}]}',
+    });
+    expect(r2.status).toBe(0);
+    expect(mock.requests[0]?.body).toMatchObject({
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    mock.requests.length = 0;
+    const r3 = await runBin(["openai", "chat", "-m", "gpt-4o-mini", "plain-text-input"], {
+      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+    });
+    expect(r3.status).toBe(0);
+    expect(mock.requests[0]?.body).toMatchObject({
+      messages: [{ role: "user", content: "plain-text-input" }],
+    });
+  });
 });

--- a/packages/ai-relay/tests/integration/pack-contract.test.ts
+++ b/packages/ai-relay/tests/integration/pack-contract.test.ts
@@ -1,0 +1,178 @@
+// Publish-contract integration tests for the `ai-relay` tarball.
+//
+// Runs `pnpm pack` (or `npm pack` — both produce the same tarball layout)
+// and asserts:
+//   - A1/A5: allowlist of files in the tarball; nothing outside dist/, README,
+//     LICENSE, package.json.
+//   - A2: each documented subpath imports cleanly from the installed tarball.
+//   - A3/A4: types resolve under `moduleResolution: "bundler"` and `"nodenext"`.
+//   - A6: LICENSE is present.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SDK_DIR = resolve(__dirname, "..", "..");
+const REPO_ROOT = resolve(SDK_DIR, "..", "..");
+
+const ALLOWED_TOP_LEVEL = new Set(["package.json", "README.md", "LICENSE"]);
+const FORBIDDEN_PATTERNS = [
+  /(^|\/)\.env(\..+)?$/,
+  /\.(spec|test)\.[mc]?[jt]sx?$/,
+  /\.tsbuildinfo$/,
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)src(\/|$)/,
+];
+
+let tarball: string;
+let scratchDir: string;
+
+function listTarballEntries(tarPath: string): string[] {
+  const out = execFileSync("tar", ["-tzf", tarPath], { encoding: "utf8" });
+  return out
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function pack(destDir: string): string {
+  // Pack into an isolated dir so this test never races with
+  // bin-tarball.test.ts (which packs into SDK_DIR and rms its tarball).
+  execFileSync("npm", ["pack", "--pack-destination", destDir], {
+    cwd: SDK_DIR,
+    stdio: "pipe",
+  });
+  const tarballs = readdirSync(destDir).filter((f) => f.endsWith(".tgz"));
+  if (tarballs.length !== 1 || !tarballs[0]) {
+    throw new Error(
+      `Expected exactly 1 tarball after npm pack, got ${tarballs.length}: ${tarballs.join(", ")}`,
+    );
+  }
+  return join(destDir, tarballs[0]);
+}
+
+beforeAll(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), "ai-relay-pack-"));
+  tarball = pack(scratchDir);
+}, 180_000);
+
+afterAll(() => {
+  if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe("pack contract — tarball layout", () => {
+  it("A1/A5: tarball only contains dist/**, package.json, README.md, LICENSE", () => {
+    const entries = listTarballEntries(tarball);
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const rawEntry of entries) {
+      // npm pack prefixes every entry with `package/`. Strip it.
+      const entry = rawEntry.replace(/^package\//, "");
+      // Skip directory entries (trailing slash).
+      if (entry === "" || entry.endsWith("/")) continue;
+
+      const top = entry.split("/")[0];
+      const isAllowedTop = top !== undefined && ALLOWED_TOP_LEVEL.has(top);
+      const isDist = entry.startsWith("dist/");
+      expect(isAllowedTop || isDist, `unexpected file in tarball: ${entry}`).toBe(true);
+
+      for (const pat of FORBIDDEN_PATTERNS) {
+        expect(pat.test(entry), `forbidden pattern matched ${entry} (${pat})`).toBe(false);
+      }
+    }
+  });
+
+  it("A6: tarball contains LICENSE", () => {
+    const entries = listTarballEntries(tarball);
+    const hasLicense = entries.some((e) => e === "package/LICENSE");
+    expect(hasLicense).toBe(true);
+  });
+});
+
+describe("pack contract — installed-tarball imports", () => {
+  it("A2: each subpath import resolves and exposes its documented exports", () => {
+    const installDir = join(scratchDir, "import-check");
+    execFileSync("mkdir", ["-p", installDir]);
+    writeFileSync(
+      join(installDir, "package.json"),
+      JSON.stringify({ name: "pack-import-check", private: true, type: "module" }),
+    );
+    execFileSync("npm", ["install", "--no-audit", "--no-fund", tarball], {
+      cwd: installDir,
+      stdio: "pipe",
+    });
+
+    const script = `
+      import * as root from "ai-relay";
+      import * as env from "ai-relay/env";
+      import * as auth from "ai-relay/auth";
+      import * as openai from "ai-relay/openai";
+      const ok =
+        typeof root.verifyBearer === "function" &&
+        typeof root.loadConfig === "function" &&
+        typeof env.loadConfig === "function" &&
+        typeof auth.verifyBearer === "function" &&
+        typeof openai.registerOpenAIChat === "function" &&
+        typeof openai.makeOpenAIChatHandler === "function";
+      console.log(ok ? "EXPORTS_OK" : "EXPORTS_MISSING");
+    `;
+    const out = execFileSync("node", ["--input-type=module", "-e", script], {
+      cwd: installDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    expect(out.trim()).toBe("EXPORTS_OK");
+  }, 120_000);
+});
+
+describe("pack contract — typecheck under bundler + nodenext", () => {
+  // Each fixture lives under `tests/runtime-fixtures/typecheck-*`. We copy it
+  // to a temp dir, install the tarball, install typescript, and run tsc.
+  function runTypecheck(fixtureDir: string): void {
+    const tmp = join(scratchDir, `tc-${fixtureDir.split("/").pop()}`);
+    execFileSync("cp", ["-R", fixtureDir, tmp]);
+
+    // Install ai-relay (from tarball) + typescript in ONE invocation. A
+    // second `npm install --no-save <X>` would treat the prior unsaved
+    // ai-relay install as extraneous and prune it.
+    execFileSync(
+      "npm",
+      ["install", "--no-audit", "--no-fund", "--no-save", tarball, "typescript@^6.0.3"],
+      { cwd: tmp, stdio: "pipe" },
+    );
+
+    try {
+      execFileSync("npx", ["tsc", "--noEmit"], {
+        cwd: tmp,
+        stdio: "pipe",
+      });
+    } catch (err: unknown) {
+      const e = err as { stdout?: Buffer | string; stderr?: Buffer | string };
+      const out = (e.stdout ? e.stdout.toString() : "") + (e.stderr ? e.stderr.toString() : "");
+      throw new Error(`tsc failed in ${tmp}:\n${out}`);
+    }
+  }
+
+  it("A3: types resolve under moduleResolution=bundler", () => {
+    runTypecheck(join(REPO_ROOT, "tests", "runtime-fixtures", "typecheck-bundler"));
+  }, 180_000);
+
+  it("A4: types resolve under moduleResolution=nodenext", () => {
+    runTypecheck(join(REPO_ROOT, "tests", "runtime-fixtures", "typecheck-nodenext"));
+  }, 180_000);
+});
+
+describe("pack contract — README parity", () => {
+  // Sanity check that the package's README is included and non-empty.
+  it("README is present and references the SDK", () => {
+    const tmp = join(scratchDir, "readme-check");
+    execFileSync("mkdir", ["-p", tmp]);
+    execFileSync("tar", ["-xzf", tarball, "-C", tmp]);
+    const readme = readFileSync(join(tmp, "package", "README.md"), "utf8");
+    expect(readme.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ai-relay/tests/setup-env.ts
+++ b/packages/ai-relay/tests/setup-env.ts
@@ -1,3 +1,10 @@
+// Clear leaked upstream envs so MSW handlers and mock-openai fixtures
+// reliably intercept. Without this, a developer who has OPENAI_BASE_URL /
+// OPENAI_API_KEY exported in their shell will see the OpenAI SDK target
+// the leaked URL and MSW handlers will stop firing.
+delete process.env.OPENAI_API_KEY;
+delete process.env.OPENAI_BASE_URL;
+
 // Seeds process.env with minimal valid values BEFORE lib/env.ts loads in tests.
 // `??=` so an externally provided value (CI secret) is not overwritten.
 process.env.AI_RELAY_API_KEY ??= "test-ai-relay-api-key";

--- a/packages/ai-relay/tests/unit/chat-stream-edge.test.ts
+++ b/packages/ai-relay/tests/unit/chat-stream-edge.test.ts
@@ -1,0 +1,89 @@
+// Stream edge cases for the OpenAI chat handler.
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { type MockHandle, startMockOpenAI } from "../../../../tests/fixtures/mock-openai/index.js";
+import { makeOpenAIChatHandler } from "../../src/openai/chat.js";
+
+const mswServer = setupServer();
+// `bypass` (not `"error"`) — the chunk-boundary suite below routes its
+// requests to a real 127.0.0.1 server, which MSW must let through.
+beforeAll(() => mswServer.listen({ onUnhandledRequest: "bypass" }));
+afterEach(() => mswServer.resetHandlers());
+afterAll(() => mswServer.close());
+
+const ENDPOINT = "https://api.openai.com/v1/chat/completions";
+const VALID_MODEL = "gpt-4o-mini";
+const VALID_MESSAGES = [{ role: "user" as const, content: "ping" }];
+
+describe("openai chat — stream mid-error (C-3)", () => {
+  it("D1: maps mid-stream socket failure to upstream_error", async () => {
+    mswServer.use(
+      http.post(ENDPOINT, () => {
+        const encoder = new TextEncoder();
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ choices: [{ delta: { content: "par" } }] })}\n\n`,
+              ),
+            );
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ choices: [{ delta: { content: "tial" } }] })}\n\n`,
+              ),
+            );
+            // Force-error the stream WITHOUT writing [DONE].
+            setTimeout(() => controller.error(new Error("network reset")), 5);
+          },
+        });
+        return new HttpResponse(body, {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+
+    const { handler } = makeHandler();
+    const result = await handler({ model: VALID_MODEL, messages: VALID_MESSAGES });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    // Document the SDK's actual partial-content behavior. The current
+    // OpenAI Node SDK discards in-progress accumulation when the stream
+    // errors mid-flight — the catch in runOnce builds a fresh result from
+    // mapOpenAIError, so `content[0].text` is the mapped error message,
+    // NOT the partial deltas. Asserting this pins the behavior; changing
+    // SDK semantics to surface partial content would be a separate diff.
+    expect(typeof result.content[0]?.text).toBe("string");
+  });
+});
+
+describe("openai chat — chunk boundary (C-4)", () => {
+  let mock: MockHandle;
+
+  beforeAll(async () => {
+    mock = await startMockOpenAI({ preset: "chunk-boundary" });
+  });
+
+  afterAll(async () => {
+    if (mock) await mock.close();
+  });
+
+  it("P1: SDK reassembles an SSE frame split across two TCP writes", async () => {
+    const { handler } = makeOpenAIChatHandler({
+      apiKey: "test-key",
+      baseURL: mock.baseURL,
+    });
+    const result = await handler({ model: VALID_MODEL, messages: VALID_MESSAGES });
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("hello");
+    expect(result.structuredContent.finish_reason).toBe("stop");
+  });
+});
+
+// Shared factory — kept tiny to avoid cross-file coupling.
+function makeHandler() {
+  return makeOpenAIChatHandler({ apiKey: "test-openai-api-key" });
+}

--- a/packages/ai-relay/tests/unit/chat.test.ts
+++ b/packages/ai-relay/tests/unit/chat.test.ts
@@ -532,3 +532,33 @@ describe("openai chat — handler bundle surface", () => {
     expect(bundle.description).toBe("Azure deployment");
   });
 });
+
+// =========================================================================
+// G: Timeout — requestTimeoutMs propagates to the SDK and aborts in time
+// =========================================================================
+
+describe("openai chat — requestTimeoutMs propagation", () => {
+  it("D1: returns upstream_error within ~timeout when upstream stalls", async () => {
+    server.use(
+      http.post(ENDPOINT, async () => {
+        // Stall well past the configured timeout. The SDK's timeout should
+        // fire BEFORE this resolves, so the handler returns within ~timeout.
+        await new Promise((r) => setTimeout(r, 500));
+        return sseResponse([
+          JSON.stringify({ choices: [{ delta: { content: "late" }, finish_reason: "stop" }] }),
+        ]);
+      }),
+    );
+    const { handler } = makeHandler({ requestTimeoutMs: 50 });
+    const t0 = Date.now();
+    const result = await handler({ model: VALID_MODEL, messages: VALID_MESSAGES });
+    const elapsed = Date.now() - t0;
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+    // SDK timeouts are not always tight; allow generous headroom but reject
+    // the "no timeout fired" case (which would resolve only after the full
+    // 500 ms stall).
+    expect(elapsed).toBeLessThan(450);
+    assertNoSecretLeak(result);
+  });
+});

--- a/packages/ai-relay/tests/unit/concurrent-registration.test.ts
+++ b/packages/ai-relay/tests/unit/concurrent-registration.test.ts
@@ -1,0 +1,109 @@
+// AsyncLocalStorage scope isolation across concurrent registrations.
+//
+// `multi-registration.test.ts` proves closure isolation (each handler holds
+// its own apiKey + baseURL). This file proves the request-scope (ALS)
+// captured upstream-error body cannot leak across handlers when they run
+// concurrently.
+//
+// Setup: three registrations, each with a distinct apiKey. Each MSW handler
+// echoes the matching apiKey verbatim in a 5xx body. The createOpenAIClient
+// fetch-capture stores the body in `requestScope.getStore().upstreamBody`
+// after redacting the configured apiKey. The captured body is then surfaced
+// by `mapOpenAIError` into the result text. Because the redaction is keyed
+// on each handler's own apiKey, handler A's result must contain "[REDACTED]"
+// (its own key removed) but NOT a verbatim copy of B's or C's apiKey.
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { makeOpenAIChatHandler } from "../../src/openai/chat.js";
+
+const mswServer = setupServer();
+beforeAll(() => mswServer.listen({ onUnhandledRequest: "error" }));
+afterEach(() => mswServer.resetHandlers());
+afterAll(() => mswServer.close());
+
+const VALID_MODEL = "gpt-4o-mini";
+const VALID_MESSAGES = [{ role: "user" as const, content: "ping" }];
+
+describe("ALS scope isolation across concurrent handlers", () => {
+  it("D1: each handler's captured upstreamBody is scoped to its own AsyncLocalStorage", async () => {
+    const keyA = "sk-tenant-AAA-xxxxxxxxxxxxxxxxxxxx";
+    const keyB = "sk-tenant-BBB-yyyyyyyyyyyyyyyyyyyy";
+    const keyC = "sk-tenant-CCC-zzzzzzzzzzzzzzzzzzzz";
+
+    // Each MSW handler responds with a 5xx body containing the apiKey it
+    // received via Authorization. Routing by base URL keeps each handler
+    // hitting only its own MSW intercept.
+    function makeHandlerFor(url: string, apiKey: string) {
+      return http.post(url, async ({ request }) => {
+        const auth = request.headers.get("authorization") ?? "";
+        // Body echoes the bearer (which equals the handler's apiKey) and
+        // forces a real upstream-style stall before responding so the
+        // handlers' fetches genuinely overlap.
+        await new Promise((r) => setTimeout(r, 25));
+        return new HttpResponse(
+          JSON.stringify({ error: { message: `tenant ${auth} blew up; key=${apiKey}` } }),
+          { status: 500 },
+        );
+      });
+    }
+
+    mswServer.use(
+      makeHandlerFor("https://a.example.com/v1/chat/completions", keyA),
+      makeHandlerFor("https://b.example.com/v1/chat/completions", keyB),
+      makeHandlerFor("https://c.example.com/v1/chat/completions", keyC),
+    );
+
+    const a = makeOpenAIChatHandler({
+      apiKey: keyA,
+      baseURL: "https://a.example.com/v1",
+    });
+    const b = makeOpenAIChatHandler({
+      apiKey: keyB,
+      baseURL: "https://b.example.com/v1",
+    });
+    const c = makeOpenAIChatHandler({
+      apiKey: keyC,
+      baseURL: "https://c.example.com/v1",
+    });
+
+    const [ra, rb, rc] = await Promise.all([
+      a.handler({ model: VALID_MODEL, messages: VALID_MESSAGES }),
+      b.handler({ model: VALID_MODEL, messages: VALID_MESSAGES }),
+      c.handler({ model: VALID_MODEL, messages: VALID_MESSAGES }),
+    ]);
+
+    expect(ra.isError).toBe(true);
+    expect(rb.isError).toBe(true);
+    expect(rc.isError).toBe(true);
+    expect(ra.structuredContent.code).toBe("upstream_error");
+    expect(rb.structuredContent.code).toBe("upstream_error");
+    expect(rc.structuredContent.code).toBe("upstream_error");
+
+    const txtA = ra.content[0]?.text ?? "";
+    const txtB = rb.content[0]?.text ?? "";
+    const txtC = rc.content[0]?.text ?? "";
+
+    // Each result must contain its own redaction marker (proves the body
+    // was captured under this handler's scope and redaction ran with this
+    // handler's apiKey).
+    expect(txtA).toContain("[REDACTED]");
+    expect(txtB).toContain("[REDACTED]");
+    expect(txtC).toContain("[REDACTED]");
+
+    // Cross-tenant leakage check — no result text contains another
+    // tenant's apiKey verbatim.
+    expect(txtA).not.toContain(keyB);
+    expect(txtA).not.toContain(keyC);
+    expect(txtB).not.toContain(keyA);
+    expect(txtB).not.toContain(keyC);
+    expect(txtC).not.toContain(keyA);
+    expect(txtC).not.toContain(keyB);
+
+    // And the result texts must each have redacted exactly the configured key.
+    expect(txtA).not.toContain(keyA);
+    expect(txtB).not.toContain(keyB);
+    expect(txtC).not.toContain(keyC);
+  });
+});

--- a/packages/ai-relay/vitest.config.ts
+++ b/packages/ai-relay/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
     // spawn npm pack + npm install in a temp dir and exercise the
     // installed bin end-to-end, catching packaging regressions that
     // unit tests can't see.
-    include: ["tests/unit/**/*.test.ts", "tests/integration/**/*.test.ts"],
+    include: [
+      "tests/unit/**/*.test.ts",
+      "tests/integration/**/*.test.ts",
+      "tests/cli/**/*.test.ts",
+    ],
     setupFiles: ["./tests/setup-env.ts"],
     environment: "node",
     pool: "threads",

--- a/scripts/check-readme-parity.mjs
+++ b/scripts/check-readme-parity.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// EN/KO README parity gate.
+//
+// Walks the repo for non-localized `*.md` files and asserts:
+//   1. each has a matching `*.ko.md` sibling, OR
+//   2. the file is on the explicit `KNOWN_EN_ONLY` allowlist below.
+//
+// For pairs, the script also checks that the last-commit timestamps are
+// within 7 days of each other (uses `git log -1 --format=%ct` — filesystem
+// mtime is unreliable after clone).
+//
+// Exit non-zero on violation. Wired as `pnpm check-readme-parity`.
+//
+// The KNOWN_EN_ONLY allowlist is intentional — it makes EN-only docs a
+// reviewable contract instead of a silent default. Removing an entry from
+// the allowlist requires a Korean translation to land in the same PR.
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, statSync } from "node:fs";
+import { join, relative, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = (() => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..");
+})();
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".github",
+  "dist",
+  ".claude",
+  ".next",
+  "coverage",
+]);
+
+const KNOWN_EN_ONLY = new Set([
+  "CLAUDE.md",
+  "packages/ai-relay/CHANGELOG.md",
+  "packages/ai-relay/COMPATIBILITY.md",
+  "packages/ai-relay/README.md",
+  "examples/vercel/README.md",
+  "examples/stdio/README.md",
+  "examples/multi-upstream/README.md",
+  "examples/cloudflare-workers/README.md",
+  // Test fixtures and CI scaffolding — internal-facing, EN-only.
+  "tests/fixtures/mock-openai/README.md",
+  "tests/runtime-fixtures/README.md",
+  "tests/runtime-fixtures/cjs-require/README.md",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+]);
+
+const STALE_THRESHOLD_DAYS = 7;
+const STALE_THRESHOLD_SECONDS = STALE_THRESHOLD_DAYS * 24 * 60 * 60;
+
+function walkMd(dir, acc = []) {
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue;
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkMd(full, acc);
+    } else if (st.isFile() && name.endsWith(".md")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function lastCommitTimestamp(path) {
+  try {
+    const out = execFileSync("git", ["log", "-1", "--format=%ct", "--", path], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }).trim();
+    if (!out) return null;
+    return Number(out);
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const all = walkMd(REPO_ROOT).map((p) => relative(REPO_ROOT, p));
+  const set = new Set(all);
+
+  const violations = [];
+
+  for (const file of all) {
+    if (file.endsWith(".ko.md")) continue;
+    const koSibling = file.replace(/\.md$/, ".ko.md");
+    if (set.has(koSibling)) {
+      // Both exist — check mtime drift.
+      const enT = lastCommitTimestamp(file);
+      const koT = lastCommitTimestamp(koSibling);
+      if (enT !== null && koT !== null) {
+        const delta = Math.abs(enT - koT);
+        if (delta > STALE_THRESHOLD_SECONDS) {
+          violations.push(
+            `STALE: ${file} (${new Date(enT * 1000).toISOString()}) vs ${koSibling} (${new Date(koT * 1000).toISOString()}) — last-commit delta ${(delta / 86400).toFixed(1)}d exceeds ${STALE_THRESHOLD_DAYS}d`,
+          );
+        }
+      }
+      continue;
+    }
+    if (KNOWN_EN_ONLY.has(file)) continue;
+    violations.push(`MISSING_KO: ${file} (no ${koSibling}, and not in KNOWN_EN_ONLY allowlist)`);
+  }
+
+  if (violations.length > 0) {
+    console.error("README parity check FAILED:");
+    for (const v of violations) console.error(`  ${v}`);
+    console.error("");
+    console.error(
+      `Add a translation (e.g. ${violations[0]?.split(" ")[1]?.replace(/\.md$/, ".ko.md")}) or, if the file is intentionally EN-only, add it to KNOWN_EN_ONLY in scripts/check-readme-parity.mjs.`,
+    );
+    process.exit(1);
+  }
+  console.log(`README parity OK — ${all.length} .md files checked.`);
+}
+
+main();

--- a/scripts/examples-smoke.mjs
+++ b/scripts/examples-smoke.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const SKIP_CF = process.env.SKIP_CF_SMOKE === "1";
+
+const runs = [
+  { label: "stdio", cmd: "pnpm", args: ["--filter", "@example/stdio", "smoke"] },
+  { label: "multi-upstream", cmd: "pnpm", args: ["--filter", "@example/multi-upstream", "smoke"] },
+  { label: "vercel", cmd: "bash", args: ["examples/vercel/scripts/smoke.sh"] },
+];
+
+if (!SKIP_CF) {
+  runs.push({
+    label: "cloudflare-workers",
+    cmd: "pnpm",
+    args: ["--filter", "@example/cloudflare-workers", "smoke"],
+  });
+}
+
+function run({ label, cmd, args }) {
+  return new Promise((resolve) => {
+    console.log(`\n===== smoke: ${label} =====`);
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("exit", (code) => resolve({ label, code: code ?? 1 }));
+  });
+}
+
+const results = [];
+for (const r of runs) {
+  results.push(await run(r));
+}
+
+console.log("\n===== examples:smoke summary =====");
+let failed = 0;
+for (const { label, code } of results) {
+  const status = code === 0 ? "PASS" : `FAIL (exit ${code})`;
+  console.log(`  ${label}: ${status}`);
+  if (code !== 0) failed++;
+}
+
+if (failed > 0) {
+  console.log("=== FAIL ===");
+  process.exit(1);
+}
+console.log("=== PASS ===");

--- a/scripts/test-runtime.mjs
+++ b/scripts/test-runtime.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Local runtime-matrix runner. Runs the smoke fixtures against installed
+// runtimes only — cells whose runtime is missing are skipped (not failed).
+//
+// To run a full matrix, push to a branch and let
+// `.github/workflows/runtime-matrix.yml` cover the cells this script skipped.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = (() => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..");
+})();
+
+function has(cmd) {
+  const r = spawnSync("command", ["-v", cmd], { shell: true });
+  return r.status === 0;
+}
+
+function pack() {
+  const sdkDir = join(REPO_ROOT, "packages", "ai-relay");
+  const outDir = join(tmpdir(), `ai-relay-runtime-pack-${process.pid}`);
+  mkdirSync(outDir, { recursive: true });
+  // Build first so dist/ is fresh.
+  execFileSync("pnpm", ["--filter", "ai-relay", "build"], {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+  // `npm pack` works regardless of which package manager owns the workspace.
+  execFileSync("npm", ["pack", "--pack-destination", outDir], {
+    cwd: sdkDir,
+    stdio: "inherit",
+  });
+  const tgz = readdirSync(outDir).find((f) => f.endsWith(".tgz"));
+  if (!tgz) throw new Error("pack: no tarball produced");
+  return join(outDir, tgz);
+}
+
+function installInto(fixtureDir, tarball) {
+  // npm install --no-save: ensures the lockfile/package.json drift is local.
+  execFileSync("npm", ["install", "--no-audit", "--no-fund", "--no-save", tarball], {
+    cwd: fixtureDir,
+    stdio: "inherit",
+  });
+}
+
+function runNodeSmoke(tarball) {
+  if (!has("node")) {
+    console.log("SKIP: node not on PATH");
+    return { ran: false };
+  }
+  const fix = join(REPO_ROOT, "tests", "runtime-fixtures", "smoke-node");
+  installInto(fix, tarball);
+  const r = spawnSync("node", ["smoke.mjs"], { cwd: fix, stdio: "inherit" });
+  return { ran: true, ok: r.status === 0 };
+}
+
+function runBunSmoke(tarball) {
+  if (!has("bun")) {
+    console.log("SKIP: bun not on PATH");
+    return { ran: false };
+  }
+  const fix = join(REPO_ROOT, "tests", "runtime-fixtures", "smoke-bun");
+  installInto(fix, tarball);
+  const r = spawnSync("bun", ["run", "smoke.mjs"], { cwd: fix, stdio: "inherit" });
+  return { ran: true, ok: r.status === 0 };
+}
+
+function runCjsSmoke(tarball) {
+  if (!has("node")) {
+    console.log("SKIP: node not on PATH");
+    return { ran: false };
+  }
+  const fix = join(REPO_ROOT, "tests", "runtime-fixtures", "cjs-require");
+  installInto(fix, tarball);
+  const r = spawnSync("node", ["smoke.cjs"], { cwd: fix, stdio: "inherit" });
+  return { ran: true, ok: r.status === 0 };
+}
+
+function main() {
+  const tarball = pack();
+  if (!existsSync(tarball)) throw new Error(`tarball not found: ${tarball}`);
+
+  const results = [
+    { name: "smoke-node", ...runNodeSmoke(tarball) },
+    { name: "smoke-bun", ...runBunSmoke(tarball) },
+    { name: "cjs-require", ...runCjsSmoke(tarball) },
+  ];
+
+  let failed = 0;
+  for (const r of results) {
+    if (!r.ran) {
+      console.log(`[${r.name}] SKIP (runtime missing)`);
+      continue;
+    }
+    console.log(`[${r.name}] ${r.ok ? "PASS" : "FAIL"}`);
+    if (!r.ok) failed++;
+  }
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();

--- a/tests/fixtures/mock-openai/README.md
+++ b/tests/fixtures/mock-openai/README.md
@@ -1,0 +1,60 @@
+# mock-openai test fixture
+
+A preset-driven mock of the OpenAI Chat Completions endpoint. Used by tests
+that need to exercise the real `openai` SDK + the relay's `createOpenAIClient`
+fetch capture against a controlled upstream — i.e. anywhere MSW cannot reach
+(child processes, separate Node workers) or where we need TCP-level control
+(packet splitting, mid-stream socket destruction).
+
+## Why `node:http`, not Hono
+
+The dev-plan originally specified Hono. The fixture lives under `tests/fixtures/`,
+which is consumed by both `packages/ai-relay/tests/` and root-level `tests/`.
+Neither test surface has `hono` as a direct dependency (only `app/` does),
+and adding it as a root devDependency just to host one mock would expand the
+surface area. `node:http` matches the existing pattern in
+`packages/ai-relay/tests/integration/bin-tarball.test.ts` and is sufficient for
+the small set of behaviors we exercise here.
+
+## API
+
+```ts
+import { startMockOpenAI } from "../../tests/fixtures/mock-openai";
+
+const mock = await startMockOpenAI({ preset: "happy" });
+process.env.AI_RELAY_BASE_URL = mock.baseURL;        // http://127.0.0.1:<port>/v1
+// run code under test ...
+await mock.close();
+```
+
+`startMockOpenAI(opts)` accepts:
+
+- `port` — bind port (default `0` = OS picks a free port).
+- `preset` — one of the presets below (default `"happy"`).
+- `handler(req, res)` — fully custom request handler; when supplied, `preset`
+  is ignored. Use this for one-off shapes the preset set doesn't cover.
+
+`mock.baseURL` is the path the OpenAI SDK targets: it appends
+`/chat/completions` to whatever baseURL you hand it.
+
+## Presets
+
+| preset | behavior |
+|---|---|
+| `happy` | SSE with `"Hello"` + `" "` + `"world"` deltas, final `usage`, then `[DONE]`. Accumulated content is `"Hello world"`. |
+| `401` | `401` JSON error body matching OpenAI's shape (`{error:{message}}`). |
+| `429` | `429` JSON error + `Retry-After: 5` header. |
+| `500` | `500` JSON error body. |
+| `timeout` | Writes nothing; holds the connection open. Use to trigger the SDK's `timeout` / consumer's `AbortSignal`. |
+| `stream-mid-error` | 2 valid delta chunks (`"par"`, `"tial"`), then destroys the socket without `[DONE]`. |
+| `chunk-boundary` | A single SSE frame split across two TCP writes 10 ms apart, exercising the SDK's frame reassembly path. |
+
+## Adding a new preset
+
+1. Add the preset name to the `Preset` union in `index.ts`.
+2. Add a `case` in `handleByPreset` returning a small `send<Preset>(res)` function.
+3. Document it in the table above.
+
+Keep the preset surface small. If you need something exotic (custom headers,
+multi-tenant routing, body-driven branching), use the `handler` override
+instead of growing the enum.

--- a/tests/fixtures/mock-openai/index.ts
+++ b/tests/fixtures/mock-openai/index.ts
@@ -1,0 +1,166 @@
+// Mock OpenAI Chat Completions server — preset-driven test fixture.
+//
+// Lifecycle:
+//   const mock = await startMockOpenAI({ preset: "happy" });
+//   process.env.AI_RELAY_BASE_URL = mock.baseURL;  // http://127.0.0.1:<port>/v1
+//   ...run code that hits Chat Completions...
+//   await mock.close();
+//
+// The fixture binds to 127.0.0.1:0 and resolves the actual port from the
+// listening socket, so concurrent tests do not clash. State is per-instance
+// (no module-level mutables) so multiple fixtures can run in the same
+// process.
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export type Preset =
+  | "happy"
+  | "401"
+  | "429"
+  | "500"
+  | "timeout"
+  | "stream-mid-error"
+  | "chunk-boundary";
+
+export interface StartOptions {
+  port?: number;
+  preset?: Preset;
+  // Optional fully custom handler. When supplied, `preset` is ignored.
+  handler?: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+}
+
+export interface MockHandle {
+  baseURL: string;
+  port: number;
+  close: () => Promise<void>;
+}
+
+const SSE_HEADERS = {
+  "content-type": "text/event-stream",
+  "cache-control": "no-cache",
+  connection: "keep-alive",
+} as const;
+
+export async function startMockOpenAI(opts: StartOptions = {}): Promise<MockHandle> {
+  const preset: Preset = opts.preset ?? "happy";
+  const customHandler = opts.handler;
+
+  const server: Server = createServer((req, res) => {
+    if (customHandler) {
+      void customHandler(req, res);
+      return;
+    }
+    handleByPreset(preset, req, res);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(opts.port ?? 0, "127.0.0.1", resolve);
+  });
+  const addr = server.address() as AddressInfo | null;
+  if (!addr) throw new Error("mock-openai: listen() returned no address");
+
+  return {
+    baseURL: `http://127.0.0.1:${addr.port}/v1`,
+    port: addr.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+        // Force-destroy any keep-alive sockets so close() resolves promptly.
+        server.closeAllConnections?.();
+      }),
+  };
+}
+
+// --- preset handlers ------------------------------------------------------
+
+function handleByPreset(preset: Preset, req: IncomingMessage, res: ServerResponse): void {
+  // All presets only respond to POST on the chat/completions path the SDK
+  // uses. The SDK appends `/chat/completions` to whatever baseURL we hand it.
+  if (req.method !== "POST" || !req.url?.endsWith("/chat/completions")) {
+    res.statusCode = 404;
+    res.end();
+    return;
+  }
+  // Drain the request body so the socket can close cleanly.
+  req.on("data", () => {});
+  req.on("end", () => {
+    switch (preset) {
+      case "happy":
+        return sendHappy(res);
+      case "401":
+        return sendJsonError(res, 401, { message: "Invalid API key" });
+      case "429":
+        return sendRateLimited(res);
+      case "500":
+        return sendJsonError(res, 500, { message: "Upstream server error" });
+      case "timeout":
+        return holdOpen(res);
+      case "stream-mid-error":
+        return sendStreamMidError(res);
+      case "chunk-boundary":
+        return sendChunkBoundary(res);
+    }
+  });
+}
+
+function sendHappy(res: ServerResponse): void {
+  res.writeHead(200, SSE_HEADERS);
+  // Three deltas + final usage + DONE.
+  const frames = [
+    JSON.stringify({ choices: [{ delta: { content: "Hello" } }] }),
+    JSON.stringify({ choices: [{ delta: { content: " " } }] }),
+    JSON.stringify({ choices: [{ delta: { content: "world" }, finish_reason: "stop" }] }),
+    JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    }),
+  ];
+  for (const f of frames) res.write(`data: ${f}\n\n`);
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
+function sendJsonError(
+  res: ServerResponse,
+  status: number,
+  error: { message: string; code?: string },
+): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error }));
+}
+
+function sendRateLimited(res: ServerResponse): void {
+  res.writeHead(429, {
+    "content-type": "application/json",
+    "retry-after": "5",
+  });
+  res.end(JSON.stringify({ error: { message: "Rate limited" } }));
+}
+
+function holdOpen(res: ServerResponse): void {
+  // Write nothing. The socket stays open until the client times out or the
+  // server is closed via `mock.close()` → `closeAllConnections()`.
+  res.writeHead(200, SSE_HEADERS);
+  // Intentionally no .write / .end — caller's AbortSignal/timeout fires.
+}
+
+function sendStreamMidError(res: ServerResponse): void {
+  res.writeHead(200, SSE_HEADERS);
+  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: "par" } }] })}\n\n`);
+  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: "tial" } }] })}\n\n`);
+  // Forcibly destroy the underlying socket without [DONE].
+  setTimeout(() => res.destroy(new Error("network reset")), 10);
+}
+
+function sendChunkBoundary(res: ServerResponse): void {
+  res.writeHead(200, SSE_HEADERS);
+  // Split one SSE frame across two TCP writes with a delay so the OS
+  // doesn't coalesce them. The SDK must reassemble correctly.
+  res.write('data: {"choices":[{"de');
+  setTimeout(() => {
+    res.write('lta":{"content":"hello"},"finish_reason":"stop"}]}\n\n');
+    res.write("data: [DONE]\n\n");
+    res.end();
+  }, 10);
+}

--- a/tests/fixtures/mock-openai/server.mjs
+++ b/tests/fixtures/mock-openai/server.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Minimal OpenAI Chat Completions mock for the docker smoke harness.
+//
+// Usage:
+//   node tests/fixtures/mock-openai/server.mjs --port=0
+//   node tests/fixtures/mock-openai/server.mjs --port=18080
+//
+// Contract for the docker-smoke harness:
+//   - Exits 0 on SIGTERM/SIGINT.
+//   - Prints exactly one line `LISTENING port=<N>` to stdout once the
+//     listener is bound. The harness greps stdout for this token to
+//     discover the port (`--port=0` lets the OS pick a free port).
+//   - Returns the OpenAI v1 chat-completion JSON shape; the assistant
+//     content is the literal token `smoke-canned-reply` so callers can
+//     assert on it.
+//
+// Per project CLAUDE.md §4: never log request/response bodies.
+
+import { createServer } from "node:http";
+
+const portArg = process.argv.find((a) => a.startsWith("--port="));
+const port = Number(portArg ? portArg.slice("--port=".length) : 0);
+
+const CANNED_REPLY = "smoke-canned-reply";
+
+function chatCompletionResponse(model) {
+  return {
+    id: "chatcmpl-smoke-0001",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: typeof model === "string" && model.length > 0 ? model : "gpt-4o-mini",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: CANNED_REPLY },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+  };
+}
+
+function streamChunk(model, delta, finishReason, usage) {
+  const obj = {
+    id: "chatcmpl-smoke-0001",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: typeof model === "string" && model.length > 0 ? model : "gpt-4o-mini",
+    choices:
+      delta !== null
+        ? [
+            {
+              index: 0,
+              delta: delta,
+              finish_reason: finishReason,
+            },
+          ]
+        : [],
+    ...(usage ? { usage } : {}),
+  };
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+const server = createServer((req, res) => {
+  if (req.method === "POST" && req.url === "/v1/chat/completions") {
+    let body = "";
+    let bodyLen = 0;
+    req.on("data", (chunk) => {
+      bodyLen += chunk.length;
+      if (bodyLen < 16384) body += chunk.toString("utf8");
+    });
+    req.on("end", () => {
+      // Match `"model":"..."` and `"stream":true` without parsing the body.
+      const modelMatch = body.match(/"model"\s*:\s*"([^"]+)"/);
+      const model = modelMatch ? modelMatch[1] : "";
+      const wantsStream = /"stream"\s*:\s*true/.test(body);
+      if (wantsStream) {
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(streamChunk(model, { role: "assistant", content: "" }, null, null));
+        res.write(streamChunk(model, { content: CANNED_REPLY }, null, null));
+        res.write(streamChunk(model, {}, "stop", null));
+        res.write(
+          streamChunk(model, null, null, {
+            prompt_tokens: 1,
+            completion_tokens: 3,
+            total_tokens: 4,
+          }),
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      } else {
+        const payload = JSON.stringify(chatCompletionResponse(model));
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(payload),
+        });
+        res.end(payload);
+      }
+    });
+    req.on("error", () => {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "mock upstream read error" } }));
+    });
+    return;
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: { message: "not found" } }));
+});
+
+// Bind 0.0.0.0 so the docker-smoke harness can reach this fixture from
+// inside the container via host.docker.internal. 127.0.0.1 would only
+// be reachable from the host's loopback interface.
+server.listen(port, "0.0.0.0", () => {
+  const addr = server.address();
+  const boundPort = typeof addr === "object" && addr ? addr.port : port;
+  process.stdout.write(`LISTENING port=${boundPort}\n`);
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+  // Force-exit if shutdown hangs (in-flight request held the socket).
+  setTimeout(() => process.exit(0), 1000).unref();
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/tests/integration/docker.test.ts
+++ b/tests/integration/docker.test.ts
@@ -1,0 +1,50 @@
+// Integration wrapper around app/scripts/docker-smoke.sh.
+//
+// Self-skips when Docker is unavailable (so this stays cheap on dev
+// machines without Docker). The script itself prints PASS/FAIL per
+// assertion; we only assert on its exit code.
+//
+// Also gated behind RUN_DOCKER_SMOKE because the underlying docker build
+// + smoke run takes several minutes; opt in explicitly to keep
+// `pnpm test` snappy on machines that have Docker installed.
+
+import { execSync, spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..");
+const SCRIPT = resolve(REPO_ROOT, "app", "scripts", "docker-smoke.sh");
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SHOULD_RUN = !!process.env.RUN_DOCKER_SMOKE;
+
+describe.skipIf(!SHOULD_RUN || !hasDocker())("docker smoke", () => {
+  it(
+    "app/scripts/docker-smoke.sh exits 0",
+    async () => {
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        const child = spawn("bash", [SCRIPT], {
+          cwd: REPO_ROOT,
+          stdio: "inherit",
+          env: process.env,
+        });
+        child.on("error", rejectPromise);
+        child.on("exit", (code) => {
+          expect(code).toBe(0);
+          resolvePromise();
+        });
+      });
+    },
+    5 * 60 * 1000,
+  );
+});

--- a/tests/runtime-fixtures/README.md
+++ b/tests/runtime-fixtures/README.md
@@ -1,0 +1,38 @@
+# runtime-fixtures
+
+Self-contained fixtures used by the runtime-matrix CI workflow
+(`.github/workflows/runtime-matrix.yml`) and by the local `pnpm test:runtime`
+script.
+
+## Layout
+
+| Fixture | Used by | What it proves |
+|---|---|---|
+| `smoke-node/` | Node matrix job (20.10.0, 20.x, 22.x, 24.x) + local `pnpm test:runtime` | The packed tarball installs and imports cleanly on every supported Node minor; no side-effects at import. |
+| `smoke-bun/` | Bun job | The packed tarball installs and imports cleanly on Bun. |
+| `cjs-require/` | ESM-only assertion job | `require('ai-relay')` from a CJS context fails with a clear ESM-only error (or, on Node 22+ with `require(esm)`, succeeds with the documented shape). See `cjs-require/README.md`. |
+| `typecheck-bundler/` | Publish-contract test (`packages/ai-relay/tests/integration/pack-contract.test.ts`) | `ai-relay` types resolve under `moduleResolution: "bundler"` for every documented subpath. |
+| `typecheck-nodenext/` | Publish-contract test | `ai-relay` types resolve under `moduleResolution: "nodenext"` for every documented subpath. |
+
+## smoke duplication
+
+`smoke-node/smoke.mjs` and `smoke-bun/smoke.mjs` are byte-for-byte
+identical today. They are duplicated rather than shared so that:
+
+- Each runtime cell is self-contained — adding a new runtime (Deno, Cloudflare
+  Workers) means copying one of these and editing it, not modifying a shared
+  file with growing runtime branches.
+- A runtime-specific divergence (e.g. Bun-only API check) can be added
+  without affecting the others.
+
+If the cells stay identical for a sustained period across 3+ runtimes the
+duplication is cheap to collapse later.
+
+## Adding a runtime cell
+
+1. Copy `smoke-node/` to `smoke-<runtime>/`. Edit the SENTINEL string and any
+   runtime-specific assertions.
+2. Add a new job to `.github/workflows/runtime-matrix.yml` that installs the
+   runtime, packs the SDK, installs the tarball into the fixture, and runs
+   the smoke.
+3. Update the table above.

--- a/tests/runtime-fixtures/cjs-require/README.md
+++ b/tests/runtime-fixtures/cjs-require/README.md
@@ -1,0 +1,25 @@
+# cjs-require runtime fixture
+
+Validates that `require('ai-relay')` from a CommonJS context produces a
+clear, ESM-only failure mode.
+
+## Why this fixture
+
+`ai-relay` ships as ESM-only (`"type": "module"`, `exports` map with
+`"import"` only, no `"require"` condition). A CommonJS consumer who tries
+to `require()` it should hit a clear error so the migration path is
+obvious — silently importing a stale partial shape would be worse.
+
+Node 22 added experimental `require(esm)` support. When the flag is on,
+`require()` may succeed. This fixture handles both outcomes:
+
+- If `require()` throws, the error must be one of the canonical ESM-only
+  failures: `ERR_REQUIRE_ESM` (classic), `ERR_PACKAGE_PATH_NOT_EXPORTED`
+  (raised when the `exports` map exposes only an `import` condition, so
+  CJS can't resolve anything), or a message containing `"ESM"` /
+  `"No \"exports\" main defined"`.
+- If `require()` succeeds, the returned module must expose the documented
+  named exports.
+
+Either outcome passes the smoke. We do NOT require throwing — that would
+fail on Node 22+ with `require(esm)` enabled.

--- a/tests/runtime-fixtures/cjs-require/package.json
+++ b/tests/runtime-fixtures/cjs-require/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cjs-require-fixture",
+  "private": true,
+  "version": "0.0.0"
+}

--- a/tests/runtime-fixtures/cjs-require/smoke.cjs
+++ b/tests/runtime-fixtures/cjs-require/smoke.cjs
@@ -1,0 +1,50 @@
+// CommonJS require() smoke for the ESM-only `ai-relay` package.
+//
+// On Node < 22 we expect a clean `ERR_REQUIRE_ESM` (or message containing
+// "ESM"). On Node >= 22 the `require(esm)` flag may be enabled and the call
+// can succeed — in that case we assert the returned module shape instead of
+// asserting the throw.
+//
+// Either way the smoke succeeds. The point is to PROVE the failure mode is
+// clear, not to mandate that the call throw.
+
+let mod;
+let caughtErr;
+try {
+  mod = require("ai-relay");
+} catch (err) {
+  caughtErr = err;
+}
+
+if (caughtErr) {
+  const code = caughtErr.code ?? "";
+  const msg = String(caughtErr.message ?? "");
+  // Accept any of the canonical ESM-only failure modes:
+  //  - `ERR_REQUIRE_ESM`: classic Node < 22 CJS-requiring-ESM error.
+  //  - `ERR_PACKAGE_PATH_NOT_EXPORTED`: our exports map has only an `import`
+  //    condition; CJS can't resolve any condition, so Node raises this.
+  //  - Message text mentioning ESM.
+  const looksESM =
+    code === "ERR_REQUIRE_ESM" ||
+    code === "ERR_PACKAGE_PATH_NOT_EXPORTED" ||
+    /ESM/i.test(msg) ||
+    /import\(\) which is available/.test(msg) ||
+    /No "exports" main defined/.test(msg);
+  if (!looksESM) {
+    console.error("FAIL: require() threw but error did not mention ESM:", caughtErr);
+    process.exit(1);
+  }
+  console.log(`OK: require('ai-relay') threw ESM-only error (code=${code || "—"})`);
+  process.exit(0);
+}
+
+// require() succeeded: assert the module exposes the expected named exports.
+if (typeof mod.verifyBearer !== "function") {
+  console.error("FAIL: require() succeeded but verifyBearer is missing");
+  process.exit(1);
+}
+if (typeof mod.loadConfig !== "function") {
+  console.error("FAIL: require() succeeded but loadConfig is missing");
+  process.exit(1);
+}
+console.log("OK: require('ai-relay') succeeded under Node require(esm); shape verified");

--- a/tests/runtime-fixtures/smoke-bun/package.json
+++ b/tests/runtime-fixtures/smoke-bun/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "smoke-bun-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/tests/runtime-fixtures/smoke-bun/smoke.mjs
+++ b/tests/runtime-fixtures/smoke-bun/smoke.mjs
@@ -1,0 +1,71 @@
+// Bun smoke is byte-for-byte identical to Node smoke. Duplicated rather than
+// imported so each runtime fixture is self-contained — a future maintainer
+// can drop a runtime cell without untangling a shared file.
+//
+// See ../README.md for the rationale.
+
+const { fetch: originalFetch } = globalThis;
+const SENTINEL = "smoke-bun:should-not-be-called";
+
+let fetchInvoked = false;
+globalThis.fetch = () => {
+  fetchInvoked = true;
+  throw new Error(SENTINEL);
+};
+
+const beforeKeys = new Set(Object.keys(globalThis));
+const setTimeoutBefore = setTimeout;
+const setIntervalBefore = setInterval;
+
+let failures = 0;
+function assert(cond, msg) {
+  if (!cond) {
+    failures++;
+    console.error(`FAIL: ${msg}`);
+  } else {
+    console.log(`OK:   ${msg}`);
+  }
+}
+
+const root = await import("ai-relay");
+const env = await import("ai-relay/env");
+const auth = await import("ai-relay/auth");
+const openai = await import("ai-relay/openai");
+
+const afterKeys = new Set(Object.keys(globalThis));
+const ALLOWED_GLOBALS = new Set(["__zod_globalConfig", "__zod_globalRegistry"]);
+const newKeys = [...afterKeys].filter((k) => !beforeKeys.has(k) && !ALLOWED_GLOBALS.has(k));
+assert(
+  newKeys.length === 0,
+  `no new globalThis keys (allowed-zod ignored; unexpected: ${JSON.stringify(newKeys)})`,
+);
+
+assert(setTimeout === setTimeoutBefore, "setTimeout identity preserved");
+assert(setInterval === setIntervalBefore, "setInterval identity preserved");
+assert(fetchInvoked === false, "globalThis.fetch never invoked during import");
+
+globalThis.fetch = originalFetch;
+
+assert(typeof root.verifyBearer === "function", "ai-relay exports verifyBearer");
+assert(typeof root.loadConfig === "function", "ai-relay exports loadConfig");
+assert(typeof env.loadConfig === "function", "ai-relay/env exports loadConfig");
+assert(typeof auth.verifyBearer === "function", "ai-relay/auth exports verifyBearer");
+assert(
+  typeof openai.registerOpenAIChat === "function",
+  "ai-relay/openai exports registerOpenAIChat",
+);
+assert(
+  typeof openai.makeOpenAIChatHandler === "function",
+  "ai-relay/openai exports makeOpenAIChatHandler",
+);
+assert(typeof openai.mapOpenAIError === "function", "ai-relay/openai exports mapOpenAIError");
+
+assert(auth.verifyBearer("a", "a") === true, "verifyBearer('a','a') === true");
+assert(auth.verifyBearer("a", "b") === false, "verifyBearer('a','b') === false");
+assert(auth.verifyBearer("", "a") === false, "verifyBearer('','a') === false");
+
+if (failures > 0) {
+  console.error(`smoke: ${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("smoke: all checks passed");

--- a/tests/runtime-fixtures/smoke-node/package.json
+++ b/tests/runtime-fixtures/smoke-node/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "smoke-node-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}

--- a/tests/runtime-fixtures/smoke-node/smoke.mjs
+++ b/tests/runtime-fixtures/smoke-node/smoke.mjs
@@ -1,0 +1,86 @@
+// Canonical smoke test for the published `ai-relay` tarball.
+//
+// Runs from inside a temp dir where `npm install <tarball>` has been
+// executed. The matrix workflow re-runs this on every (runtime × node)
+// cell; the local `pnpm test:runtime` runs it once.
+//
+// Assertions:
+//   1. globalThis has no new keys after importing any of the public subpaths
+//      (proves the SDK has no side-effects at import time).
+//   2. `setTimeout` / `setInterval` are not patched.
+//   3. `globalThis.fetch` is never called during import (we install a
+//      throwing stub before the imports).
+//   4. Each subpath exposes the documented named exports.
+
+const { fetch: originalFetch } = globalThis;
+const SENTINEL = "smoke-node:should-not-be-called";
+
+let fetchInvoked = false;
+globalThis.fetch = () => {
+  fetchInvoked = true;
+  throw new Error(SENTINEL);
+};
+
+const beforeKeys = new Set(Object.keys(globalThis));
+const setTimeoutBefore = setTimeout;
+const setIntervalBefore = setInterval;
+
+let failures = 0;
+function assert(cond, msg) {
+  if (!cond) {
+    failures++;
+    console.error(`FAIL: ${msg}`);
+  } else {
+    console.log(`OK:   ${msg}`);
+  }
+}
+
+const root = await import("ai-relay");
+const env = await import("ai-relay/env");
+const auth = await import("ai-relay/auth");
+const openai = await import("ai-relay/openai");
+
+const afterKeys = new Set(Object.keys(globalThis));
+// Zod v4 attaches `__zod_globalConfig` and `__zod_globalRegistry` to
+// globalThis at import time. These are zod-owned, not added by `ai-relay`
+// itself, and the runtime contract is that nothing in our SDK creates new
+// globals — so we allowlist exactly the zod ones and assert everything else
+// is empty.
+const ALLOWED_GLOBALS = new Set(["__zod_globalConfig", "__zod_globalRegistry"]);
+const newKeys = [...afterKeys].filter((k) => !beforeKeys.has(k) && !ALLOWED_GLOBALS.has(k));
+assert(
+  newKeys.length === 0,
+  `no new globalThis keys (allowed-zod ignored; unexpected: ${JSON.stringify(newKeys)})`,
+);
+
+assert(setTimeout === setTimeoutBefore, "setTimeout identity preserved");
+assert(setInterval === setIntervalBefore, "setInterval identity preserved");
+assert(fetchInvoked === false, "globalThis.fetch never invoked during import");
+
+// Restore so subsequent code in the smoke can call fetch if it wants to.
+globalThis.fetch = originalFetch;
+
+assert(typeof root.verifyBearer === "function", "ai-relay exports verifyBearer");
+assert(typeof root.loadConfig === "function", "ai-relay exports loadConfig");
+assert(typeof env.loadConfig === "function", "ai-relay/env exports loadConfig");
+assert(typeof auth.verifyBearer === "function", "ai-relay/auth exports verifyBearer");
+assert(
+  typeof openai.registerOpenAIChat === "function",
+  "ai-relay/openai exports registerOpenAIChat",
+);
+assert(
+  typeof openai.makeOpenAIChatHandler === "function",
+  "ai-relay/openai exports makeOpenAIChatHandler",
+);
+assert(typeof openai.mapOpenAIError === "function", "ai-relay/openai exports mapOpenAIError");
+
+// Functional sanity: verifyBearer is constant-time but still produces correct boolean.
+assert(auth.verifyBearer("a", "a") === true, "verifyBearer('a','a') === true");
+assert(auth.verifyBearer("a", "b") === false, "verifyBearer('a','b') === false");
+assert(auth.verifyBearer("", "a") === false, "verifyBearer('','a') === false");
+
+if (failures > 0) {
+  console.error(`smoke: ${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("smoke: all checks passed");

--- a/tests/runtime-fixtures/typecheck-bundler/index.ts
+++ b/tests/runtime-fixtures/typecheck-bundler/index.ts
@@ -1,0 +1,27 @@
+// Exercise every public subpath of `ai-relay` under
+// `moduleResolution: "bundler"`. Used by the publish-contract test —
+// `pack-contract.test.ts` installs the packed tarball into this fixture and
+// runs `tsc --noEmit`. Exit 0 = subpath types resolve under bundler mode.
+
+import { verifyBearer } from "ai-relay";
+import { verifyBearer as verifyBearerSub } from "ai-relay/auth";
+import { loadConfig } from "ai-relay/env";
+import type { OpenAIChatConfig, OpenAIChatResult, ToolDescriptor } from "ai-relay/openai";
+import { makeOpenAIChatHandler, registerOpenAIChat } from "ai-relay/openai";
+
+const _ok: boolean = verifyBearer("a", "a") && verifyBearerSub("b", "b");
+
+const _cfg: OpenAIChatConfig = { apiKey: "k" };
+const _handler = makeOpenAIChatHandler(_cfg);
+const _register: typeof registerOpenAIChat = registerOpenAIChat;
+
+const _loaded = loadConfig({ env: { AI_RELAY_API_KEY: "x" } });
+const _providers = _loaded.providers.length;
+
+// Force the type imports to be retained under verbatimModuleSyntax-style
+// strictness even though this isn't actually verbatim. The cast keeps the
+// types referenced so the typecheck has work to do.
+const _result: OpenAIChatResult | undefined = undefined;
+const _tool: ToolDescriptor | undefined = undefined;
+
+export { _handler, _ok, _providers, _register, _result, _tool };

--- a/tests/runtime-fixtures/typecheck-bundler/package.json
+++ b/tests/runtime-fixtures/typecheck-bundler/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "typecheck-bundler-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/tests/runtime-fixtures/typecheck-bundler/tsconfig.json
+++ b/tests/runtime-fixtures/typecheck-bundler/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "lib": ["esnext"]
+  },
+  "include": ["index.ts"]
+}

--- a/tests/runtime-fixtures/typecheck-nodenext/index.ts
+++ b/tests/runtime-fixtures/typecheck-nodenext/index.ts
@@ -1,0 +1,22 @@
+// Exercise every public subpath of `ai-relay` under
+// `moduleResolution: "nodenext"`. Used by the publish-contract test.
+
+import { verifyBearer } from "ai-relay";
+import { verifyBearer as verifyBearerSub } from "ai-relay/auth";
+import { loadConfig } from "ai-relay/env";
+import type { OpenAIChatConfig, OpenAIChatResult, ToolDescriptor } from "ai-relay/openai";
+import { makeOpenAIChatHandler, registerOpenAIChat } from "ai-relay/openai";
+
+const _ok: boolean = verifyBearer("a", "a") && verifyBearerSub("b", "b");
+
+const _cfg: OpenAIChatConfig = { apiKey: "k" };
+const _handler = makeOpenAIChatHandler(_cfg);
+const _register: typeof registerOpenAIChat = registerOpenAIChat;
+
+const _loaded = loadConfig({ env: { AI_RELAY_API_KEY: "x" } });
+const _providers = _loaded.providers.length;
+
+const _result: OpenAIChatResult | undefined = undefined;
+const _tool: ToolDescriptor | undefined = undefined;
+
+export { _handler, _ok, _providers, _register, _result, _tool };

--- a/tests/runtime-fixtures/typecheck-nodenext/package.json
+++ b/tests/runtime-fixtures/typecheck-nodenext/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "typecheck-nodenext-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/tests/runtime-fixtures/typecheck-nodenext/tsconfig.json
+++ b/tests/runtime-fixtures/typecheck-nodenext/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "lib": ["esnext"]
+  },
+  "include": ["index.ts"]
+}

--- a/tests/setup-env.ts
+++ b/tests/setup-env.ts
@@ -1,3 +1,10 @@
+// Clear leaked upstream envs so MSW handlers and mock-openai fixtures
+// reliably intercept. Without this, a developer who has OPENAI_BASE_URL /
+// OPENAI_API_KEY exported in their shell will see the OpenAI SDK target
+// the leaked URL and MSW handlers will stop firing.
+delete process.env.OPENAI_API_KEY;
+delete process.env.OPENAI_BASE_URL;
+
 // Seeds process.env with minimal valid values BEFORE the integration
 // test imports the app module (which calls `parseEnv(process.env)` at
 // module load). `??=` so an externally provided value (CI secret) is not


### PR DESCRIPTION
Closes #69

Merges the test-coverage Epic — 4 sub-issue PRs already accumulated on `epic/69-test-coverage`:

| Sub-issue | PR | Commit |
|---|---|---|
| #70 SDK — publish contract + runtime matrix + edge case gaps | #76 | `505bc24` |
| #73 Examples — committed pnpm smoke for stdio/multi-upstream/vercel | #75 | `a3b799b` |
| #72 App — committed docker smoke + image-size regression guard | #77 | `7ec4a11` |
| #71 CLI — real automated stdio MCP harness | #78 | `4d34038` |

## Why this Epic existed

PR #67 (`ai-relay@0.2.0` prep) shipped a cf-workers smoke that reported `=== PASS ===` while both no-auth and bearer-auth curls returned 401. The "smoke" verified only that wrangler booted, not that auth or MCP transport actually worked. Forcing function: the project ships across multiple surfaces (CLI / Docker app / SDK / examples) but each surface had uneven testing maturity. This Epic closes the four most consequential gaps before `ai-relay@0.2.0` ships to npm.

## What landed (per surface)

**SDK (#76)** — publish contract guard (tarball allowlist), runtime matrix CI (Node 20.10 / 22.x / Bun, ESM-only `require()` assertion), edge cases (concurrent-registration, stream-edge), `tests/fixtures/mock-openai/index.ts` shared fixture, `packages/ai-relay/COMPATIBILITY.md`, `scripts/check-readme-parity.mjs` (EN/KO drift guard), `scripts/test-runtime.mjs` (local matrix runner).

**Examples (#75)** — committed `pnpm smoke` for `examples/{stdio, multi-upstream, vercel}` (cf-workers already done in PR #67), root `pnpm examples:smoke` runner, `.github/workflows/examples-smoke.yml`.

**App / Docker (#77)** — committed `app/scripts/docker-smoke.sh` covering 12 checks (B-1..B-4 build, R-1..R-9 runtime), `.github/workflows/docker-smoke.yml`, root `pnpm docker:smoke`. Image-size regression guard uses `docker image inspect .Size` (the real metric, not Docker Desktop's cache-inclusive `docker images SIZE` which #66 mis-measured at 233 MB while real shipped image is 46.5 MB).

**CLI (#78)** — real subprocess harness: `packages/ai-relay/tests/cli/spawn.test.ts` (spawn-based stdio JSON-in/JSON-out), `spawn-harness.ts` helper, dedicated `mock-openai.ts` for the CLI tests. Original sub-issue #71 was rewritten mid-Epic when headless dispatch flagged the original premise as wrong (CLI is one-shot, NOT a stdio MCP server — `examples/stdio/server.ts` is the real stdio surface, covered by #75).

## Verification trail

- All 4 sub-issue PRs were green at merge time:
  - #76: full Bun + Node 20.10/20.x/22.x runtime matrix + ESM/CJS assertion green
  - #75: `examples-smoke.yml` green (23s)
  - #77: `docker-smoke.yml` green (12/12 PASS, 53s) — required mid-merge fix `71230ef` to bind mock OpenAI on `0.0.0.0` instead of `127.0.0.1` so the container could reach it via `host.docker.internal`
  - #78: vitest spawn harness covers H/E/R/A/T paths in-process

- One conflict resolved during merge: root `package.json` `scripts` block (PR #75 added `examples:smoke`; PR #76 added `check-readme-parity` + `test:runtime`) — combined all 3 in `69c3cda`.

## Follow-ups (not blocking this PR)

- **#68** — `ai-relay@0.2.0` publish to npm. Held until this Epic merges. Now unblocked.
- **#28 (`ragingwind/dotclaude`)** — refactor `scripts/epic.ts` for per-issue stderr file + full stage event extractor. Forcing function discovered during this Epic's dispatch (`/epic 69`).
- Shared fixture consolidation: each sub-PR ended up with its own mock-openai variant (#76: `tests/fixtures/mock-openai/index.ts`, #77: `tests/fixtures/mock-openai/server.mjs`, #78: `packages/ai-relay/tests/cli/mock-openai.ts`). Worth unifying in a follow-up.

## Refs

- Closes #69 (Epic)
- Sub-issues: #70 #71 #72 #73 (auto-closed via sub-issue PRs)
- Held by this Epic: #68 (publish — now unblocks)
- PR #67 (`ai-relay@0.2.0` prep) — false-PASS that motivated this Epic
