### PR TITLE
refactor!: introduce <provider> positional on ai-relay and ai-relay-cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ These are NOT read by the Hono server; they only configure the one-shot CLI.
 
 | Key | Required | Notes |
 |---|---|---|
-| `AI_RELAY_MODEL` | ❌ | Default model id for `ai-relay-cli`. Falls behind `model` in JSON input and behind `-m`/`--model` flag. The MCP server (`ai-relay <api-type>`) does not read this; clients must supply `model` in `tools/call` arguments. |
+| `AI_RELAY_MODEL` | ❌ | Default model id for `ai-relay-cli`. Falls behind `model` in JSON input and behind `-m`/`--model` flag. The MCP server (`ai-relay <provider>`) does not read this; clients must supply `model` in `tools/call` arguments. |
 
 ### Script-only (consumed by `scripts/mcp-inspect.mjs` and `scripts/verify.mjs`)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,8 +19,8 @@ MCP host  ──►  ai-relay  ──►  OpenAI-compatible API
 
 | 표면 | 전송 | 설치 | 사용 시점 |
 |---|---|---|---|
-| `npx ai-relay-cli <tool> [flags] [input]` | 없음 (단발) | 없음 | 빠른 테스트, 스크립팅, CI 스모크 |
-| `npx ai-relay <api-type>` | stdio MCP | 없음 | Claude Desktop / Claude Code / Cursor 직접 등록 |
+| `npx ai-relay-cli <provider> <tool> [flags] [input]` | 없음 (단발) | 없음 | 빠른 테스트, 스크립팅, CI 스모크 |
+| `npx ai-relay <provider>` | stdio MCP | 없음 | Claude Desktop / Claude Code / Cursor 직접 등록 |
 | SDK (`ai-relay`) | 호출자 선택 (stdio / HTTP / Workers) | npm | 커스텀 MCP 서버에 임베드 |
 | App (`./app`, Hono) | HTTP | `git clone` (Node에 셀프 호스트) | 개인 또는 팀 HTTP 엔드포인트 |
 | Docker (`ghcr.io/ragingwind/ai-relay`) | HTTP | `docker run` (빌드 없음) | 컨테이너 배포, 멀티 아키텍처 (amd64/arm64) |
@@ -30,32 +30,32 @@ MCP host  ──►  ai-relay  ──►  OpenAI-compatible API
 ## 빠른 시작 — 단발 CLI (`ai-relay-cli`)
 
 ```bash
-AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions -m gpt-4o-mini "ping"
+AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
 
 # 모델을 JSON 입력에 포함시켜도 됩니다
-AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions \
+AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions \
   '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'
 
 # …또는 환경변수로
 AI_RELAY_API_KEY=sk-... AI_RELAY_MODEL=gpt-4o-mini \
-  npx ai-relay-cli chat-completions "ping"
+  npx ai-relay-cli openai chat-completions "ping"
 
 echo "explain TLS in 2 sentences" \
-  | AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions -m gpt-4o-mini -s "be terse"
+  | AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini -s "be terse"
 
 # 환경변수 없이 플래그로 API 키 직접 전달:
-npx ai-relay-cli chat-completions -m gpt-4o-mini --api-key sk-... "ping"
+npx ai-relay-cli openai chat-completions -m gpt-4o-mini --api-key sk-... "ping"
 
 # Azure OpenAI / vLLM / Ollama / AI Gateway 등 OpenAI 호환 엔드포인트 지정:
-AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions -m gpt-4o-mini \
+AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini \
   --base-url https://my-azure.openai.azure.com/v1 \
   "ping"
 ```
 
-호출 형식은 `ai-relay-cli <tool> [flags] [input]`입니다. tool 이름은
-공급자 API의 native 명명을 따릅니다 — 현재 OpenAI Chat Completions은
-`chat-completions`이고, 향후 Anthropic은 `messages`, OpenAI Responses는
-`responses`로 추가됩니다. 입력은 위치 인자이거나 stdin으로 파이프되며
+호출 형식은 `ai-relay-cli <provider> <tool> [flags] [input]`입니다.
+현재 provider는 `openai` 하나이며 `chat-completions` 도구를 노출합니다.
+향후 `anthropic`(`messages`), 추가 OpenAI `responses` 등이 레지스트리에
+편입될 예정입니다. 입력은 위치 인자이거나 stdin으로 파이프되며
 (정확히 하나 — XOR 관계). 평문 위치 인자는 `{messages:[…]}` 배열이 되고,
 JSON 리터럴 (`{` / `[`)은 그대로 전달됩니다.
 
@@ -70,7 +70,7 @@ JSON 리터럴 (`{` / `[`)은 그대로 전달됩니다.
 
 ---
 
-## 빠른 시작 — stdio MCP 서버 (`ai-relay <api-type>`)
+## 빠른 시작 — stdio MCP 서버 (`ai-relay <provider>`)
 
 Claude Desktop, Claude Code, Cursor 등 자식 프로세스를 spawn해 stdin/stdout으로
 JSON-RPC를 주고받는 MCP 호스트에 직접 등록할 때 사용합니다.
@@ -80,16 +80,17 @@ JSON-RPC를 주고받는 MCP 호스트에 직접 등록할 때 사용합니다.
   "mcpServers": {
     "ai-relay": {
       "command": "npx",
-      "args": ["-y", "ai-relay", "chat-completions"],
+      "args": ["-y", "ai-relay", "openai"],
       "env": { "AI_RELAY_API_KEY": "sk-..." }
     }
   }
 }
 ```
 
-`ai-relay <api-type>` 형태로 실행해 stdio MCP 서버 모드로 동작합니다
-(현재 지원되는 api-type은 `chat-completions` 하나). 단발 셸 호출에는
-`ai-relay-cli <tool> -m <model> "…"`를 사용합니다.
+`ai-relay <provider>` 형태로 실행해 stdio MCP 서버 모드로 동작합니다
+(현재 지원되는 provider는 `openai` 하나이며 `chat-completions` 도구를
+노출). 단발 셸 호출에는 `ai-relay-cli <provider> <tool> -m <model> "…"`를
+사용합니다.
 
 Azure OpenAI / vLLM / Ollama / AI Gateway 같은 OpenAI 호환 엔드포인트를
 가리키려면 `env` 블록에 `"AI_RELAY_BASE_URL"`을 추가:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ MCP host  ──►  ai-relay  ──►  OpenAI-compatible API
 
 | Surface | Transport | Install | When |
 |---|---|---|---|
-| `npx ai-relay-cli <tool> [flags] [input]` | none (one-shot) | none | quick test, scripting, CI smoke |
-| `npx ai-relay <api-type>` | stdio MCP | none | direct registration in Claude Desktop / Claude Code / Cursor |
+| `npx ai-relay-cli <provider> <tool> [flags] [input]` | none (one-shot) | none | quick test, scripting, CI smoke |
+| `npx ai-relay <provider>` | stdio MCP | none | direct registration in Claude Desktop / Claude Code / Cursor |
 | SDK (`ai-relay`) | caller's choice (stdio / HTTP / Workers) | npm | embed in custom MCP server |
 | App (`./app`, Hono) | HTTP | `git clone` (self-host on Node) | personal or team HTTP endpoint |
 | Docker (`ghcr.io/ragingwind/ai-relay`) | HTTP | `docker run` (no build) | container deployment, multi-arch (amd64/arm64) |
@@ -31,32 +31,32 @@ MCP host  ──►  ai-relay  ──►  OpenAI-compatible API
 ## Quick start — one-shot CLI (`ai-relay-cli`)
 
 ```bash
-AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions -m gpt-4o-mini "ping"
+AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
 
 # Model can also come from the JSON input itself
-AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions \
+AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions \
   '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'
 
 # …or from an env var
 AI_RELAY_API_KEY=sk-... AI_RELAY_MODEL=gpt-4o-mini \
-  npx ai-relay-cli chat-completions "ping"
+  npx ai-relay-cli openai chat-completions "ping"
 
 echo "explain TLS in 2 sentences" \
-  | AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions -m gpt-4o-mini -s "be terse"
+  | AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini -s "be terse"
 
 # Inline key via flag (no env var):
-npx ai-relay-cli chat-completions -m gpt-4o-mini --api-key sk-... "ping"
+npx ai-relay-cli openai chat-completions -m gpt-4o-mini --api-key sk-... "ping"
 
 # Point at Azure OpenAI / vLLM / Ollama / AI Gateway (any OpenAI-compatible endpoint):
-AI_RELAY_API_KEY=sk-... npx ai-relay-cli chat-completions -m gpt-4o-mini \
+AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini \
   --base-url https://my-azure.openai.azure.com/v1 \
   "ping"
 ```
 
-Invocation is `ai-relay-cli <tool> [flags] [input]`. The tool name
-follows the upstream API's native naming — `chat-completions` for OpenAI
-Chat Completions today; future entries will be `messages` for Anthropic
-and `responses` for OpenAI Responses. Input is either a positional
+Invocation is `ai-relay-cli <provider> <tool> [flags] [input]`. Today the
+only provider is `openai`, exposing `chat-completions`; future entries
+will be `anthropic` (with `messages`) and `openai` with `responses`.
+Input is either a positional
 argument or piped via stdin (exactly one — they are XOR). A plain-text
 positional becomes a `{messages:[…]}` array; a JSON literal (`{` / `[`) is
 passed verbatim.
@@ -72,7 +72,7 @@ are redacted; stdout JSON is never polluted.
 
 ---
 
-## Quick start — stdio MCP server (`ai-relay <api-type>`)
+## Quick start — stdio MCP server (`ai-relay <provider>`)
 
 For direct registration in Claude Desktop, Claude Code, Cursor, or any other
 MCP host that spawns a child process and speaks JSON-RPC over stdin/stdout:
@@ -82,16 +82,17 @@ MCP host that spawns a child process and speaks JSON-RPC over stdin/stdout:
   "mcpServers": {
     "ai-relay": {
       "command": "npx",
-      "args": ["-y", "ai-relay", "chat-completions"],
+      "args": ["-y", "ai-relay", "openai"],
       "env": { "AI_RELAY_API_KEY": "sk-..." }
     }
   }
 }
 ```
 
-Run `ai-relay <api-type>` to start the stdio MCP server (today the only
-api-type is `chat-completions`). For shell pipelines and one-shot
-invocation, use `ai-relay-cli <tool> -m <model> "…"`.
+Run `ai-relay <provider>` to start the stdio MCP server (today the only
+provider is `openai`, which exposes the `chat-completions` tool). For
+shell pipelines and one-shot invocation, use
+`ai-relay-cli <provider> <tool> -m <model> "…"`.
 
 Point at an OpenAI-compatible endpoint (Azure OpenAI / vLLM / Ollama / AI
 Gateway) by adding `"AI_RELAY_BASE_URL"` to the `env` block:

--- a/doc/ARCHITECTURE.ko.md
+++ b/doc/ARCHITECTURE.ko.md
@@ -141,8 +141,8 @@ mcp-ai-relay/                              # 저장소 루트 — pnpm 워크스
 │       │   ├── index.ts                # 공개 re-export (auth)
 │       │   ├── auth.ts                 # verifyBearer (portable, node:crypto 불필요)
 │       │   ├── bin/
-│       │   │   ├── ai-relay.ts         # bin 진입점 — `ai-relay <api-type>` MCP stdio 서버
-│       │   │   ├── ai-relay-cli.ts     # bin 진입점 — `ai-relay-cli <tool> [flags] [input]` 단발 실행
+│       │   │   ├── ai-relay.ts         # bin 진입점 — `ai-relay <provider>` MCP stdio 서버
+│       │   │   ├── ai-relay-cli.ts     # bin 진입점 — `ai-relay-cli <provider> <tool> [flags] [input]` 단발 실행
 │       │   │   ├── mcp-server.ts       # startMcpServer({apiType,config}) — 순수 라이브러리 함수
 │       │   │   ├── run.ts              # 단발 CLI 오케스트레이터(ai-relay-cli에서 사용)
 │       │   │   ├── parse.ts            # parseArgv (CLI) + parseMcpArgv (MCP)
@@ -338,6 +338,7 @@ export function verifyToken(req: Request, bearerToken: string | undefined) {
 - **Observability** — OpenTelemetry traces + Pino NDJSON 로그 + (선택) Sentry
 - **Progress notifications** — `_meta.progressToken` 처리, 진행 메시지 발행
 - **Tools/function-calling pass-through** — `tool_calls` 결과를 `structuredContent`로 직렬화
+- **서버당 다중 provider** — `ai-relay <provider-a> <provider-b> ...` 로 여러 provider의 도구를 동일 MCP 서버에 등록. 도입 시 도구 이름은 `<provider>.<api>` 네임스페이스로 마이그레이션해 충돌을 방지.
 
 ---
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -142,8 +142,8 @@ mcp-ai-relay/                              # repo root — pnpm workspace orches
 │       │   ├── index.ts                # public re-exports (auth)
 │       │   ├── auth.ts                 # verifyBearer (portable, no node:crypto)
 │       │   ├── bin/
-│       │   │   ├── ai-relay.ts         # bin entry — `ai-relay <api-type>` MCP stdio server
-│       │   │   ├── ai-relay-cli.ts     # bin entry — `ai-relay-cli <tool> [flags] [input]` one-shot
+│       │   │   ├── ai-relay.ts         # bin entry — `ai-relay <provider>` MCP stdio server
+│       │   │   ├── ai-relay-cli.ts     # bin entry — `ai-relay-cli <provider> <tool> [flags] [input]` one-shot
 │       │   │   ├── mcp-server.ts       # startMcpServer({apiType,config}) — pure library function
 │       │   │   ├── run.ts              # one-shot CLI orchestrator (used by ai-relay-cli)
 │       │   │   ├── parse.ts            # parseArgv (CLI) + parseMcpArgv (MCP)
@@ -338,6 +338,7 @@ Principle: **mock only the OpenAI HTTP boundary** (MSW). Never mock the SDK modu
 - **Observability** — OpenTelemetry traces + Pino NDJSON logs + (optional) Sentry
 - **Progress notifications** — handle `_meta.progressToken` and emit progress messages
 - **Tools/function-calling pass-through** — serialize `tool_calls` results into `structuredContent`
+- **Multi-provider per server** — `ai-relay <provider-a> <provider-b> ...` to register multiple providers' tools on a single MCP server. When introduced, tool names migrate to `<provider>.<api>` namespacing to avoid collisions.
 
 ---
 

--- a/doc/QA-MCP-INSPECTOR.ko.md
+++ b/doc/QA-MCP-INSPECTOR.ko.md
@@ -94,10 +94,10 @@ OpenAI 요청/JSON-RPC 트래픽을 들여다봐야 할 때는 bin에 `-v` / `--
 Inspector가 읽는 stdout JSON-RPC 채널은 깨끗하게 유지됩니다.
 
 ```bash
-ai-relay-cli chat-completions -v -m gpt-4o-mini "ping"
+ai-relay-cli openai chat-completions -v -m gpt-4o-mini "ping"
 
 AI_RELAY_VERBOSE=1 npx @modelcontextprotocol/inspector --cli \
-  node packages/ai-relay/dist/bin/ai-relay.js chat-completions \
+  node packages/ai-relay/dist/bin/ai-relay.js openai \
   --method tools/list
 ```
 

--- a/doc/QA-MCP-INSPECTOR.md
+++ b/doc/QA-MCP-INSPECTOR.md
@@ -95,10 +95,10 @@ written to **stderr** so the stdout JSON-RPC channel that Inspector reads
 remains clean.
 
 ```bash
-ai-relay-cli chat-completions -v -m gpt-4o-mini "ping"
+ai-relay-cli openai chat-completions -v -m gpt-4o-mini "ping"
 
 AI_RELAY_VERBOSE=1 npx @modelcontextprotocol/inspector --cli \
-  node packages/ai-relay/dist/bin/ai-relay.js chat-completions \
+  node packages/ai-relay/dist/bin/ai-relay.js openai \
   --method tools/list
 ```
 

--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -7,12 +7,13 @@ server.
 
 The SDK ships two bins:
 
-- **`ai-relay <api-type>`** — long-lived stdio MCP server keyed by an
-  api-type positional (today: `chat-completions`).
-- **`ai-relay-cli <tool> [flags] [input]`** — one-shot CLI invocation
-  that prints a single tool result as JSON. The model is resolved from
-  the input JSON's `model` field, the `-m`/`--model` flag, or
-  `AI_RELAY_MODEL` (in that order).
+- **`ai-relay <provider>`** — long-lived stdio MCP server keyed by a
+  provider positional (today: `openai`, which mounts
+  `chat-completions`).
+- **`ai-relay-cli <provider> <tool> [flags] [input]`** — one-shot CLI
+  invocation that prints a single tool result as JSON. The model is
+  resolved from the input JSON's `model` field, the `-m`/`--model`
+  flag, or `AI_RELAY_MODEL` (in that order).
 
 > **v0.6.0** ships only the OpenAI provider, exposed as `chat-completions`
 > (the upstream API's native name). Future provider tools — `messages`
@@ -41,37 +42,39 @@ compatibility — Bun, Deno, Cloudflare Workers with `nodejs_compat`).
 
 This package ships two bins:
 
-- **`ai-relay <api-type>`** — long-lived stdio MCP server that an MCP
+- **`ai-relay <provider>`** — long-lived stdio MCP server that an MCP
   host (Claude Desktop, Claude Code, Cursor, …) spawns as a child
-  process. The `<api-type>` positional (today: `chat-completions`)
-  selects which upstream API is registered. Speaks the JSON-RPC MCP
-  protocol over stdin/stdout. See
+  process. The `<provider>` positional (today: `openai`) selects which
+  upstream provider is mounted; all of that provider's tools are then
+  registered on the server. Speaks the JSON-RPC MCP protocol over
+  stdin/stdout. See
   [Claude Desktop / Claude Code / Cursor — stdio MCP server](#claude-desktop--claude-code--cursor--stdio-mcp-server)
   below.
-- **`ai-relay-cli <tool> [flags] [input]`** — one-shot
+- **`ai-relay-cli <provider> <tool> [flags] [input]`** — one-shot
   invocation that prints a single tool result as JSON to stdout, then
   exits. For scripts, CI smoke tests, and ad-hoc use.
 
 ### One-shot CLI
 
-`ai-relay-cli <tool> [flags] [input]` — prints the tool result
-as JSON on stdout.
+`ai-relay-cli <provider> <tool> [flags] [input]` — prints the tool
+result as JSON on stdout.
 
 ```bash
-ai-relay-cli chat-completions -m gpt-4o-mini "ping"
-ai-relay-cli chat-completions --model gpt-4o-mini -s "be terse" "explain TLS"
-ai-relay-cli chat-completions '{"model":"gpt-4o","messages":[{"role":"user","content":"ping"}]}'
-AI_RELAY_MODEL=gpt-4o-mini ai-relay-cli chat-completions "ping"
-ai-relay-cli chat-completions -m gpt-4o-mini --api-key sk-... "ping"
-ai-relay-cli chat-completions -m gpt-4o-mini --base-url https://my-azure.openai.azure.com/v1 "ping"
-ai-relay-cli chat-completions -m gpt-4o-mini --env ./prod.env "ping"
-echo '{"messages":[…]}' | ai-relay-cli chat-completions -m gpt-4o-mini
+ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
+ai-relay-cli openai chat-completions --model gpt-4o-mini -s "be terse" "explain TLS"
+ai-relay-cli openai chat-completions '{"model":"gpt-4o","messages":[{"role":"user","content":"ping"}]}'
+AI_RELAY_MODEL=gpt-4o-mini ai-relay-cli openai chat-completions "ping"
+ai-relay-cli openai chat-completions -m gpt-4o-mini --api-key sk-... "ping"
+ai-relay-cli openai chat-completions -m gpt-4o-mini --base-url https://my-azure.openai.azure.com/v1 "ping"
+ai-relay-cli openai chat-completions -m gpt-4o-mini --env ./prod.env "ping"
+echo '{"messages":[…]}' | ai-relay-cli openai chat-completions -m gpt-4o-mini
 ```
 
-Only the tool name is a required positional; it follows the upstream
-API's native naming — `chat-completions` for OpenAI Chat Completions
-today; future entries (e.g. `messages` for Anthropic, `responses` for
-OpenAI Responses) will be added as additional keys.
+`<provider>` selects the upstream (today: `openai`); `<tool>` is looked
+up within that provider's scope. Tool names follow the upstream API's
+native naming — `chat-completions` for OpenAI Chat Completions today;
+future entries (e.g. `messages` for Anthropic, `responses` for OpenAI
+Responses) will be added as additional keys.
 
 Input is either a positional argument or piped via stdin (exactly one).
 A positional starting with `{` or `[` is parsed as a JSON literal;
@@ -109,8 +112,8 @@ Pass `-v` / `--verbose`, or set `AI_RELAY_VERBOSE=1` (`true` / `yes` /
 **stderr**. The stdout JSON channel is never polluted.
 
 ```bash
-ai-relay-cli chat-completions -v -m gpt-4o-mini "ping"   # one-shot CLI
-AI_RELAY_VERBOSE=1 ai-relay chat-completions             # MCP server
+ai-relay-cli openai chat-completions -v -m gpt-4o-mini "ping"   # one-shot CLI
+AI_RELAY_VERBOSE=1 ai-relay openai                              # MCP server
 ```
 
 Stages emitted:
@@ -140,8 +143,8 @@ CLI flags > `--env` file > process env > built-in defaults.
 
 ### Claude Desktop / Claude Code / Cursor — stdio MCP server
 
-Invoke the `ai-relay` bin with the `<api-type>` positional (today:
-`chat-completions`) and it runs as a long-lived stdio MCP server that
+Invoke the `ai-relay` bin with the `<provider>` positional (today:
+`openai`) and it runs as a long-lived stdio MCP server that
 an MCP host can spawn directly. It accepts the configuration flags
 (`--api-key`, `--base-url`, `--max-tokens`, `--timeout`, `--env`) and
 reads `AI_RELAY_*` env vars.
@@ -151,7 +154,7 @@ reads `AI_RELAY_*` env vars.
   "mcpServers": {
     "ai-relay": {
       "command": "npx",
-      "args": ["-y", "ai-relay", "chat-completions"],
+      "args": ["-y", "ai-relay", "openai"],
       "env": { "AI_RELAY_API_KEY": "sk-..." }
     }
   }
@@ -161,18 +164,17 @@ reads `AI_RELAY_*` env vars.
 Point at an OpenAI-compatible endpoint (Azure / vLLM / Ollama / AI
 Gateway) by adding `"AI_RELAY_BASE_URL"` to the `env` block, or by
 passing `--base-url <url>` in `args` (e.g.
-`"args": ["-y", "ai-relay", "chat-completions", "--base-url", "https://my-azure.openai.azure.com/v1"]`).
+`"args": ["-y", "ai-relay", "openai", "--base-url", "https://my-azure.openai.azure.com/v1"]`).
 
 Project-local `.mcp.json` works the same way — pass the absolute path
-to the installed bin (or `npx ai-relay`) plus the `chat-completions`
-positional.
+to the installed bin (or `npx ai-relay`) plus the `openai` positional.
 
 ```json
 {
   "mcpServers": {
     "ai-relay": {
       "command": "node",
-      "args": ["./node_modules/ai-relay/dist/bin/ai-relay.js", "chat-completions"],
+      "args": ["./node_modules/ai-relay/dist/bin/ai-relay.js", "openai"],
       "env": { "AI_RELAY_API_KEY": "sk-..." }
     }
   }

--- a/packages/ai-relay/src/bin/ai-relay-cli.ts
+++ b/packages/ai-relay/src/bin/ai-relay-cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// `ai-relay-cli <tool> [flags] [input]` — one-shot CLI relay.
+// `ai-relay-cli <provider> <tool> [flags] [input]` — one-shot CLI relay.
 // Prints a single tool result as JSON to stdout, then exits.
 
 import { run } from "./run.js";

--- a/packages/ai-relay/src/bin/ai-relay.ts
+++ b/packages/ai-relay/src/bin/ai-relay.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// `ai-relay <api-type>` — start an MCP stdio server that relays calls
-// to the upstream provider keyed by `<api-type>` (today: chat-completions).
+// `ai-relay <provider>` — start an MCP stdio server that relays calls
+// to the upstream provider's tools (today: openai → chat-completions).
 
 import { realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -17,18 +17,18 @@ import {
 } from "./logger.js";
 import { startMcpServer } from "./mcp-server.js";
 import { type ParsedMcpInvocation, parseMcpArgv, UsageError } from "./parse.js";
-import { registry, resolveApiType } from "./registry.js";
+import { registry, resolveProvider } from "./registry.js";
 
 export { VERSION };
 
-const USAGE = `Usage: ai-relay <api-type> [flags]
+const USAGE = `Usage: ai-relay <provider> [flags]
 
-Start an MCP stdio server that relays calls to the given API. Intended to be
-spawned by an MCP host (Claude Desktop, Claude Code, Cursor, …) — do not run
-interactively.
+Start an MCP stdio server that relays calls to the given provider's tools.
+Intended to be spawned by an MCP host (Claude Desktop, Claude Code, Cursor, …)
+— do not run interactively.
 
-API types:
-  chat-completions  OpenAI Chat Completions API
+Providers:
+  ${Object.keys(registry).join(", ")}
 
 Flags:
       --api-key <key>     Upstream API key (overrides AI_RELAY_API_KEY)
@@ -45,7 +45,7 @@ Example claude_desktop_config.json:
     "mcpServers": {
       "ai-relay": {
         "command": "npx",
-        "args": ["-y", "ai-relay", "chat-completions"],
+        "args": ["-y", "ai-relay", "openai"],
         "env": { "AI_RELAY_API_KEY": "sk-..." }
       }
     }
@@ -54,10 +54,10 @@ Example claude_desktop_config.json:
 For one-shot CLI invocation (no MCP server), use \`ai-relay-cli\`.
 `;
 
-const USAGE_NO_API_TYPE = `error: <api-type> positional is required
+const USAGE_NO_PROVIDER = `error: <provider> positional is required
 
-usage: ai-relay <api-type> [flags]
-api types: ${Object.keys(registry).join(", ")}
+usage: ai-relay <provider> [flags]
+providers: ${Object.keys(registry).join(", ")}
 
 For one-shot CLI invocation, use \`ai-relay-cli\`.
 `;
@@ -95,21 +95,21 @@ export async function main(argv: readonly string[], io: AiRelayIO): Promise<numb
   });
   verbose.log("argv", redactArgv(argv));
   verbose.log("parsed-flags", {
-    apiType: parsed.apiType,
+    provider: parsed.provider,
     flags: redactMcpFlags(parsed.flags),
     verbose: parsed.verbose,
   });
   verbose.log("env-snapshot", snapshotRelayEnv(io.env));
 
-  if (parsed.apiType === undefined) {
-    io.stderr.write(USAGE_NO_API_TYPE);
+  if (parsed.provider === undefined) {
+    io.stderr.write(USAGE_NO_PROVIDER);
     return 2;
   }
 
-  const apiType = resolveApiType(parsed.apiType);
-  if (apiType === undefined) {
+  const providerEntry = resolveProvider(parsed.provider);
+  if (providerEntry === undefined) {
     io.stderr.write(
-      `unknown api-type: ${parsed.apiType}\nknown api types: ${Object.keys(registry).join(", ")}\n`,
+      `unknown provider: ${parsed.provider}\nknown providers: ${Object.keys(registry).join(", ")}\n`,
     );
     return 2;
   }
@@ -164,7 +164,8 @@ export async function main(argv: readonly string[], io: AiRelayIO): Promise<numb
   });
 
   await startMcpServer({
-    apiType,
+    provider: parsed.provider,
+    providerEntry,
     version: VERSION,
     logger: verbose,
     config: {

--- a/packages/ai-relay/src/bin/mcp-server.ts
+++ b/packages/ai-relay/src/bin/mcp-server.ts
@@ -1,15 +1,16 @@
 // MCP stdio server library function. The argv-parsing entrypoint lives
 // in `ai-relay.ts`; this module exposes a pure starter that takes a
-// resolved api-type + config and connects the stdio transport.
+// resolved provider + config and connects the stdio transport.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { OpenAIChatConfig } from "../openai/index.js";
 import type { VerboseLogger } from "./logger.js";
-import { type ApiType, registry } from "./registry.js";
+import type { ProviderEntry } from "./registry.js";
 
 export interface StartMcpServerOptions {
-  apiType: ApiType;
+  provider: string;
+  providerEntry: ProviderEntry;
   config: OpenAIChatConfig;
   version: string;
   logger?: VerboseLogger;
@@ -17,14 +18,14 @@ export interface StartMcpServerOptions {
 
 export async function startMcpServer(opts: StartMcpServerOptions): Promise<void> {
   const server = new McpServer({ name: "ai-relay", version: opts.version });
-  registry[opts.apiType].registerMcp(server, opts.config);
+  opts.providerEntry.registerOnServer(server, opts.config);
 
   const logger = opts.logger;
   const transport = new StdioServerTransport();
 
   if (logger?.enabled) {
     logger.log("mcp-server-ready", {
-      apiType: opts.apiType,
+      provider: opts.provider,
       version: opts.version,
     });
     instrumentTransport(transport, logger);

--- a/packages/ai-relay/src/bin/parse.ts
+++ b/packages/ai-relay/src/bin/parse.ts
@@ -1,6 +1,6 @@
 // argv → ParsedInvocation. Pure module with no I/O.
 //
-// Surface: `ai-relay-cli <tool> [flags] [input]`
+// Surface: `ai-relay-cli <provider> <tool> [flags] [input]`
 //
 // Long flags: --system -s, --model -m, --api-key, --base-url,
 //             --max-tokens, --timeout, --env, --verbose -v,
@@ -29,6 +29,7 @@ export interface ParsedInvocation {
   help: boolean;
   version: boolean;
   verbose: boolean;
+  provider: string;
   tool: string;
   flags: ParsedFlags;
   positional?: string;
@@ -65,6 +66,7 @@ export function parseArgv(argv: readonly string[]): ParsedInvocation {
     help: false,
     version: false,
     verbose: false,
+    provider: "",
     tool: "",
     flags: {},
   };
@@ -169,21 +171,23 @@ export function parseArgv(argv: readonly string[]): ParsedInvocation {
     return out;
   }
 
-  if (positionals.length < 1) {
-    throw new UsageError("usage: ai-relay-cli <tool> [flags] [input]");
+  if (positionals.length < 2) {
+    throw new UsageError("usage: ai-relay-cli <provider> <tool> [flags] [input]");
   }
 
-  const tool = positionals[0];
-  if (tool === undefined) {
-    throw new UsageError("usage: ai-relay-cli <tool> [flags] [input]");
+  const provider = positionals[0];
+  const tool = positionals[1];
+  if (provider === undefined || tool === undefined) {
+    throw new UsageError("usage: ai-relay-cli <provider> <tool> [flags] [input]");
   }
+  out.provider = provider;
   out.tool = tool;
 
-  if (positionals.length > 2) {
+  if (positionals.length > 3) {
     throw new UsageError("at most one positional input is accepted after <tool>");
   }
-  if (positionals.length === 2) {
-    const pos = positionals[1];
+  if (positionals.length === 3) {
+    const pos = positionals[2];
     if (pos !== undefined) out.positional = pos;
   }
 
@@ -192,7 +196,7 @@ export function parseArgv(argv: readonly string[]): ParsedInvocation {
 
 // argv → ParsedMcpInvocation. Pure module with no I/O.
 //
-// Surface: `ai-relay <api-type> [flags]`
+// Surface: `ai-relay <provider> [flags]`
 // Flags: --api-key, --base-url, --max-tokens, --timeout, --env,
 //        --verbose -v, --help -h, --version -V.
 
@@ -208,7 +212,7 @@ export interface ParsedMcpInvocation {
   help: boolean;
   version: boolean;
   verbose: boolean;
-  apiType?: string;
+  provider?: string;
   flags: ParsedMcpFlags;
 }
 
@@ -304,9 +308,9 @@ export function parseMcpArgv(argv: readonly string[]): ParsedMcpInvocation {
     return out;
   }
   if (positionals.length > 1) {
-    throw new UsageError("usage: ai-relay <api-type> [flags]");
+    throw new UsageError("usage: ai-relay <provider> [flags]");
   }
   const first = positionals[0];
-  if (first !== undefined) out.apiType = first;
+  if (first !== undefined) out.provider = first;
   return out;
 }

--- a/packages/ai-relay/src/bin/registry.ts
+++ b/packages/ai-relay/src/bin/registry.ts
@@ -3,36 +3,35 @@ import {
   type OpenAIChatConfig,
   type OpenAIChatHandlerBundle,
   openAIChatTool,
-  registerOpenAIChat,
+  registerOpenAIProvider,
   type ToolDescriptor,
 } from "../openai/index.js";
 
 export type AnyTool = ToolDescriptor<OpenAIChatConfig, OpenAIChatHandlerBundle>;
 
-export interface RegistryEntry {
-  /** CLI one-shot handler bundle (used by `ai-relay-cli`). */
-  cli: AnyTool;
-  /** Register this tool on an `McpServer` (used by `ai-relay`). */
-  registerMcp: (server: McpServer, config: OpenAIChatConfig) => void;
+export interface ProviderEntry {
+  /** Mount all of this provider's API tools on an `McpServer`. */
+  registerOnServer: (server: McpServer, config: OpenAIChatConfig) => void;
+  /** CLI one-shot tool descriptors keyed by tool name. */
+  tools: Record<string, AnyTool>;
 }
 
-// Each key is the api-type exposed at the CLI / MCP surface and follows the
-// upstream provider's native API naming. Future entries: `messages` for
-// Anthropic Messages, `responses` for OpenAI Responses, etc.
 export const registry = {
-  "chat-completions": {
-    cli: openAIChatTool,
-    registerMcp: registerOpenAIChat,
+  openai: {
+    registerOnServer: registerOpenAIProvider,
+    tools: {
+      "chat-completions": openAIChatTool,
+    },
   },
-} as const satisfies Record<string, RegistryEntry>;
+} as const satisfies Record<string, ProviderEntry>;
 
-export type ApiType = keyof typeof registry;
+export type Provider = keyof typeof registry;
 
-export function resolveApiType(name: string): ApiType | undefined {
-  return name in registry ? (name as ApiType) : undefined;
+export function resolveProvider(name: string): ProviderEntry | undefined {
+  return (registry as Record<string, ProviderEntry>)[name];
 }
 
-export function resolveTool(tool: string): AnyTool | undefined {
-  const entry = (registry as Record<string, RegistryEntry>)[tool];
-  return entry?.cli;
+export function resolveProviderTool(provider: string, tool: string): AnyTool | undefined {
+  const entry = (registry as Record<string, ProviderEntry>)[provider];
+  return entry?.tools[tool];
 }

--- a/packages/ai-relay/src/bin/run.ts
+++ b/packages/ai-relay/src/bin/run.ts
@@ -16,14 +16,17 @@ import {
   summariseMessages,
 } from "./logger.js";
 import { type ParsedInvocation, parseArgv, UsageError } from "./parse.js";
-import { type AnyTool, resolveTool } from "./registry.js";
+import { type AnyTool, registry, resolveProvider, resolveProviderTool } from "./registry.js";
 
 export { VERSION };
 
-const USAGE = `Usage: ai-relay-cli <tool> [flags] [input]
+const USAGE = `Usage: ai-relay-cli <provider> <tool> [flags] [input]
 
-Positional:
-  <tool>                  Tool name (e.g. chat-completions)
+Positionals:
+  <provider>              Upstream provider (e.g. openai)
+  <tool>                  Tool name within the provider (e.g. chat-completions)
+
+Providers: ${Object.keys(registry).join(", ")}
 
 Inputs (exactly one of):
   positional <input>      JSON literal or plain text
@@ -47,15 +50,15 @@ Flags:
   -V, --version           Print SDK version
 
 Examples:
-  ai-relay-cli chat-completions -m gpt-4o-mini "ping"
-  ai-relay-cli chat-completions --model gpt-4o-mini -s "be terse" "explain TLS"
-  ai-relay-cli chat-completions '{"model":"gpt-4o","messages":[{"role":"user","content":"ping"}]}'
-  AI_RELAY_MODEL=gpt-4o-mini ai-relay-cli chat-completions "ping"
-  ai-relay-cli chat-completions -m gpt-4o-mini --api-key sk-... "ping"
-  ai-relay-cli chat-completions -m gpt-4o-mini --base-url https://my-azure.openai.azure.com/v1 "ping"
-  echo '{"messages":[…]}' | ai-relay-cli chat-completions -m gpt-4o-mini
+  ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
+  ai-relay-cli openai chat-completions --model gpt-4o-mini -s "be terse" "explain TLS"
+  ai-relay-cli openai chat-completions '{"model":"gpt-4o","messages":[{"role":"user","content":"ping"}]}'
+  AI_RELAY_MODEL=gpt-4o-mini ai-relay-cli openai chat-completions "ping"
+  ai-relay-cli openai chat-completions -m gpt-4o-mini --api-key sk-... "ping"
+  ai-relay-cli openai chat-completions -m gpt-4o-mini --base-url https://my-azure.openai.azure.com/v1 "ping"
+  echo '{"messages":[…]}' | ai-relay-cli openai chat-completions -m gpt-4o-mini
 
-Tip: \`ai-relay <api-type>\` (without -cli) starts the MCP stdio server.
+Tip: \`ai-relay <provider>\` (without -cli) starts the MCP stdio server.
 `;
 
 export interface RunIO {
@@ -91,6 +94,7 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
   });
   verbose.log("argv", redactArgv(argv));
   verbose.log("parsed-flags", {
+    provider: parsed.provider,
     tool: parsed.tool,
     positional: parsed.positional === undefined ? "(none)" : `(${parsed.positional.length} chars)`,
     flags: redactParsedFlags(parsed.flags),
@@ -98,9 +102,18 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
   });
   verbose.log("env-snapshot", snapshotRelayEnv(io.env));
 
-  const tool = resolveTool(parsed.tool);
+  const providerEntry = resolveProvider(parsed.provider);
+  if (!providerEntry) {
+    io.stderr.write(
+      `unknown provider: ${parsed.provider}\nknown providers: ${Object.keys(registry).join(", ")}\n`,
+    );
+    return 2;
+  }
+  const tool = resolveProviderTool(parsed.provider, parsed.tool);
   if (!tool) {
-    io.stderr.write(`unknown tool: ${parsed.tool}\n`);
+    io.stderr.write(
+      `unknown tool for provider ${parsed.provider}: ${parsed.tool}\nknown tools: ${Object.keys(providerEntry.tools).join(", ")}\n`,
+    );
     return 2;
   }
 

--- a/packages/ai-relay/src/openai/index.ts
+++ b/packages/ai-relay/src/openai/index.ts
@@ -3,6 +3,9 @@
 // Compatible with any OpenAI Chat Completions-shaped API: OpenAI proper,
 // Azure OpenAI, vLLM, Ollama, OpenRouter, Vercel AI Gateway (OpenAI mode).
 
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { type OpenAIChatConfig, registerOpenAIChat } from "./chat.js";
+
 export type {
   OpenAIChatConfig,
   OpenAIChatHandler,
@@ -27,3 +30,7 @@ export type {
   RequestScope,
 } from "./client.js";
 export { createOpenAIClient } from "./client.js";
+
+export function registerOpenAIProvider(server: McpServer, config: OpenAIChatConfig): void {
+  registerOpenAIChat(server, config);
+}

--- a/packages/ai-relay/tests/cli/spawn.test.ts
+++ b/packages/ai-relay/tests/cli/spawn.test.ts
@@ -26,7 +26,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
   it("H-1: positional plain text against mocked upstream → exit 0", async () => {
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "ping"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "ping"],
       env: happyEnv(),
     });
     expect(r.status).toBe(0);
@@ -39,7 +39,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
   it("H-2: stdin JSON → exit 0 + result on stdout", async () => {
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("hi back") }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini"],
       env: happyEnv(),
       input: '{"messages":[{"role":"user","content":"hi"}]}',
     });
@@ -52,7 +52,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
 
   it("H-3: positional plain text desugared into messages[role=user]", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(0);
@@ -64,7 +64,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
 
   it("H-4: --name flag is NOT supported → exit 2", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "--name", "foo", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "--name", "foo", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(2);
@@ -73,7 +73,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
 
   it("H-5: --description flag is NOT supported → exit 2", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "--description", "x", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "--description", "x", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(2);
@@ -83,7 +83,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
   it("H-6: AI_RELAY_MODEL env resolves model when no flag", async () => {
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
     const r = await runCli({
-      args: ["chat-completions", "ping"],
+      args: ["openai", "chat-completions", "ping"],
       env: { ...happyEnv(), AI_RELAY_MODEL: "gpt-4o-mini" },
     });
     expect(r.status).toBe(0);
@@ -97,6 +97,7 @@ describe("A: Positive — Happy Path Scenarios", () => {
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
     const r = await runCli({
       args: [
+        "openai",
         "chat-completions",
         "-m",
         "from-flag",
@@ -116,7 +117,7 @@ describe("C: Negative — Error / Exit Codes", () => {
       body: JSON.stringify({ error: { message: "no auth" } }),
     }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(1);
@@ -131,7 +132,7 @@ describe("C: Negative — Error / Exit Codes", () => {
       body: JSON.stringify({ error: { message: "slow down" } }),
     }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(1);
@@ -146,7 +147,7 @@ describe("C: Negative — Error / Exit Codes", () => {
       body: JSON.stringify({ error: { message: "boom" } }),
     }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(1);
@@ -158,7 +159,7 @@ describe("C: Negative — Error / Exit Codes", () => {
   it("E-4: --timeout exceeded → exit 1 + code 'upstream_error'", async () => {
     mock.setResponse(() => ({ status: 200, body: "", hang: true }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "--timeout", "200", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "--timeout", "200", "hi"],
       env: happyEnv(),
       timeoutMs: 5_000,
     });
@@ -170,7 +171,7 @@ describe("C: Negative — Error / Exit Codes", () => {
 
   it("E-5: connection refused → exit 1 + isError + code 'upstream_error'", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: "http://127.0.0.1:1/v1" },
       timeoutMs: 10_000,
     });
@@ -182,7 +183,7 @@ describe("C: Negative — Error / Exit Codes", () => {
 
   it("E-6: invalid JSON on stdin (leading '{') → exit 2 + 'not valid JSON' on stderr", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini"],
       env: happyEnv(),
       input: "{not-valid-json",
     });
@@ -192,7 +193,7 @@ describe("C: Negative — Error / Exit Codes", () => {
 
   it("E-7: messages is not an array → exit 1 + ZodError on stderr", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini"],
       env: happyEnv(),
       input: '{"messages":"not-an-array"}',
     });
@@ -202,7 +203,7 @@ describe("C: Negative — Error / Exit Codes", () => {
 
   it("E-8: no model from any source on plain text → exit 2 + 'no model resolved'", async () => {
     const r = await runCli({
-      args: ["chat-completions", "hi"],
+      args: ["openai", "chat-completions", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(2);
@@ -217,18 +218,27 @@ describe("B: Argv / Env handling", () => {
     expect(r.stderr).toMatch(/usage:|--model|provider/i);
   });
 
-  it("A-2: unknown provider/tool → exit 2", async () => {
+  it("A-2: unknown provider → exit 2", async () => {
     const r = await runCli({
-      args: ["nope", "hi"],
+      args: ["nope", "chat-completions", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(2);
-    expect(r.stderr).toContain("unknown tool: nope");
+    expect(r.stderr).toContain("unknown provider: nope");
+  });
+
+  it("A-2b: unknown tool for known provider → exit 2", async () => {
+    const r = await runCli({
+      args: ["openai", "messages", "hi"],
+      env: happyEnv(),
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("unknown tool for provider openai: messages");
   });
 
   it("A-3: openai chat without AI_RELAY_API_KEY → exit 2 mentioning apiKey", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: {},
     });
     expect(r.status).toBe(2);
@@ -251,7 +261,7 @@ describe("B: Argv / Env handling", () => {
 
   it("A-6: env-only happy path (no flags besides -m) → exit 0", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(0);
@@ -263,7 +273,7 @@ describe("B: Argv / Env handling", () => {
 describe("D: Resilience / Lifecycle", () => {
   it("R-1: closed stdin + no positional → exit 2 within 1 s", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini"],
       env: happyEnv(),
       timeoutMs: 1_000,
     });
@@ -275,7 +285,7 @@ describe("D: Resilience / Lifecycle", () => {
   it("R-2: SIGTERM during slow upstream → child exits within 2 s", async () => {
     mock.setResponse(() => ({ status: 200, body: "", hang: true }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
       killAfterMs: 200,
       killSignal: "SIGTERM",
@@ -289,7 +299,7 @@ describe("D: Resilience / Lifecycle", () => {
   it("R-3: SIGINT during slow upstream → child exits within 2 s", async () => {
     mock.setResponse(() => ({ status: 200, body: "", hang: true }));
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
       killAfterMs: 200,
       killSignal: "SIGINT",
@@ -302,7 +312,7 @@ describe("D: Resilience / Lifecycle", () => {
 
   it("R-4: stdout is JSON-only, stderr is not JSON", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(0);
@@ -324,7 +334,7 @@ describe("D: Resilience / Lifecycle", () => {
       return { status: 200, body: defaultSseBody("ok") };
     });
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini"],
       env: happyEnv(),
       inputStream: async (stdin) => {
         const chunkSize = 8 * 1024;
@@ -344,7 +354,7 @@ describe("D: Resilience / Lifecycle", () => {
   it("R-6a: failing --env path does not echo AI_RELAY_API_KEY", async () => {
     const canary = "leak-canary-XYZ";
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "--env", "/no/such.env", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "--env", "/no/such.env", "hi"],
       env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(2);
@@ -355,7 +365,7 @@ describe("D: Resilience / Lifecycle", () => {
   it("R-6b: happy path does not echo AI_RELAY_API_KEY on stderr", async () => {
     const canary = "leak-canary-HAPPY";
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(0);
@@ -364,7 +374,7 @@ describe("D: Resilience / Lifecycle", () => {
 
   it("V-1: -v flag emits verbose stage lines on stderr, stdout is single JSON line", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-v", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"],
       env: happyEnv(),
     });
     expect(r.status).toBe(0);
@@ -378,7 +388,7 @@ describe("D: Resilience / Lifecycle", () => {
 
   it("V-2: AI_RELAY_VERBOSE=1 env enables verbose without the flag", async () => {
     const r = await runCli({
-      args: ["chat-completions", "-m", "gpt-4o-mini", "hi"],
+      args: ["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"],
       env: { ...happyEnv(), AI_RELAY_VERBOSE: "1" },
     });
     expect(r.status).toBe(0);
@@ -389,7 +399,7 @@ describe("D: Resilience / Lifecycle", () => {
   it("V-3: -v + secret API key → secret never appears in stderr", async () => {
     const canary = "sk-leak-canary-VERBOSE";
     const r = await runCli({
-      args: ["chat-completions", "-v", "-m", "gpt-4o-mini", "--api-key", canary, "hi"],
+      args: ["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "--api-key", canary, "hi"],
       env: { AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(0);

--- a/packages/ai-relay/tests/integration/bin-tarball.test.ts
+++ b/packages/ai-relay/tests/integration/bin-tarball.test.ts
@@ -203,9 +203,13 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
     mock.requests.length = 0;
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
 
-    const r = await runBin(cliBinPath, ["chat-completions", "-m", "gpt-4o-mini", "ping"], {
-      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
-    });
+    const r = await runBin(
+      cliBinPath,
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "ping"],
+      {
+        env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+      },
+    );
     expect(r.status).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.isError).toBe(false);
@@ -217,7 +221,7 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
     mock.requests.length = 0;
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
 
-    const r = await runBin(cliBinPath, ["chat-completions", "ping"], {
+    const r = await runBin(cliBinPath, ["openai", "chat-completions", "ping"], {
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(2);
@@ -229,7 +233,7 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
     mock.requests.length = 0;
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
 
-    const r = await runBin(cliBinPath, ["chat-completions", "-m", "gpt-4o-mini"], {
+    const r = await runBin(cliBinPath, ["openai", "chat-completions", "-m", "gpt-4o-mini"], {
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
       input: '{"messages":[{"role":"user","content":"ping"}]}',
     });
@@ -249,7 +253,7 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
 
     const r = await runBin(
       cliBinPath,
-      ["chat-completions", "-m", "gpt-4o-mini", "--env", envFile, "hi"],
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "--env", envFile, "hi"],
       { env: { AI_RELAY_API_KEY: "systemkey" } },
     );
     expect(r.status).toBe(0);
@@ -266,7 +270,7 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
     mock.requests.length = 0;
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
 
-    const r = await runBin(cliBinPath, ["chat-completions", "ping"], {
+    const r = await runBin(cliBinPath, ["openai", "chat-completions", "ping"], {
       env: {
         AI_RELAY_API_KEY: "test-k",
         AI_RELAY_BASE_URL: mock.baseURL,
@@ -285,9 +289,13 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
     mock.requests.length = 0;
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("hello world") }));
 
-    const r1 = await runBin(cliBinPath, ["chat-completions", "-m", "gpt-4o-mini", "ping"], {
-      env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
-    });
+    const r1 = await runBin(
+      cliBinPath,
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "ping"],
+      {
+        env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
+      },
+    );
     expect(r1.status).toBe(0);
     const out1 = JSON.parse(r1.stdout.trim());
     expect(out1.isError).toBe(false);
@@ -295,7 +303,7 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
 
     mock.requests.length = 0;
     mock.setResponse(() => ({ status: 200, body: defaultSseBody("ok") }));
-    const r2 = await runBin(cliBinPath, ["chat-completions", "-m", "gpt-4o-mini"], {
+    const r2 = await runBin(cliBinPath, ["openai", "chat-completions", "-m", "gpt-4o-mini"], {
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
       input: '{"messages":[{"role":"user","content":"hi"}]}',
     });
@@ -305,7 +313,7 @@ describe("ai-relay-cli bin — installed tarball, one-shot CLI mode", () => {
     });
 
     mock.requests.length = 0;
-    const r3 = await runBin(cliBinPath, ["chat-completions", "plain-text-input"], {
+    const r3 = await runBin(cliBinPath, ["openai", "chat-completions", "plain-text-input"], {
       env: {
         AI_RELAY_API_KEY: "test-k",
         AI_RELAY_BASE_URL: mock.baseURL,
@@ -406,10 +414,10 @@ const initializedNotification = {
   method: "notifications/initialized",
 };
 
-describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions positional)", () => {
+describe("ai-relay bin — installed tarball, MCP stdio mode (openai provider positional)", () => {
   it("A1: initialize handshake returns protocolVersion + serverInfo", async () => {
     const r = await runMcpSession([initRequest, initializedNotification], {
-      args: ["chat-completions"],
+      args: ["openai"],
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(0);
@@ -428,7 +436,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
     const r = await runMcpSession(
       [initRequest, initializedNotification, { jsonrpc: "2.0", id: 2, method: "tools/list" }],
       {
-        args: ["chat-completions"],
+        args: ["openai"],
         env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
       },
     );
@@ -466,7 +474,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
         },
       ],
       {
-        args: ["chat-completions"],
+        args: ["openai"],
         env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
       },
     );
@@ -487,7 +495,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
     expect(callRes?.structuredContent?.model).toBe("gpt-4o-mini");
   });
 
-  it("C1: bare invocation (no api-type) → exit 2 + usage on stderr; no upstream call", async () => {
+  it("C1: bare invocation (no provider) → exit 2 + usage on stderr; no upstream call", async () => {
     mock.requests.length = 0;
     const r = await runMcpSession([], {
       args: [],
@@ -495,27 +503,27 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(2);
-    expect(r.stderr).toContain("<api-type>");
-    expect(r.stderr).toContain("usage: ai-relay <api-type>");
+    expect(r.stderr).toContain("<provider>");
+    expect(r.stderr).toContain("usage: ai-relay <provider>");
     expect(mock.requests).toHaveLength(0);
   });
 
-  it("C2: unknown api-type → exit 2; no upstream call", async () => {
+  it("C2: unknown provider → exit 2; no upstream call", async () => {
     mock.requests.length = 0;
     const r = await runMcpSession([], {
-      args: ["messages"],
+      args: ["anthropic"],
       expectStartupFailure: true,
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(2);
-    expect(r.stderr).toContain("unknown api-type: messages");
+    expect(r.stderr).toContain("unknown provider: anthropic");
     expect(mock.requests).toHaveLength(0);
   });
 
   it("D1: missing AI_RELAY_API_KEY → exits 2 with stderr message; no upstream call", async () => {
     mock.requests.length = 0;
     const r = await runMcpSession([initRequest], {
-      args: ["chat-completions"],
+      args: ["openai"],
       env: { AI_RELAY_API_KEY: undefined, AI_RELAY_BASE_URL: mock.baseURL },
       expectStartupFailure: true,
     });
@@ -531,7 +539,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
 
   it("D2: unknown flag exits 2", async () => {
     const r = await runMcpSession([], {
-      args: ["chat-completions", "--bogus"],
+      args: ["openai", "--bogus"],
       expectStartupFailure: true,
     });
     expect(r.status).toBe(2);
@@ -543,7 +551,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
     const r = await runMcpSession(
       [initRequest, initializedNotification, { jsonrpc: "2.0", id: 2, method: "tools/list" }],
       {
-        args: ["chat-completions", "--verbose"],
+        args: ["openai", "--verbose"],
         env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
       },
     );
@@ -557,7 +565,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
 
   it("V2: AI_RELAY_VERBOSE=1 enables verbose without the flag", async () => {
     const r = await runMcpSession([initRequest, initializedNotification], {
-      args: ["chat-completions"],
+      args: ["openai"],
       env: {
         AI_RELAY_API_KEY: "test-k",
         AI_RELAY_BASE_URL: mock.baseURL,
@@ -572,7 +580,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
   it("V3: --verbose redacts the AI_RELAY_API_KEY in stderr", async () => {
     const canary = "sk-mcp-leak-canary-9999";
     const r = await runMcpSession([initRequest, initializedNotification], {
-      args: ["chat-completions", "--verbose"],
+      args: ["openai", "--verbose"],
       env: { AI_RELAY_API_KEY: canary, AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(0);
@@ -603,7 +611,7 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (chat-completions p
         },
       ],
       {
-        args: ["chat-completions", "--verbose"],
+        args: ["openai", "--verbose"],
         env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
       },
     );

--- a/packages/ai-relay/tests/unit/ai-relay.test.ts
+++ b/packages/ai-relay/tests/unit/ai-relay.test.ts
@@ -1,4 +1,4 @@
-// Pre-startup unit tests for `ai-relay <api-type>` — covers argv parsing,
+// Pre-startup unit tests for `ai-relay <provider>` — covers argv parsing,
 // registry lookup, --help / --version, and config-error short circuits
 // before the stdio transport is ever constructed. The transport itself
 // is exercised by tests/integration/bin-tarball.test.ts.
@@ -39,15 +39,15 @@ describe("ai-relay — argv short-circuits", () => {
     const cap = makeIO();
     const code = await main(["--help"], cap.io);
     expect(code).toBe(0);
-    expect(cap.stdout.value).toContain("Usage: ai-relay <api-type>");
-    expect(cap.stdout.value).toContain("chat-completions");
+    expect(cap.stdout.value).toContain("Usage: ai-relay <provider>");
+    expect(cap.stdout.value).toContain("openai");
   });
 
   it("P2: -h prints usage on stdout, exit 0", async () => {
     const cap = makeIO();
     const code = await main(["-h"], cap.io);
     expect(code).toBe(0);
-    expect(cap.stdout.value).toContain("Usage: ai-relay <api-type>");
+    expect(cap.stdout.value).toContain("Usage: ai-relay <provider>");
   });
 
   it("P3: --version prints SDK version on stdout, exit 0", async () => {
@@ -70,21 +70,21 @@ describe("ai-relay — argv short-circuits", () => {
 });
 
 describe("ai-relay — usage / registry errors", () => {
-  it("D1: bare invocation (no api-type) → exit 2 + usage on stderr", async () => {
+  it("D1: bare invocation (no provider) → exit 2 + usage on stderr", async () => {
     const cap = makeIO();
     const code = await main([], cap.io);
     expect(code).toBe(2);
-    expect(cap.stderr.value).toContain("<api-type>");
-    expect(cap.stderr.value).toContain("usage: ai-relay <api-type>");
+    expect(cap.stderr.value).toContain("<provider>");
+    expect(cap.stderr.value).toContain("usage: ai-relay <provider>");
     expect(cap.stdout.value).toBe("");
   });
 
-  it("D2: unknown api-type → exit 2 + 'unknown api-type' on stderr", async () => {
+  it("D2: unknown provider → exit 2 + 'unknown provider' on stderr", async () => {
     const cap = makeIO({ AI_RELAY_API_KEY: "k" });
-    const code = await main(["messages"], cap.io);
+    const code = await main(["anthropic"], cap.io);
     expect(code).toBe(2);
-    expect(cap.stderr.value).toContain("unknown api-type: messages");
-    expect(cap.stderr.value).toContain("chat-completions");
+    expect(cap.stderr.value).toContain("unknown provider: anthropic");
+    expect(cap.stderr.value).toContain("openai");
   });
 
   it("D3: unknown long flag → exit 2 with stderr message", async () => {
@@ -103,14 +103,14 @@ describe("ai-relay — usage / registry errors", () => {
 
   it("D5: more than one positional rejected", async () => {
     const cap = makeIO();
-    const code = await main(["chat-completions", "extra"], cap.io);
+    const code = await main(["openai", "extra"], cap.io);
     expect(code).toBe(2);
-    expect(cap.stderr.value).toContain("usage: ai-relay <api-type>");
+    expect(cap.stderr.value).toContain("usage: ai-relay <provider>");
   });
 
   it("D6: --max-tokens with non-integer rejected (before registry lookup)", async () => {
     const cap = makeIO({ AI_RELAY_API_KEY: "k" });
-    const code = await main(["chat-completions", "--max-tokens", "abc"], cap.io);
+    const code = await main(["openai", "--max-tokens", "abc"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain("--max-tokens must be a positive integer");
   });
@@ -119,14 +119,14 @@ describe("ai-relay — usage / registry errors", () => {
 describe("ai-relay — config / env-file errors", () => {
   it("D1: missing AI_RELAY_API_KEY → exit 2 before stdio transport starts", async () => {
     const cap = makeIO({});
-    const code = await main(["chat-completions"], cap.io);
+    const code = await main(["openai"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value.toLowerCase()).toContain("apikey");
   });
 
   it("D2: missing --env file → exit 2 with file-read message", async () => {
     const cap = makeIO({ AI_RELAY_API_KEY: "k" });
-    const code = await main(["chat-completions", "--env", "/no/such/file.env"], cap.io);
+    const code = await main(["openai", "--env", "/no/such/file.env"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain("cannot read --env file");
   });

--- a/packages/ai-relay/tests/unit/cli.test.ts
+++ b/packages/ai-relay/tests/unit/cli.test.ts
@@ -1,11 +1,12 @@
-// Argv parser tests for `ai-relay-cli <tool> [flags] [input]`.
+// Argv parser tests for `ai-relay-cli <provider> <tool> [flags] [input]`.
 
 import { describe, expect, it } from "vitest";
 import { parseArgv, parseMcpArgv, UsageError } from "../../src/bin/parse.js";
 
 describe("parseArgv — basic shape", () => {
-  it("P1: <tool> <input> → ParsedInvocation", () => {
-    const out = parseArgv(["chat-completions", "hi"]);
+  it("P1: <provider> <tool> <input> → ParsedInvocation", () => {
+    const out = parseArgv(["openai", "chat-completions", "hi"]);
+    expect(out.provider).toBe("openai");
     expect(out.tool).toBe("chat-completions");
     expect(out.flags.model).toBeUndefined();
     expect(out.positional).toBe("hi");
@@ -13,58 +14,68 @@ describe("parseArgv — basic shape", () => {
     expect(out.version).toBe(false);
   });
 
-  it("P2: <tool> with no input is valid (stdin will be read by runner)", () => {
-    const out = parseArgv(["chat-completions"]);
+  it("P2: <provider> <tool> with no input is valid (stdin will be read by runner)", () => {
+    const out = parseArgv(["openai", "chat-completions"]);
+    expect(out.provider).toBe("openai");
     expect(out.tool).toBe("chat-completions");
     expect(out.positional).toBeUndefined();
   });
 
   it("P3: -m <model> captured as flag", () => {
-    const out = parseArgv(["chat-completions", "-m", "gpt-4o-mini", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"]);
     expect(out.flags.model).toBe("gpt-4o-mini");
     expect(out.positional).toBe("hi");
   });
 
   it("P4: long --model accepted", () => {
-    const out = parseArgv(["chat-completions", "--model", "gpt-4o", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "--model", "gpt-4o", "hi"]);
     expect(out.flags.model).toBe("gpt-4o");
   });
 
   it("P5: --model=value inline form works", () => {
-    const out = parseArgv(["chat-completions", "--model=gpt-4o-mini", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "--model=gpt-4o-mini", "hi"]);
     expect(out.flags.model).toBe("gpt-4o-mini");
   });
 
   it("P6: --system value preserved verbatim and supports multi-word", () => {
-    const out = parseArgv(["chat-completions", "-s", "be terse and concise", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "-s", "be terse and concise", "hi"]);
     expect(out.flags.system).toBe("be terse and concise");
   });
 
   it("P7: long --system also accepted", () => {
-    const out = parseArgv(["chat-completions", "--system", "be terse", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "--system", "be terse", "hi"]);
     expect(out.flags.system).toBe("be terse");
   });
 
   it("P8: --key=value and --key value are equivalent", () => {
-    const a = parseArgv(["chat-completions", "--system=be terse", "hi"]);
-    const b = parseArgv(["chat-completions", "--system", "be terse", "hi"]);
+    const a = parseArgv(["openai", "chat-completions", "--system=be terse", "hi"]);
+    const b = parseArgv(["openai", "chat-completions", "--system", "be terse", "hi"]);
     expect(a.flags.system).toBe("be terse");
     expect(b.flags.system).toBe("be terse");
   });
 
   it("P9: numeric flags (--max-tokens, --timeout) parse to integers", () => {
-    const out = parseArgv(["chat-completions", "--max-tokens", "1024", "--timeout", "30000", "hi"]);
+    const out = parseArgv([
+      "openai",
+      "chat-completions",
+      "--max-tokens",
+      "1024",
+      "--timeout",
+      "30000",
+      "hi",
+    ]);
     expect(out.flags["max-tokens"]).toBe(1024);
     expect(out.flags.timeout).toBe(30000);
   });
 
   it("P10: --env path captured", () => {
-    const out = parseArgv(["chat-completions", "--env", "./prod.env", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "--env", "./prod.env", "hi"]);
     expect(out.flags.env).toBe("./prod.env");
   });
 
   it("P11: --api-key and --base-url captured", () => {
     const out = parseArgv([
+      "openai",
       "chat-completions",
       "--api-key",
       "sk-secret",
@@ -77,7 +88,7 @@ describe("parseArgv — basic shape", () => {
   });
 
   it("P12: -m and -s combine cleanly", () => {
-    const out = parseArgv(["chat-completions", "-m", "gpt-4o", "-s", "be terse", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "-m", "gpt-4o", "-s", "be terse", "hi"]);
     expect(out.flags.model).toBe("gpt-4o");
     expect(out.flags.system).toBe("be terse");
     expect(out.positional).toBe("hi");
@@ -98,24 +109,24 @@ describe("parseArgv — help/version short-circuit", () => {
 
 describe("parseArgv — verbose flag", () => {
   it("P1: --verbose long flag sets verbose=true", () => {
-    const out = parseArgv(["chat-completions", "--verbose", "-m", "gpt-4o-mini", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "--verbose", "-m", "gpt-4o-mini", "hi"]);
     expect(out.verbose).toBe(true);
     expect(out.flags.model).toBe("gpt-4o-mini");
     expect(out.positional).toBe("hi");
   });
 
   it("P2: -v short flag sets verbose=true", () => {
-    const out = parseArgv(["chat-completions", "-v", "-m", "gpt-4o-mini", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"]);
     expect(out.verbose).toBe(true);
   });
 
   it("P3: omitted verbose flag → verbose=false", () => {
-    const out = parseArgv(["chat-completions", "-m", "gpt-4o-mini", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"]);
     expect(out.verbose).toBe(false);
   });
 
   it("P4: -v is a boolean — does NOT consume the next token as a value", () => {
-    const out = parseArgv(["chat-completions", "-v", "hi"]);
+    const out = parseArgv(["openai", "chat-completions", "-v", "hi"]);
     expect(out.verbose).toBe(true);
     expect(out.positional).toBe("hi");
   });
@@ -123,18 +134,18 @@ describe("parseArgv — verbose flag", () => {
 
 describe("parseMcpArgv — verbose flag", () => {
   it("P1: --verbose long flag sets verbose=true", () => {
-    const out = parseMcpArgv(["chat-completions", "--verbose"]);
+    const out = parseMcpArgv(["openai", "--verbose"]);
     expect(out.verbose).toBe(true);
-    expect(out.apiType).toBe("chat-completions");
+    expect(out.provider).toBe("openai");
   });
 
   it("P2: -v short flag sets verbose=true", () => {
-    const out = parseMcpArgv(["chat-completions", "-v"]);
+    const out = parseMcpArgv(["openai", "-v"]);
     expect(out.verbose).toBe(true);
   });
 
   it("P3: omitted verbose flag → verbose=false", () => {
-    const out = parseMcpArgv(["chat-completions"]);
+    const out = parseMcpArgv(["openai"]);
     expect(out.verbose).toBe(false);
   });
 });
@@ -145,43 +156,51 @@ describe("parseArgv — error paths", () => {
     expect(() => parseArgv([])).toThrow(/usage: ai-relay-cli/);
   });
 
+  it("D1b: single positional (provider only) rejected — tool is required", () => {
+    expect(() => parseArgv(["openai"])).toThrow(/usage: ai-relay-cli/);
+  });
+
   it("D2: unknown long flag → UsageError", () => {
-    expect(() => parseArgv(["chat-completions", "--bogus", "x"])).toThrow(/unknown flag: --bogus/);
+    expect(() => parseArgv(["openai", "chat-completions", "--bogus", "x"])).toThrow(
+      /unknown flag: --bogus/,
+    );
   });
 
   it("D3: unknown short flag → UsageError", () => {
-    expect(() => parseArgv(["chat-completions", "-x"])).toThrow(/unknown flag: -x/);
+    expect(() => parseArgv(["openai", "chat-completions", "-x"])).toThrow(/unknown flag: -x/);
   });
 
   it("D4: --max-tokens with non-integer value rejected", () => {
-    expect(() => parseArgv(["chat-completions", "--max-tokens", "abc", "hi"])).toThrow(
+    expect(() => parseArgv(["openai", "chat-completions", "--max-tokens", "abc", "hi"])).toThrow(
       /--max-tokens must be a positive integer/,
     );
   });
 
   it("D5: --max-tokens with zero rejected", () => {
-    expect(() => parseArgv(["chat-completions", "--max-tokens", "0", "hi"])).toThrow(
+    expect(() => parseArgv(["openai", "chat-completions", "--max-tokens", "0", "hi"])).toThrow(
       /must be a positive integer/,
     );
   });
 
   it("D6: more than one positional input rejected (model is no longer a positional)", () => {
-    expect(() => parseArgv(["chat-completions", "gpt-4o-mini", "hi"])).toThrow(
+    expect(() => parseArgv(["openai", "chat-completions", "gpt-4o-mini", "hi"])).toThrow(
       /at most one positional input/,
     );
   });
 
   it("D7: flag without value at end of argv rejected", () => {
-    expect(() => parseArgv(["chat-completions", "--api-key"])).toThrow(
+    expect(() => parseArgv(["openai", "chat-completions", "--api-key"])).toThrow(
       /--api-key requires a value/,
     );
   });
 
   it("D8: -m without value rejected", () => {
-    expect(() => parseArgv(["chat-completions", "-m"])).toThrow(/-m requires a value/);
+    expect(() => parseArgv(["openai", "chat-completions", "-m"])).toThrow(/-m requires a value/);
   });
 
   it("D9: --model without value rejected", () => {
-    expect(() => parseArgv(["chat-completions", "--model"])).toThrow(/--model requires a value/);
+    expect(() => parseArgv(["openai", "chat-completions", "--model"])).toThrow(
+      /--model requires a value/,
+    );
   });
 });

--- a/packages/ai-relay/tests/unit/run.test.ts
+++ b/packages/ai-relay/tests/unit/run.test.ts
@@ -105,11 +105,18 @@ describe("run — usage errors short-circuit", () => {
     expect(cap.stderr.value).toMatch(/usage: ai-relay-cli/);
   });
 
-  it("D2: unknown tool → exit 2", async () => {
+  it("D2: unknown provider → exit 2", async () => {
     const cap = makeIO();
-    const code = await run(["nope", "hi"], cap.io);
+    const code = await run(["nope", "chat-completions", "hi"], cap.io);
     expect(code).toBe(2);
-    expect(cap.stderr.value).toContain("unknown tool: nope");
+    expect(cap.stderr.value).toContain("unknown provider: nope");
+  });
+
+  it("D2b: unknown tool for known provider → exit 2", async () => {
+    const cap = makeIO();
+    const code = await run(["openai", "messages", "hi"], cap.io);
+    expect(code).toBe(2);
+    expect(cap.stderr.value).toContain("unknown tool for provider openai: messages");
   });
 
   it("D3: -h prints usage on stdout, exit 0", async () => {
@@ -130,7 +137,7 @@ describe("run — usage errors short-circuit", () => {
 describe("run — input handling", () => {
   it("D1: stdin + positional both present → exit 2 with conflict message", async () => {
     const cap = makeIO({ stdin: '{"messages":[]}' });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain("received both stdin and positional input");
   });
@@ -144,7 +151,7 @@ describe("run — input handling", () => {
       }),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(captured?.messages).toEqual([{ role: "user", content: "hi" }]);
     const out = JSON.parse(cap.stdout.value.trim());
@@ -165,7 +172,7 @@ describe("run — input handling", () => {
       stdin: '{"messages":[{"role":"user","content":"ping"}]}',
       env: { AI_RELAY_API_KEY: "k" },
     });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini"], cap.io);
     expect(code).toBe(0);
     expect(captured?.messages).toEqual([{ role: "user", content: "ping" }]);
     expect(captured?.model).toBe("gpt-4o-mini");
@@ -182,6 +189,7 @@ describe("run — input handling", () => {
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
     const code = await run(
       [
+        "openai",
         "chat-completions",
         "-m",
         "gpt-4o-mini",
@@ -195,7 +203,7 @@ describe("run — input handling", () => {
 
   it("D2: empty stdin pipe → exit 2 with empty-stdin message (not generic 'requires input')", async () => {
     const cap = makeIO({ stdin: "", env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain("empty stdin");
     expect(cap.stderr.value).not.toContain("requires input");
@@ -203,7 +211,7 @@ describe("run — input handling", () => {
 
   it("D3: positional JSON array → exit 2 with array-rejection message naming the tool", async () => {
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "[1,2,3]"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "[1,2,3]"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain(
       "input JSON for chat-completions must be an object, not an array",
@@ -220,7 +228,7 @@ describe("run — input handling", () => {
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
     const code = await run(
-      ["chat-completions", "-m", "gpt-4o-mini", "-s", "be terse", "hi"],
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "-s", "be terse", "hi"],
       cap.io,
     );
     expect(code).toBe(0);
@@ -241,7 +249,7 @@ describe("run — model resolution precedence", () => {
       }),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "from-flag", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "from-flag", "hi"], cap.io);
     expect(code).toBe(0);
     expect(captured?.model).toBe("from-flag");
   });
@@ -255,7 +263,7 @@ describe("run — model resolution precedence", () => {
       }),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k", AI_RELAY_MODEL: "from-env" } });
-    const code = await run(["chat-completions", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "hi"], cap.io);
     expect(code).toBe(0);
     expect(captured?.model).toBe("from-env");
   });
@@ -269,7 +277,7 @@ describe("run — model resolution precedence", () => {
       }),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k", AI_RELAY_MODEL: "from-env" } });
-    const code = await run(["chat-completions", "-m", "from-flag", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "from-flag", "hi"], cap.io);
     expect(code).toBe(0);
     expect(captured?.model).toBe("from-flag");
   });
@@ -285,6 +293,7 @@ describe("run — model resolution precedence", () => {
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k", AI_RELAY_MODEL: "from-env" } });
     const code = await run(
       [
+        "openai",
         "chat-completions",
         "-m",
         "from-flag",
@@ -305,14 +314,17 @@ describe("run — model resolution precedence", () => {
       }),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "--model", "from-long-flag", "hi"], cap.io);
+    const code = await run(
+      ["openai", "chat-completions", "--model", "from-long-flag", "hi"],
+      cap.io,
+    );
     expect(code).toBe(0);
     expect(captured?.model).toBe("from-long-flag");
   });
 
   it("D1: no model from any source on plain text input → exit 2 with helpful message", async () => {
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "hi"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain("no model resolved");
     expect(cap.stderr.value).toMatch(/-m\/--model/);
@@ -322,7 +334,7 @@ describe("run — model resolution precedence", () => {
   it("D2: no model on JSON input falls through to schema rejection (ZodError)", async () => {
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
     await expect(
-      run(["chat-completions", '{"messages":[{"role":"user","content":"hi"}]}'], cap.io),
+      run(["openai", "chat-completions", '{"messages":[{"role":"user","content":"hi"}]}'], cap.io),
     ).rejects.toThrow(/model/i);
   });
 });
@@ -344,7 +356,17 @@ describe("run — env precedence", () => {
     writeFileSync(envFile, "AI_RELAY_API_KEY=fromfile\n");
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "fromenv" } });
     const code = await run(
-      ["chat-completions", "-m", "gpt-4o-mini", "--api-key", "fromflag", "--env", envFile, "hi"],
+      [
+        "openai",
+        "chat-completions",
+        "-m",
+        "gpt-4o-mini",
+        "--api-key",
+        "fromflag",
+        "--env",
+        envFile,
+        "hi",
+      ],
       cap.io,
     );
     expect(code).toBe(0);
@@ -362,7 +384,7 @@ describe("run — env precedence", () => {
     writeFileSync(envFile, "AI_RELAY_API_KEY=fromfile\n");
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "fromenv" } });
     const code = await run(
-      ["chat-completions", "-m", "gpt-4o-mini", "--env", envFile, "hi"],
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "--env", envFile, "hi"],
       cap.io,
     );
     expect(code).toBe(0);
@@ -378,14 +400,14 @@ describe("run — env precedence", () => {
       }),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "fromenv" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(auth).toBe("Bearer fromenv");
   });
 
   it("D1: no key from any source → exit 2 with config error", async () => {
     const cap = makeIO();
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(2);
     expect(cap.stderr.value).toContain("apiKey");
   });
@@ -397,6 +419,7 @@ describe("run — secret redaction", () => {
     const cap = makeIO({ env: {} });
     const code = await run(
       [
+        "openai",
         "chat-completions",
         "-m",
         "gpt-4o-mini",
@@ -416,7 +439,7 @@ describe("run — secret redaction", () => {
     const sentinel = "leak-marker-env-file";
     const cap = makeIO({ env: { AI_RELAY_API_KEY: sentinel } });
     const code = await run(
-      ["chat-completions", "-m", "gpt-4o-mini", "--env", "/no/such/file.env", "hi"],
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "--env", "/no/such/file.env", "hi"],
       cap.io,
     );
     expect(code).toBe(2);
@@ -435,7 +458,7 @@ describe("run — flag-driven config", () => {
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
     const code = await run(
-      ["chat-completions", "-m", "gpt-4o-mini", "--max-tokens", "256", "hi"],
+      ["openai", "chat-completions", "-m", "gpt-4o-mini", "--max-tokens", "256", "hi"],
       cap.io,
     );
     expect(code).toBe(0);
@@ -452,7 +475,15 @@ describe("run — flag-driven config", () => {
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
     const code = await run(
-      ["chat-completions", "-m", "gpt-4o-mini", "--base-url", "https://relay.example.com/v1", "hi"],
+      [
+        "openai",
+        "chat-completions",
+        "-m",
+        "gpt-4o-mini",
+        "--base-url",
+        "https://relay.example.com/v1",
+        "hi",
+      ],
       cap.io,
     );
     expect(code).toBe(0);
@@ -464,7 +495,7 @@ describe("run — verbose stderr", () => {
   it("P1: -v flag emits verbose stage lines to stderr, stdout stays single JSON line", async () => {
     server.use(http.post(ENDPOINT, () => happyResponse("ok")));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     // stdout stays exactly one JSON line (no verbose pollution)
     expect(cap.stdout.value.trim().split("\n")).toHaveLength(1);
@@ -492,7 +523,7 @@ describe("run — verbose stderr", () => {
   it("P2: AI_RELAY_VERBOSE=1 env enables verbose without the -v flag", async () => {
     server.use(http.post(ENDPOINT, () => happyResponse("ok")));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k", AI_RELAY_VERBOSE: "1" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stderr.value).toContain("] argv:");
     expect(cap.stderr.value).toContain("] openai-request:");
@@ -501,7 +532,7 @@ describe("run — verbose stderr", () => {
   it("P3: no -v and no AI_RELAY_VERBOSE → no verbose lines on stderr", async () => {
     server.use(http.post(ENDPOINT, () => happyResponse("ok")));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stderr.value).toBe("");
   });
@@ -511,7 +542,7 @@ describe("run — verbose stderr", () => {
     const sentinel = "sk-leak-canary-7777";
     const cap = makeIO({ env: {} });
     const code = await run(
-      ["chat-completions", "-v", "-m", "gpt-4o-mini", "--api-key", sentinel, "hi"],
+      ["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "--api-key", sentinel, "hi"],
       cap.io,
     );
     expect(code).toBe(0);
@@ -523,7 +554,7 @@ describe("run — verbose stderr", () => {
     server.use(http.post(ENDPOINT, () => happyResponse("ok")));
     const sentinel = "sk-env-leak-canary-8888";
     const cap = makeIO({ env: { AI_RELAY_API_KEY: sentinel } });
-    const code = await run(["chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stderr.value).not.toContain(sentinel);
   });
@@ -532,7 +563,7 @@ describe("run — verbose stderr", () => {
     const upstreamMarker = "upstream-body-leak-marker-3333";
     server.use(http.post(ENDPOINT, () => happyResponse(upstreamMarker)));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stderr.value).not.toContain(upstreamMarker);
     // stdout still carries the body (this is the JSON channel)
@@ -546,7 +577,7 @@ describe("run — verbose stderr", () => {
       ),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(1);
     expect(cap.stderr.value).toContain("] openai-error:");
   });
@@ -556,7 +587,7 @@ describe("run — exit-code mapping", () => {
   it("P1: success → exit 0 + JSON on stdout", async () => {
     server.use(http.post(ENDPOINT, () => happyResponse("done")));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stdout.value.trim().length).toBeGreaterThan(0);
   });
@@ -568,7 +599,7 @@ describe("run — exit-code mapping", () => {
       ),
     );
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(1);
     const out = JSON.parse(cap.stdout.value.trim());
     expect(out.isError).toBe(true);
@@ -578,7 +609,7 @@ describe("run — exit-code mapping", () => {
   it("P2: TTY stdout is pretty-printed (multi-line)", async () => {
     server.use(http.post(ENDPOINT, () => happyResponse()));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" }, isTTY: true });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stdout.value.split("\n").length).toBeGreaterThan(2);
   });
@@ -586,7 +617,7 @@ describe("run — exit-code mapping", () => {
   it("P3: piped stdout is single-line JSON", async () => {
     server.use(http.post(ENDPOINT, () => happyResponse()));
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" }, isTTY: false });
-    const code = await run(["chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
+    const code = await run(["openai", "chat-completions", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(0);
     expect(cap.stdout.value.trim().split("\n")).toHaveLength(1);
   });


### PR DESCRIPTION
## Summary

CLI redesign to separate the two axes that the previous `<api-type>` positional was collapsing into one string. The server positional and the registered MCP tool name shared the same value (`chat-completions`), which made the selector and the tool identity indistinguishable. Provider is now an explicit positional on both bins; tool name within a single-provider server stays bare.

- `ai-relay <api-type>` → `ai-relay <provider>` (today: `openai`); the provider entry mounts all of its tools.
- `ai-relay-cli <tool>` → `ai-relay-cli <provider> <tool>` (today: `openai chat-completions`); lookup is provider-scoped.
- Tool name `chat-completions` is unchanged — provider is conveyed by the positional, not by tool-name prefix. Namespacing (`<provider>.<api>`) is reserved for a future multi-provider-per-server world (recorded in `doc/ARCHITECTURE.md` §11).
- Registry is provider-keyed; no v1-only hardcoded allowlist. Adding a future provider/API only touches the registry.

**BREAKING**: callers must pass `<provider>` as the first positional on both bins.

## Verify Commands output

```
$ pnpm build
ai-relay build: Done
app build: Done

$ pnpm typecheck
(no errors)

$ pnpm lint
Checked 60 files. No fixes applied.

$ pnpm test
284 passed, 1 skipped (Docker integration), 0 failed
```

## MCP Inspector verification (per `doc/QA-MCP-INSPECTOR.md`)

Stdio bin verified directly against MCP Inspector CLI on this branch:

```
AI_RELAY_API_KEY=sk-dummy npx -y @modelcontextprotocol/inspector \
  --method tools/list \
  --cli node packages/ai-relay/dist/bin/ai-relay.js openai
```

Returns a single `chat-completions` tool with `model` + `messages` input schema.

- [x] C1 — `tools/list` exposes a single `chat-completions` tool with input schema
- [ ] C2 — `chat-completions` happy path returns text + usage metadata
- [ ] C4 — `max_tokens` clamp succeeds without error
- [ ] C5 — Wrong bearer returns 401 + `WWW-Authenticate: Bearer`
- [ ] C6 — Cancellation aborts the upstream call

> C2/C4/C5/C6 require live upstream credentials and the Hono HTTP server; refactor scope is CLI wiring only. Tool schema + Hono route + auth paths are unchanged and covered by existing integration tests.

## v1 non-goal self-check

- [x] No Responses API usage
- [x] No embeddings / image tools
- [x] No OAuth 2.1 / DCR
- [x] No rate limiting (Upstash, etc.)
- [x] No daily budget counters
- [x] No external observability (Sentry, OTel, Axiom)
- [x] No SSE transport / Redis
- [x] No additional MCP routes (single `app/api/[transport]/route.ts` only)

## Notes for reviewer

- CHANGELOG and `package.json` version bump intentionally NOT touched — those are the `release` skill's responsibility at version-bump time. The breaking-change marker (`!:` in commit subject + `BREAKING CHANGE:` footer in commit body) is in place for the eventual release.
- `app/src/index.ts`, `scripts/{verify,mcp-inspect}.mjs`, `.github/PULL_REQUEST_TEMPLATE.md`, and `examples/**` were inspected and intentionally left untouched: every reference there is to the **tool name** `chat-completions` (unchanged), not to the CLI positional.
- `examples/multi-upstream/` still uses `config.name` override to alias tools — that mechanism is separate from provider namespacing and stays working.