### PR TITLE
chore: ignore .next build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ tsconfig.tsbuildinfo
 .vercel
 packages/*/dist
 
+# Next.js build output (if a contributor experiments with Next locally)
+.next/
+
 # Wrangler local dev cache (Cloudflare Workers smoke tests)
 .wrangler/
 


### PR DESCRIPTION
## Summary

Next.js build artifacts (`.next/`) surfaced as untracked at the repo root when contributors experimented with Next locally. Add the directory to `.gitignore` so `git status` and PR-creation flows stay clean.

## Verify Commands output

```
$ git status
On branch chore/gitignore-next
nothing to commit, working tree clean
```

N/A for `pnpm typecheck` / `pnpm lint` / `pnpm build` / `pnpm test` — gitignore-only change.

## MCP Inspector verification

N/A — non-runtime change.

## v1 non-goal self-check

- [x] No Responses API usage
- [x] No embeddings / image tools
- [x] No OAuth 2.1 / DCR
- [x] No rate limiting (Upstash, etc.)
- [x] No daily budget counters
- [x] No external observability (Sentry, OTel, Axiom)
- [x] No SSE transport / Redis
- [x] No additional MCP routes (single `app/api/[transport]/route.ts` only)