### PR TITLE
docs: Drop transitional 0.10.0 breaking-change framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Full tree: [`doc/ARCHITECTURE.md` §5](./doc/ARCHITECTURE.md#5-directory-structu
 |---|---|---|
 | `AI_RELAY_API_KEY` | ✅ | Container env / orchestrator secret (separate Production/Preview keys) |
 | `AI_RELAY_AUTH_TOKEN` | ✅ | Container env / orchestrator secret (32+ random bytes) |
-| `AI_RELAY_MODEL` | ✅ | Upstream model id forwarded with every `tools/call`. The caller-facing tool input no longer accepts `model` — the server is the single source of truth. |
+| `AI_RELAY_MODEL` | ✅ | Upstream model id forwarded with every `tools/call`. The caller-facing tool input does not accept `model` — the server is the single source of truth. |
 | `AI_RELAY_BASE_URL` | ❌ | Plain env var. Default: SDK built-in. Override to point at Azure OpenAI, vLLM/Ollama, or a mock. |
 | `AI_RELAY_TEMPERATURE` | ❌ | Plain, 0..2. Forwarded with every upstream call when set. |
 | `AI_RELAY_MAX_TOKENS` | ❌ | Plain, positive integer. Forwarded as `max_tokens` upstream. No server ceiling / clamp is applied. |
@@ -123,7 +123,7 @@ Both bins read the same `AI_RELAY_*` env keys as the server (model + sampling pa
 
 | Key | Notes |
 |---|---|
-| `AI_RELAY_MODEL` | Required for `ai-relay <provider>` (MCP stdio launcher) and `ai-relay-cli` (one-shot CLI). Overridden by `-m` / `--model`. The MCP tool input no longer accepts a caller-supplied `model`. |
+| `AI_RELAY_MODEL` | Required for `ai-relay <provider>` (MCP stdio launcher) and `ai-relay-cli` (one-shot CLI). Overridden by `-m` / `--model`. The MCP tool input does not accept a caller-supplied `model`. |
 | `AI_RELAY_TEMPERATURE` / `AI_RELAY_MAX_TOKENS` / `AI_RELAY_TOP_P` / `AI_RELAY_STOP` | Forwarded to every upstream call when set. Overridden by `--temperature` / `--max-tokens` / `--top-p` / `--stop` flags. |
 
 ### Script-only (consumed by `scripts/mcp-inspect.mjs` and `scripts/verify.mjs`)
@@ -136,10 +136,8 @@ These are NOT read by the server. They only set defaults for the verification sc
 | `MCP_TOOL`     | `inspect` | `chat-completions` | `--tool=` |
 | `MCP_MESSAGE`  | `inspect` | `ping` | `--message=` |
 
-> 0.10.0 removed the script-only `MCP_MODEL` and `VERIFY_MODEL` env vars (and the
-> `--model=` flag on `pnpm inspect`). The MCP tool input is `{ messages }` only;
-> the upstream model is read from the server-side `AI_RELAY_MODEL` and surfaced
-> back via `structuredContent.model`.
+> The MCP tool input is `{ messages }` only; the upstream model is read from
+> the server-side `AI_RELAY_MODEL` and surfaced back via `structuredContent.model`.
 
 Local development uses `.env.local` (gitignored). `.env.example` records key names only.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,8 +8,6 @@
 
 ## Quick reference
 
-> **0.10.0 (breaking):** 호출자가 보내는 MCP tool 입력은 `{ messages }`만 받습니다. `model`, `temperature`, `max_tokens`, `top_p`, `stop` 같은 업스트림/샘플링 파라미터는 서버 인스턴스 단위로 env 또는 플래그를 통해 설정합니다. caller(Claude Desktop 등 MCP 호스트)가 `model`을 보내면 MCP-SDK validator가 조용히 떼어내고 서버 설정값이 우선됩니다. 자세한 사항은 [`CHANGELOG`](./packages/ai-relay/CHANGELOG.md#0100--2026-05-13).
-
 **1. 단발 CLI** — 셸에서 모델 호출:
 
 ```bash
@@ -186,4 +184,4 @@ AI_RELAY_API_KEY=sk-... \
 
 ## 라이선스
 
-MIT — [LICENSE](./LICENSE) 참고.
+MIT LICENSE

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 ## Quick reference
 
-> **0.10.0 (breaking):** the caller-facing MCP tool now accepts only `{ messages }`. The upstream model and sampling parameters (`model`, `temperature`, `max_tokens`, `top_p`, `stop`) are configured per server instance via env vars or flags. Callers that still send `model` will have the field silently stripped by the MCP-SDK validator — the server-configured value wins. See [`CHANGELOG`](./packages/ai-relay/CHANGELOG.md#0100--2026-05-13).
-
 **1. One-shot CLI** — run a model from the shell:
 
 ```bash
@@ -187,4 +185,4 @@ Full scenario matrix and evidence template: [`doc/QA-MCP-INSPECTOR.md`](./doc/QA
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+MIT LICENSE

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -267,7 +267,7 @@ project that consumes `ai-relay` from npm (see `examples/vercel/README.md`).
 |---|---|---|---|
 | `AI_RELAY_API_KEY` | ✅ | Sensitive | Upstream API key. Recommend separate keys for Production/Preview. |
 | `AI_RELAY_AUTH_TOKEN` | ✅ | Sensitive | Bearer token sent by the MCP host. 32+ random bytes. |
-| `AI_RELAY_MODEL` | ✅ | Plain | Upstream model id forwarded on every `tools/call`. The caller-facing tool input no longer accepts `model`. |
+| `AI_RELAY_MODEL` | ✅ | Plain | Upstream model id forwarded on every `tools/call`. The caller-facing tool input does not accept `model`. |
 | `AI_RELAY_BASE_URL` | ❌ | Plain | Override the upstream base URL. Default: SDK built-in. Use to point at Azure OpenAI, a self-hosted vLLM/Ollama gateway, or a local mock. |
 | `AI_RELAY_TEMPERATURE` | ❌ | Plain | Float 0..2. Forwarded as `temperature` to every upstream call when set. |
 | `AI_RELAY_MAX_TOKENS` | ❌ | Plain | Positive integer. Forwarded as `max_tokens` to every upstream call. No server-side clamp is applied — set conservatively. |

--- a/doc/DEPLOY.ko.md
+++ b/doc/DEPLOY.ko.md
@@ -28,8 +28,8 @@
 
 **Vercel용** (커뮤니티 지원, [`examples/vercel/README.md`](../examples/vercel/README.md) 참고):
 - Vercel 계정 (Pro 플랜 권장 — `maxDuration: 300`에 필요).
-- npm의 `ai-relay`를 소비하는 별도 Next.js 프로젝트 — 이 저장소는 더 이상
-  Next.js 앱이 아님.
+- npm의 `ai-relay`를 소비하는 별도 Next.js 프로젝트 — 이 저장소는 Next.js
+  앱이 아님.
 - OpenAI 프로젝트 2개 (Production + Preview), 각자의 키 보유.
 - Vercel CLI: `npm i -g vercel` (또는 `pnpm dlx vercel ...`).
 
@@ -160,11 +160,9 @@ docker run --rm -p 8787:8787 --env-file .env.production ghcr.io/ragingwind/ai-re
 포함)는 선택 — 기본값은 [`ARCHITECTURE.ko.md` §7](./ARCHITECTURE.ko.md#7-환경변수)
 참고.
 
-> **0.10.0 노트:** 호출자 측 MCP 도구 입력은 더 이상 `model` / sampling
-> 파라미터를 받지 않습니다. 위의 `AI_RELAY_*` env 변수로 서버 인스턴스
-> 단위로 구성하세요. `AI_RELAY_MAX_OUTPUT_TOKENS` (서버 측 클램프 포함)
-> 는 제거되었고, `AI_RELAY_MAX_TOKENS` 가 매 업스트림 호출에 그대로
-> 전달됩니다.
+> 호출자 측 MCP 도구 입력은 `model` / sampling 파라미터를 받지 않습니다.
+> 위의 `AI_RELAY_*` env 변수로 서버 인스턴스 단위로 구성하세요.
+> `AI_RELAY_MAX_TOKENS` 는 매 업스트림 호출에 그대로 전달됩니다.
 
 ### 3.4 검증 체크리스트
 
@@ -213,14 +211,14 @@ docker history ghcr.io/ragingwind/ai-relay:latest --no-trunc \
 
 ## 4. Vercel (커뮤니티 지원)
 
-이 저장소는 더 이상 Next.js 앱이 아닙니다. Vercel에 배포하려면 npm의
+이 저장소는 Next.js 앱이 아닙니다. Vercel에 배포하려면 npm의
 `ai-relay`를 소비하는 얇은 Next.js 프로젝트를 만드세요. 레시피는
 [`examples/vercel/README.md`](../examples/vercel/README.md) 에 있습니다 —
 해당 디렉터리의 `vercel.json` 을 자기 프로젝트로 복사하고 README의 템플릿
 라우트 핸들러를 따르세요.
 
-Vercel 타깃은 더 이상 이 저장소의 CI나 릴리스 파이프라인에서 다루지
-않습니다. 참조용 배포로 간주하세요.
+Vercel 타깃은 이 저장소의 CI나 릴리스 파이프라인에서 다루지 않습니다.
+참조용 배포로 간주하세요.
 
 ---
 

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -29,7 +29,7 @@ For **Docker** (canonical):
 For **Vercel** (community-supported, see [`examples/vercel/README.md`](../examples/vercel/README.md)):
 - A Vercel account (Pro plan recommended — needed for `maxDuration: 300`).
 - A separate Next.js project that consumes `ai-relay` from npm — this
-  repository is no longer a Next.js app.
+  repository is not a Next.js app.
 - Two OpenAI projects (Production + Preview), each with its own key.
 - Vercel CLI: `npm i -g vercel` (or `pnpm dlx vercel ...`).
 
@@ -163,11 +163,9 @@ The remaining keys (including `AI_RELAY_PORT`, `AI_RELAY_TEMPERATURE`,
 [`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-environment-variables) for
 defaults.
 
-> **0.10.0 note:** the caller-facing MCP tool input no longer accepts
-> `model` / sampling parameters. Configure them per server instance via
-> the `AI_RELAY_*` env vars above. `AI_RELAY_MAX_OUTPUT_TOKENS` (with its
-> server-side clamp) was removed; `AI_RELAY_MAX_TOKENS` is now forwarded
-> as-is on every upstream call.
+> The caller-facing MCP tool input does not accept `model` / sampling
+> parameters. Configure them per server instance via the `AI_RELAY_*` env
+> vars above. `AI_RELAY_MAX_TOKENS` is forwarded as-is on every upstream call.
 
 ### 3.4 Verification checklist
 
@@ -216,13 +214,13 @@ runtime values are injected via `env_file` / `-e` only.
 
 ## 4. Vercel (community-supported)
 
-This repository is no longer a Next.js app. To deploy on Vercel, build a
+This repository is not a Next.js app. To deploy on Vercel, build a
 thin Next.js project that consumes `ai-relay` from npm. The recipe lives
 at [`examples/vercel/README.md`](../examples/vercel/README.md) — copy the
 `vercel.json` from that directory into your own project and follow the
 template route handler shown in the README.
 
-The Vercel target is no longer covered by this repository's CI or release
+The Vercel target is not covered by this repository's CI or release
 pipeline. Treat it as a reference deployment.
 
 ---

--- a/doc/QA-MCP-INSPECTOR.ko.md
+++ b/doc/QA-MCP-INSPECTOR.ko.md
@@ -15,12 +15,10 @@ production 배포 후에 한 번 실행하세요. v1은 UI가 없기 때문에
 - **수동 5-시나리오** — C4(서버 측 sampling 오버라이드) 또는 C6(취소)이
   범위에 들어올 때, 그리고 모든 production 배포 후에 필요.
 
-> **0.10.0 변경:** 호출자 측 MCP 도구 입력은 이제 `{ messages }` 만 받습니다.
-> `model`, `temperature`, `max_tokens`, `top_p`, `stop` 은 서버 측 구성
-> (Hono 앱의 env 변수, stdio bin의 플래그)입니다. 아래 시나리오는 이에
-> 맞춰 갱신되었습니다 — 이전에 호출자 측 `model` / `max_tokens` 을
-> 단언하던 호출은 이제 서버의 `AI_RELAY_MODEL` / `AI_RELAY_MAX_TOKENS` 에
-> 대해 단언합니다.
+> 호출자 측 MCP 도구 입력은 `{ messages }` 만 받습니다. `model`,
+> `temperature`, `max_tokens`, `top_p`, `stop` 은 서버 측 구성
+> (Hono 앱의 env 변수, stdio bin의 플래그)입니다. 아래 시나리오는
+> 서버의 `AI_RELAY_MODEL` / `AI_RELAY_MAX_TOKENS` 에 대해 단언합니다.
 
 **시간 예산**: 환경 세팅이 끝난 뒤 수동 절차는 ~3분.
 
@@ -56,8 +54,7 @@ evidence-record 블록 출력. 1회당 ~$0.0001 (`gpt-4o-mini` 한 번 호출).
 | `MCP_URL`      | `http://localhost:8787/api/mcp` | 엔드포인트 (Hono `AI_RELAY_PORT` 기본값과 일치) |
 
 C2 happy-path 호출에 사용되는 모델은 실행 중인 서버의 `AI_RELAY_MODEL` 값
-그대로입니다 — `verify.mjs` 는 더 이상 이를 오버라이드하지 않습니다 (호출자
-스키마는 `{ messages }` 뿐).
+그대로입니다 (호출자 스키마는 `{ messages }` 뿐).
 
 `AI_RELAY_AUTH_TOKEN`은 `.env.local`에서 읽음.
 
@@ -89,7 +86,7 @@ pnpm inspect --tool=other_tool --message="..."
 | `--message=` | `MCP_MESSAGE` | `ping` |
 | `--method=`  | —             | `tools/call` (또는 `tools/list`) |
 
-`--model=` 은 더 이상 받지 않습니다 — 모델은 서버 측 구성 (Hono 서버의
+`--model=` 은 받지 않습니다 — 모델은 서버 측 구성 (Hono 서버의
 `AI_RELAY_MODEL` env, stdio bin의 `-m` 플래그) 입니다. 이 스크립트가
 구성하는 tools/call 인자는 `{ messages }` 만 보냅니다.
 

--- a/doc/QA-MCP-INSPECTOR.md
+++ b/doc/QA-MCP-INSPECTOR.md
@@ -15,12 +15,10 @@ Two ways to run it:
 - **Manual five-scenario** — required when C4 (server-side sampling override)
   or C6 (cancellation) is in scope, and after every production deploy.
 
-> **0.10.0 change:** the caller-facing MCP tool input now accepts only
-> `{ messages }`. `model`, `temperature`, `max_tokens`, `top_p`, and `stop`
-> are server-side configuration (env vars on the Hono app, flags on the
-> stdio bin). Scenarios below have been updated accordingly — calls that
-> previously asserted caller-side `model` / `max_tokens` are now asserted
-> against `AI_RELAY_MODEL` / `AI_RELAY_MAX_TOKENS` on the server.
+> The caller-facing MCP tool input accepts only `{ messages }`. `model`,
+> `temperature`, `max_tokens`, `top_p`, and `stop` are server-side
+> configuration (env vars on the Hono app, flags on the stdio bin).
+> Scenarios below assert `AI_RELAY_MODEL` / `AI_RELAY_MAX_TOKENS` on the server.
 
 **Time budget**: ~3 minutes for the manual procedure once your env is set up.
 
@@ -56,8 +54,7 @@ Inputs (env-only — `verify.mjs` does not parse flags):
 | `MCP_URL`      | `http://localhost:8787/api/mcp` | endpoint (matches Hono `AI_RELAY_PORT` default) |
 
 The model used for the C2 happy-path call is whatever `AI_RELAY_MODEL` is set
-to on the running server — `verify.mjs` no longer overrides it (the caller
-schema is `{ messages }` only).
+to on the running server (the caller schema is `{ messages }` only).
 
 `AI_RELAY_AUTH_TOKEN` is read from `.env.local`.
 
@@ -90,7 +87,7 @@ Flags (priority: `--flag=` > `process.env` > `.env.local` > default):
 | `--message=` | `MCP_MESSAGE` | `ping` |
 | `--method=`  | —             | `tools/call` (also `tools/list`) |
 
-`--model=` is no longer accepted — the model is server-side configuration
+`--model=` is not accepted — the model is server-side configuration
 (`AI_RELAY_MODEL` env on the Hono server, `-m` flag on the stdio bin). The
 tools/call arguments built by this script send `{ messages }` only.
 

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -105,10 +105,10 @@ snippet is omitted from result text.
 |---|---|---|
 | `AI_RELAY_API_KEY` | ✅ | Set via `wrangler secret put` |
 | `AI_RELAY_AUTH_TOKEN` | ✅ | Bearer token sent by the MCP host (32+ bytes) |
-| `AI_RELAY_MODEL` | ✅ | Upstream model id (e.g. `gpt-4o-mini`) — required since 0.10.0 |
+| `AI_RELAY_MODEL` | ✅ | Upstream model id (e.g. `gpt-4o-mini`) |
 | `AI_RELAY_BASE_URL` | ❌ | Override for Azure / vLLM / Ollama / AI Gateway |
 
-Caller-facing tool input is `{ messages }` only (0.10.0 breaking change).
+Caller-facing tool input is `{ messages }` only.
 `max_tokens`, `temperature`, `top_p`, `stop`, and request timeout are
 SDK-default unless you extend `init()` in `src/index.ts` to pass them in
 `OpenAIChatConfig`.

--- a/examples/multi-upstream/README.md
+++ b/examples/multi-upstream/README.md
@@ -37,8 +37,8 @@ LOCAL_LLM_BASE_URL=http://localhost:11434/v1 LOCAL_LLM_MODEL=llama3 \
 
 Each upstream needs its own model id; `server.ts` reads `AI_RELAY_MODEL` /
 `AZURE_OPENAI_MODEL` / `LOCAL_LLM_MODEL` and falls back to sensible defaults.
-Since 0.10.0 the caller-facing MCP input is `{ messages }` only — model is
-captured per-registration at server boot.
+The caller-facing MCP input is `{ messages }` only — model is captured
+per-registration at server boot.
 
 The server logs `multi-upstream-relay: registered N tool(s).` to stderr
 on start (so it doesn't pollute the JSON-RPC stdout stream). At least

--- a/examples/stdio/README.md
+++ b/examples/stdio/README.md
@@ -92,7 +92,7 @@ Environment variables read by `server.ts`:
 | Var | Required | Notes |
 |---|---|---|
 | `AI_RELAY_API_KEY` | ✅ | OpenAI API key |
-| `AI_RELAY_MODEL` | ✅ | Upstream model id (e.g. `gpt-4o-mini`) — required since 0.10.0 |
+| `AI_RELAY_MODEL` | ✅ | Upstream model id (e.g. `gpt-4o-mini`) |
 | `AI_RELAY_BASE_URL` | ❌ | Override for Azure / vLLM / Ollama / AI Gateway |
 
 `max_tokens`, `temperature`, `top_p`, `stop`, and request timeout are

--- a/examples/vercel/README.md
+++ b/examples/vercel/README.md
@@ -15,8 +15,8 @@ shipped before it became framework-agnostic. The interesting parts:
 
 ## How to use it
 
-`ai-relay` is no longer a Next.js project, so you cannot deploy
-this repository directly to Vercel. Instead, build a thin Next.js
+`ai-relay` is not a Next.js project, so you cannot deploy this
+repository directly to Vercel. Instead, build a thin Next.js
 project that consumes the published `ai-relay` SDK:
 
 ```bash
@@ -34,7 +34,6 @@ import { registerOpenAIChat } from "ai-relay/openai";
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
 
 // loadConfig reads AI_RELAY_API_KEY + AI_RELAY_MODEL + optional sampling env vars.
-// AI_RELAY_MODEL is required since 0.10.0.
 const config = loadConfig({ env: process.env });
 const provider = config.providers[0]!;
 
@@ -94,7 +93,7 @@ The exact dropped-name list lives in `scripts/smoke.sh`. Ends with
 
 ## Why this is community-supported
 
-The Vercel target is no longer covered by this repository's CI or
+The Vercel target is not covered by this repository's CI or
 release pipeline — the canonical artifact is the multi-arch container
 image. Treat this directory as a reference; report issues but expect
 PRs to take longer.

--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -14,8 +14,6 @@ npm install ai-relay @modelcontextprotocol/sdk openai
 
 ## Quick reference
 
-> **0.10.0 (breaking):** the caller-facing MCP tool `inputSchema` accepts only `{ messages }`. The upstream model and sampling parameters live on the server config (`OpenAIChatConfig` for SDK embeds, env vars for the HTTP server, flags for `ai-relay` / `ai-relay-cli`). `OpenAIChatConfig.model` is now required and the SDK throws at boot when missing. See [`CHANGELOG`](./CHANGELOG.md#0100--2026-05-13).
-
 **1. One-shot CLI** — `ai-relay-cli <provider> <tool> [flags] [input]`:
 
 ```bash
@@ -82,7 +80,7 @@ ai-relay-cli openai chat-completions -m gpt-4o-mini --base-url https://my-azure.
 echo '{"messages":[…]}' | ai-relay-cli openai chat-completions -m gpt-4o-mini
 ```
 
-**Model resolution** (first match wins): `-m`/`--model` flag → `AI_RELAY_MODEL` env. JSON input no longer accepts a `model` field — the caller schema is `{ messages }` only and `.strict()` rejects extra keys.
+**Model resolution** (first match wins): `-m`/`--model` flag → `AI_RELAY_MODEL` env. The caller schema is `{ messages }` only and `.strict()` rejects extra keys, so JSON input cannot include a `model` field.
 
 | Flag | Purpose |
 |---|---|
@@ -243,7 +241,7 @@ interface OpenAIChatConfig {
   description?: string;
   apiKey: string;
   baseURL?: string;
-  model: string;                    // required — caller-facing input no longer accepts model
+  model: string;                    // required — caller-facing input does not accept model
   temperature?: number;             // forwarded as-is to every upstream call
   max_tokens?: number;              // forwarded as-is; no server-side clamp
   top_p?: number;


### PR DESCRIPTION
## Summary

Remove "0.10.0 (breaking)" callouts and "no longer accepts X" phrasing across the doc tree. With 0.10.0 shipped and stable in [93f6d6e](93f6d6e), the breaking-change framing is past — the docs should describe the current API in present tense and let `CHANGELOG` carry the upgrade history.

## Changes

| File | Change |
|---|---|
| `README.md`, `README.ko.md` | Drop top-level "0.10.0 (breaking)" callout; condense License section |
| `CLAUDE.md` | Reword `AI_RELAY_MODEL` server/CLI env table entries to present tense; drop stale "0.10.0 removed" sidebar |
| `doc/ARCHITECTURE.md` / `.ko.md` | One present-tense rewrite |
| `doc/DEPLOY.md` / `.ko.md` | Drop "0.10.0 note" sidebar; "is no longer" → "is not"; remove stale `AI_RELAY_MAX_OUTPUT_TOKENS` reference |
| `doc/QA-MCP-INSPECTOR.md` / `.ko.md` | Same pattern — drop release framing, present tense |
| `examples/{vercel,cloudflare-workers,multi-upstream,stdio}/README.md` | Same pattern |
| `packages/ai-relay/README.md` | Drop top-level "0.10.0 (breaking)" callout; rewrite Model resolution paragraph; update `OpenAIChatConfig` comment |

## Why now

Issue #90 (ADR) starts editing the same files (`CLAUDE.md`, `doc/ARCHITECTURE.md`, `README*.md`) — bundling this cosmetic cleanup with the ADR work would mix two unrelated diffs. Landing this first keeps the ADR PR focused on policy text.

## Test plan

- [x] No code paths touched (`git diff --name-only origin/main...HEAD` lists only `.md` files)
- [x] `pnpm typecheck && pnpm lint && pnpm test` not run — pure docs cleanup; CI will exercise

🤖 Manual docs cleanup (outside `/dev` pipeline)