### PR TITLE
feat(sdk): Anthropic Messages provider — adds ./anthropic subpath + provider-aware refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,11 +17,16 @@ AI_RELAY_AUTH_TOKEN=
 # tool input does not accept `model`; the server is the single source of truth.
 AI_RELAY_MODEL=
 
-# Sampling temperature (0..2). Optional. Forwarded on every upstream call.
+# Sampling temperature. Range depends on the invoking provider:
+#   openai:    0..2
+#   anthropic: 0..1
+# Optional. Forwarded on every upstream call.
 AI_RELAY_TEMPERATURE=
 
 # Positive integer. Forwarded as `max_tokens` on every upstream call. No
 # server-side clamp is applied — set conservatively to control cost.
+# Anthropic note: defaults to 1024 when omitted (Anthropic requires this
+# field per call); OpenAI omits it from the upstream payload when unset.
 AI_RELAY_MAX_TOKENS=
 
 # Nucleus sampling cutoff (0..1). Optional. Forwarded on every upstream call.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,13 @@ lint:     pnpm lint          # biome check .
 test:     pnpm test          # vitest run
 test:unit: pnpm test:unit    # vitest run packages/ai-relay/tests/unit
 test:integration: pnpm test:integration  # vitest run --project integration
+test:runtime: pnpm test:runtime  # pack tarball + run smoke fixtures (Node/Bun/CJS). Catches "consumer install without peer SDK" failures that vitest workspace-resolution masks.
 dev:      pnpm dev           # Hono dev server (port 8787)
 verify:   pnpm verify        # smoke against a running dev server
 inspect:  pnpm inspect       # ad-hoc tools/call via MCP Inspector CLI (see doc/QA-MCP-INSPECTOR.md)
 ```
+
+> **`test:runtime` rationale**: workspace-mode `pnpm test` resolves peer SDKs (`openai`, `@anthropic-ai/sdk`) via pnpm's symlinked `node_modules/.pnpm` tree, regardless of whether they are declared as required vs optional peers. The `runtime-matrix` smoke fixtures simulate a real `npm install <tarball>` install — only declared `dependencies` are present. Provider-SDK packaging regressions (missing peer dep, broken subpath import) surface here, not in `pnpm test`. Run before opening a PR that touches `peerDependencies` or `peerDependenciesMeta`.
 
 ### Evidence policy
 - `evidence-mode: none` — this project has no UI (API/MCP server only). Browser screenshot/video evidence gates auto-pass.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,8 +1,19 @@
 # ai-relay
 
-> OpenAI Chat Completions(및 OpenAI 호환 업스트림)를 Model Context Protocol 도구로 노출하는 MCP 릴레이입니다.
+> OpenAI Chat Completions(및 OpenAI 호환 업스트림) 또는 Anthropic Messages를 Model Context Protocol 도구로 노출하는 MCP 릴레이입니다.
 
 > English: [README.md](./README.md)
+
+---
+
+## Providers
+
+| Provider | CLI / bin | SDK 서브패스 | 비고 |
+|---|---|---|---|
+| OpenAI Chat Completions | `ai-relay openai` / `ai-relay-cli openai chat-completions` | [`ai-relay/openai`](./packages/ai-relay/README.md) | OpenAI 호환 업스트림 전반 (Azure, vLLM, Ollama, OpenRouter, AI Gateway) |
+| Anthropic Messages | `ai-relay anthropic` / `ai-relay-cli anthropic messages` | [`ai-relay/anthropic`](./packages/ai-relay/README.md#anthropic-messages) | `max_tokens` 기본 1024, `temperature` 범위 0..1 |
+
+> 배포된 프로세스는 한 번에 하나의 provider만 사용해야 합니다(ADR D8, [`doc/ARCHITECTURE.md`](./doc/ARCHITECTURE.md) 참고). 두 provider를 동시에 노출하려면 ai-relay 프로세스를 두 개 띄우세요.
 
 ---
 
@@ -11,7 +22,11 @@
 **1. 단발 CLI** — 셸에서 모델 호출:
 
 ```bash
+# OpenAI
 AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
+
+# Anthropic
+AI_RELAY_API_KEY=sk-ant-... npx ai-relay-cli anthropic messages -m claude-sonnet-4-5 "ping"
 ```
 
 (`-m`은 CLI가 이번 호출에 사용할 모델을 서버 측 설정으로 박는 옵션입니다. MCP `tools/call` 인자로 전송되는 값이 **아닙니다**.)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # ai-relay
 
-> An MCP relay that exposes OpenAI Chat Completions (and any OpenAI-compatible upstream) as a Model Context Protocol tool.
+> An MCP relay that exposes OpenAI Chat Completions (and any OpenAI-compatible upstream) **or** Anthropic Messages as a Model Context Protocol tool.
 
 > 한국어: [README.ko.md](./README.ko.md)
+
+---
+
+## Providers
+
+| Provider | CLI / bin | SDK subpath | Notes |
+|---|---|---|---|
+| OpenAI Chat Completions | `ai-relay openai` / `ai-relay-cli openai chat-completions` | [`ai-relay/openai`](./packages/ai-relay/README.md) | Compatible with any OpenAI-shaped upstream: OpenAI, Azure, vLLM, Ollama, OpenRouter, AI Gateway |
+| Anthropic Messages | `ai-relay anthropic` / `ai-relay-cli anthropic messages` | [`ai-relay/anthropic`](./packages/ai-relay/README.md#anthropic-messages) | `max_tokens` defaults to 1024; `temperature` range 0..1 |
+
+> A deployed process MUST run a single provider at a time (ADR D8 in [`doc/ARCHITECTURE.md`](./doc/ARCHITECTURE.md)). Run two ai-relay processes side-by-side to expose both providers to one MCP host.
 
 ---
 
@@ -11,7 +22,11 @@
 **1. One-shot CLI** — run a model from the shell:
 
 ```bash
+# OpenAI
 AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
+
+# Anthropic
+AI_RELAY_API_KEY=sk-ant-... npx ai-relay-cli anthropic messages -m claude-sonnet-4-5 "ping"
 ```
 
 (`-m` configures the model the CLI uses for this invocation; it is NOT sent in the MCP call arguments.)

--- a/app/scripts/docker-smoke.sh
+++ b/app/scripts/docker-smoke.sh
@@ -163,6 +163,7 @@ if ! docker run -d \
   --name="$CONTAINER_NAME" \
   -e AI_RELAY_API_KEY=smoke-key \
   -e AI_RELAY_AUTH_TOKEN="$SMOKE_BEARER" \
+  -e AI_RELAY_MODEL=gpt-4o-mini \
   -e AI_RELAY_BASE_URL="http://host.docker.internal:${mock_port}/v1" \
   --add-host=host.docker.internal:host-gateway \
   -p "${SMOKE_HOST_PORT}:8787" \

--- a/doc/ARCHITECTURE.ko.md
+++ b/doc/ARCHITECTURE.ko.md
@@ -132,6 +132,38 @@ OpenAI Chat Completions를 한 번 호출하고 누적된 텍스트를 반환합
 - `tool_choice` / `tools` 파라미터는 v1에서 미지원 — tool call은 전달되지 않습니다.
 - 응답에 function/tool call이 포함되면 텍스트로 직렬화하지 않습니다. 대신 `finish_reason: "tool_calls"`를 노출해 호스트 LLM이 후속 동작을 결정하도록 합니다.
 
+### `messages` (Anthropic provider)
+
+Anthropic Messages를 한 번 호출하고 누적된 어시스턴트 텍스트를 반환합니다. 호출자 측 입력/출력 스키마는 `chat-completions`와 동일합니다(D10 — 업스트림 충실 스키마 정책).
+
+**입력 스키마 (Zod, `.strict()`)** — `chat-completions`와 동일:
+
+| 필드 | 타입 | 필수 | 비고 |
+|---|---|---|---|
+| `messages` | `Array<{role: "system"|"user"|"assistant", content: string}>` | ✅ | 선두의 `system` 메시지는 Anthropic 최상위 `system` 필드로 추출(다수일 경우 `\n\n`으로 결합); 선두가 아닌 `system`은 `bad_request`로 거부 |
+
+**서버 측 구성 (`AnthropicMessagesConfig` / `AI_RELAY_*` env)**
+
+| 필드 | Env | 필수 | 비고 |
+|---|---|---|---|
+| `model` | `AI_RELAY_MODEL` | ✅ | 업스트림 Messages 엔드포인트로 그대로 전달 |
+| `temperature` | `AI_RELAY_TEMPERATURE` | ❌ | **0..1** (OpenAI는 0..2); 설정 시 전달 |
+| `max_tokens` | `AI_RELAY_MAX_TOKENS` | ❌ | 양의 정수. **생략 시 `1024`로 기본값 적용** — Anthropic은 매 호출마다 이 필드를 요구합니다 |
+| `top_p` | `AI_RELAY_TOP_P` | ❌ | 0..1; 설정 시 전달 |
+| `stop` | `AI_RELAY_STOP` | ❌ | 단일 문자열 또는 쉼표로 구분된 목록; 업스트림으로는 `stop_sequences: string[]`로 변환 |
+
+**출력 스키마** — `chat-completions`와 동일 (`structuredContent.model`, `usage`의 `prompt_tokens` + `completion_tokens` + `total_tokens`, `finish_reason`, `code`, `retryAfter`).
+
+#### Anthropic `stop_reason` → `finish_reason` 매핑
+
+| Anthropic `stop_reason` | 노출되는 `finish_reason` | 비고 |
+|---|---|---|
+| `end_turn` | `stop` | 정상 완료 |
+| `max_tokens` | `length` | 상한 도달 |
+| `stop_sequence` | `stop` | `stop_sequences` 중 하나와 매치 |
+| `tool_use` | `tool_calls` | OpenAI `tool_calls`와 동일(v1에서는 tool 전달하지 않음) |
+| `refusal` | `content_filter` | `isError: true` + `code: "content_policy"`도 함께 설정 |
+
 ---
 
 ## 5. 디렉터리 구조
@@ -215,14 +247,15 @@ mcp-ai-relay/                              # 저장소 루트 — pnpm 워크스
 | MCP handler | `mcp-handler@^1.1` |
 | MCP SDK | `@modelcontextprotocol/sdk@^1.26` |
 | Validation | `zod@^4` |
-| OpenAI SDK | `openai@^6` |
+| OpenAI SDK | `openai@^6` (optional peer dep) |
+| Anthropic SDK | `@anthropic-ai/sdk@^0.96.0` (optional peer dep) |
 | Runtime | Node.js `20.x` (alpine 컨테이너; 멀티 아키텍처 amd64+arm64) |
 | Language | TypeScript strict, NodeNext ESM, `verbatimModuleSyntax: true` |
 | Package manager | pnpm `^9` (`packageManager` 필드로 고정) |
 | Lint/Format | Biome `^2` |
 | Test | vitest + msw (HTTP 경계에서만 mock) |
 | Deployment | `ghcr.io/ragingwind/ai-relay` 멀티 아키텍처 이미지; production은 `compose.yml`, 로컬 빌드는 `compose.dev.yml`. Vercel 레시피는 `examples/vercel/`(커뮤니티 지원). |
-| SDK 빌드 | `tsc -p tsconfig.build.json` → `packages/ai-relay/dist/`; ESM, `@modelcontextprotocol/sdk` + `openai`(optional)는 peerDeps |
+| SDK 빌드 | `tsc -p tsconfig.build.json` → `packages/ai-relay/dist/`; ESM. peerDeps: `@modelcontextprotocol/sdk`(필수); `openai`와 `@anthropic-ai/sdk`는 optional — 실제 사용하는 provider의 SDK만 설치 |
 | App 빌드 | `tsc -p app/tsconfig.json` → `app/dist/`; 런타임 이미지는 `pnpm deploy --prod /deploy`로 자체 완결 트리 생성 |
 
 ### 컨테이너 릴리스
@@ -274,8 +307,8 @@ mcp-ai-relay/                              # 저장소 루트 — pnpm 워크스
 | `AI_RELAY_AUTH_TOKEN` | ✅ | Sensitive | MCP 호스트가 보내는 Bearer 토큰. 32바이트 이상 random. |
 | `AI_RELAY_MODEL` | ✅ | Plain | 매 `tools/call`마다 전달되는 업스트림 model id. 호출자 측 도구 입력은 이제 `model`을 받지 않습니다. |
 | `AI_RELAY_BASE_URL` | ❌ | Plain | 업스트림 base URL 오버라이드. 기본: SDK 내장. Azure OpenAI, 셀프 호스팅 vLLM/Ollama 게이트웨이, 로컬 mock을 가리킬 때 사용. |
-| `AI_RELAY_TEMPERATURE` | ❌ | Plain | 0..2 실수. 설정 시 매 업스트림 호출에 `temperature`로 전달. |
-| `AI_RELAY_MAX_TOKENS` | ❌ | Plain | 양의 정수. 매 업스트림 호출에 `max_tokens`로 그대로 전달. 서버 측 클램프 없음 — 보수적으로 설정. |
+| `AI_RELAY_TEMPERATURE` | ❌ | Plain | 실수. 범위는 provider에 따라 다름: **`openai`는 0..2**, **`anthropic`은 0..1**. 설정 시 매 업스트림 호출에 `temperature`로 전달. |
+| `AI_RELAY_MAX_TOKENS` | ❌ | Plain | 양의 정수. 매 업스트림 호출에 `max_tokens`로 그대로 전달. 서버 측 클램프 없음 — 보수적으로 설정. `anthropic`의 경우 생략 시 `1024`가 기본값으로 적용됩니다(Anthropic은 매 호출마다 이 필드를 요구). |
 | `AI_RELAY_TOP_P` | ❌ | Plain | 0..1 실수. 설정 시 매 업스트림 호출에 `top_p`로 전달. |
 | `AI_RELAY_STOP` | ❌ | Plain | 단일 값 또는 쉼표로 구분된 목록(`END` 또는 `END,STOP`). 매 업스트림 호출에 `stop`으로 전달. |
 | `AI_RELAY_REQUEST_TIMEOUT_MS` | ❌ | Plain | 정수. 기본 `60000`. 업스트림 호출 타임아웃. |

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -133,6 +133,38 @@ The caller-facing surface is intentionally minimal — `model` and all sampling 
 - `tool_choice` / `tools` parameters are not supported in v1 — tool calls are not forwarded.
 - If a function/tool call appears in the response, it is not serialized to text; instead the tool surfaces `finish_reason: "tool_calls"` so the host LLM can decide what to do.
 
+### `messages` (Anthropic provider)
+
+Invokes Anthropic Messages once and returns the accumulated assistant text. The caller-facing input/output schemas are identical to `chat-completions` (per D10 — upstream-faithful schema policy).
+
+**Input schema (Zod, `.strict()`)** — identical to `chat-completions`:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `messages` | `Array<{role: "system"|"user"|"assistant", content: string}>` | ✅ | Leading `system` messages are extracted into Anthropic's top-level `system` field (joined with `\n\n` if multiple); non-leading `system` is rejected with `bad_request` |
+
+**Server-side configuration (`AnthropicMessagesConfig` / `AI_RELAY_*` env)**
+
+| Field | Env | Required | Notes |
+|---|---|---|---|
+| `model` | `AI_RELAY_MODEL` | ✅ | Forwarded as-is to the upstream Messages endpoint |
+| `temperature` | `AI_RELAY_TEMPERATURE` | ❌ | **0..1** (OpenAI uses 0..2); forwarded when set |
+| `max_tokens` | `AI_RELAY_MAX_TOKENS` | ❌ | Positive integer. **Defaults to 1024** when omitted — Anthropic requires this field on every call |
+| `top_p` | `AI_RELAY_TOP_P` | ❌ | 0..1; forwarded when set |
+| `stop` | `AI_RELAY_STOP` | ❌ | Single string or comma-separated list; translated to `stop_sequences: string[]` upstream |
+
+**Output schema** — identical to `chat-completions` (`structuredContent.model`, `usage` with `prompt_tokens` + `completion_tokens` + `total_tokens`, `finish_reason`, `code`, `retryAfter`).
+
+#### Anthropic `stop_reason` → `finish_reason` mapping
+
+| Anthropic `stop_reason` | Surfaced `finish_reason` | Notes |
+|---|---|---|
+| `end_turn` | `stop` | Normal completion |
+| `max_tokens` | `length` | Cap hit |
+| `stop_sequence` | `stop` | One of `stop_sequences` matched |
+| `tool_use` | `tool_calls` | Mirrors OpenAI `tool_calls` (tools not forwarded in v1) |
+| `refusal` | `content_filter` | Also sets `isError: true` and `code: "content_policy"` |
+
 ---
 
 ## 5. Directory structure
@@ -216,14 +248,15 @@ mcp-ai-relay/                              # repo root — pnpm workspace orches
 | MCP handler | `mcp-handler@^1.1` |
 | MCP SDK | `@modelcontextprotocol/sdk@^1.26` |
 | Validation | `zod@^4` |
-| OpenAI SDK | `openai@^6` |
+| OpenAI SDK | `openai@^6` (optional peer dep) |
+| Anthropic SDK | `@anthropic-ai/sdk@^0.96.0` (optional peer dep) |
 | Runtime | Node.js `20.x` (alpine container; multi-arch amd64+arm64) |
 | Language | TypeScript strict, NodeNext ESM, `verbatimModuleSyntax: true` |
 | Package manager | pnpm `^9` (pinned via `packageManager`) |
 | Lint/Format | Biome `^2` |
 | Test | vitest + msw (mock at the HTTP boundary) |
 | Deployment | `ghcr.io/ragingwind/ai-relay` multi-arch image; `compose.yml` for production, `compose.dev.yml` for local builds. Vercel recipe in `examples/vercel/` (community-supported). |
-| SDK build | `tsc -p tsconfig.build.json` → `packages/ai-relay/dist/`; ESM, peerDeps for `@modelcontextprotocol/sdk` and `openai` (optional) |
+| SDK build | `tsc -p tsconfig.build.json` → `packages/ai-relay/dist/`; ESM. peerDeps: `@modelcontextprotocol/sdk` (required); `openai` and `@anthropic-ai/sdk` are optional — install only the SDK for the provider(s) you use |
 | App build | `tsc -p app/tsconfig.json` → `app/dist/`; runtime image uses `pnpm deploy --prod /deploy` to produce a self-contained tree |
 
 ### Container release
@@ -274,8 +307,8 @@ project that consumes `ai-relay` from npm (see `examples/vercel/README.md`).
 | `AI_RELAY_AUTH_TOKEN` | ✅ | Sensitive | Bearer token sent by the MCP host. 32+ random bytes. |
 | `AI_RELAY_MODEL` | ✅ | Plain | Upstream model id forwarded on every `tools/call`. The caller-facing tool input does not accept `model`. |
 | `AI_RELAY_BASE_URL` | ❌ | Plain | Override the upstream base URL. Default: SDK built-in. Use to point at Azure OpenAI, a self-hosted vLLM/Ollama gateway, or a local mock. |
-| `AI_RELAY_TEMPERATURE` | ❌ | Plain | Float 0..2. Forwarded as `temperature` to every upstream call when set. |
-| `AI_RELAY_MAX_TOKENS` | ❌ | Plain | Positive integer. Forwarded as `max_tokens` to every upstream call. No server-side clamp is applied — set conservatively. |
+| `AI_RELAY_TEMPERATURE` | ❌ | Plain | Float. Range depends on provider: **0..2 for `openai`**, **0..1 for `anthropic`**. Forwarded as `temperature` to every upstream call when set. |
+| `AI_RELAY_MAX_TOKENS` | ❌ | Plain | Positive integer. Forwarded as `max_tokens` to every upstream call. No server-side clamp is applied — set conservatively. For `anthropic`: defaults to `1024` when omitted (Anthropic requires this field per call). |
 | `AI_RELAY_TOP_P` | ❌ | Plain | Float 0..1. Forwarded as `top_p` to every upstream call when set. |
 | `AI_RELAY_STOP` | ❌ | Plain | Single value or comma-separated list (`END` or `END,STOP`). Forwarded as `stop` to every upstream call. |
 | `AI_RELAY_REQUEST_TIMEOUT_MS` | ❌ | Plain | Integer. Default `60000`. Upstream call timeout. |

--- a/doc/DEPLOY.ko.md
+++ b/doc/DEPLOY.ko.md
@@ -207,6 +207,24 @@ docker history ghcr.io/ragingwind/ai-relay:latest --no-trunc \
 아무것도 안 나와야 함 — 이미지 빌드는 실제 자격증명을 절대 읽지 않고,
 런타임 값은 `env_file` / `-e` 로만 주입됩니다.
 
+### 3.6 Anthropic provider (stdio bin 전용)
+
+위의 HTTP 컨테이너는 v1에서 OpenAI 전용입니다. Anthropic Messages
+provider를 사용하려면 provider-scoped env를 지정해 stdio bin을 직접
+실행하세요:
+
+```bash
+export AI_RELAY_API_KEY=sk-ant-...          # Anthropic API 키
+export AI_RELAY_MODEL=claude-sonnet-4-6     # Anthropic 모델 id (필수)
+export AI_RELAY_MAX_TOKENS=1024             # Anthropic은 매 호출마다 필수
+export AI_RELAY_TEMPERATURE=0.7             # 선택, 범위 0..1 (0..2 아님)
+ai-relay anthropic                          # stdio MCP 서버
+```
+
+`.mcp.json`을 통해 Claude Desktop / Claude Code에 다른 stdio 서버처럼
+연결하세요. v1에서 `app/`의 HTTP `/api/mcp` 라우트는 단일 provider
+(OpenAI)로 유지되며, multi-provider HTTP는 별도로 추적됩니다.
+
 ---
 
 ## 4. Vercel (커뮤니티 지원)

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -210,6 +210,23 @@ docker history ghcr.io/ragingwind/ai-relay:latest --no-trunc \
 Should return nothing — the image build never reads real credentials, and
 runtime values are injected via `env_file` / `-e` only.
 
+### 3.6 Anthropic provider (stdio bin only)
+
+The HTTP container above is OpenAI-only in v1. To use the Anthropic Messages
+provider, launch the stdio bin directly with provider-scoped env:
+
+```bash
+export AI_RELAY_API_KEY=sk-ant-...          # Anthropic API key
+export AI_RELAY_MODEL=claude-sonnet-4-6     # Anthropic model id (required)
+export AI_RELAY_MAX_TOKENS=1024             # required by Anthropic per call
+export AI_RELAY_TEMPERATURE=0.7             # optional, range 0..1 (not 0..2)
+ai-relay anthropic                          # stdio MCP server
+```
+
+Wire it into Claude Desktop / Claude Code via `.mcp.json` like any other
+stdio server. The HTTP `/api/mcp` route in `app/` stays single-provider
+(OpenAI) for v1 — multi-provider HTTP is tracked separately.
+
 ---
 
 ## 4. Vercel (community-supported)

--- a/examples/stdio/scripts/smoke.mjs
+++ b/examples/stdio/scripts/smoke.mjs
@@ -134,6 +134,7 @@ async function main() {
     env: {
       ...process.env,
       AI_RELAY_API_KEY: "test",
+      AI_RELAY_MODEL: "gpt-4o-mini",
       AI_RELAY_BASE_URL: baseURL,
     },
     cwd: exampleDir,

--- a/packages/ai-relay/CHANGELOG.md
+++ b/packages/ai-relay/CHANGELOG.md
@@ -6,6 +6,50 @@ the project adheres to [Semantic Versioning](https://semver.org/) once
 v1.0 ships. Pre-v1.0 minor bumps may include breaking changes — read
 this file before upgrading.
 
+## [0.11.0] — 2026-05-14
+
+### Added
+
+- **Anthropic Messages provider** under the new `./anthropic` subpath
+  (`ai-relay/anthropic`). Exposes `registerAnthropicMessages`,
+  `registerAnthropicProvider`, `anthropicMessagesTool`,
+  `makeAnthropicMessagesHandler`, `mapAnthropicError`, and the matching
+  types. The caller-facing input/output schemas are identical to the
+  OpenAI Chat Completions provider (`{ messages }` only, same result
+  shape) — internal differences (leading `system` extraction, `stop` →
+  `stop_sequences` translation, `stop_reason` → `finish_reason` mapping,
+  `max_tokens` default of 1024) are confined to the registrar.
+- `ai-relay anthropic` and `ai-relay-cli anthropic messages` bin
+  invocations. The MCP tool name defaults to `messages`. Provider names
+  are listed in `--help` output and the unknown-provider error message.
+- Default `max_tokens: 1024` is applied at handler-build time when the
+  Anthropic config omits it (Anthropic requires `max_tokens` on every
+  call). The default is logged as `anthropic-max-tokens-default` under
+  `--verbose`.
+
+### Changed
+
+- `peerDependencies` now declares both `openai` (`^6`) and
+  `@anthropic-ai/sdk` (`^0.96.0`) as **optional** via
+  `peerDependenciesMeta`. Existing OpenAI consumers see no install-time
+  change; Anthropic consumers must install `@anthropic-ai/sdk` themselves.
+
+### Refactor (internal — public API stable)
+
+- `config.ts` — `providerConfigSchema` is now a `discriminatedUnion` over
+  `provider`. The Anthropic branch enforces `temperature` range 0..1
+  (vs OpenAI's 0..2) and `capability: "messages"`. `materialiseId` now
+  produces `openai_chat` / `anthropic_messages` ids accordingly.
+- `bin/registry.ts` — provider entries are loaded lazily via
+  `import("../<provider>/index.js")`. `resolveProvider` and
+  `resolveProviderTool` return promises. The eager `registry` const is
+  replaced by a `providerNames: readonly ProviderName[]` export used for
+  usage strings.
+- `bin/run.ts` and `bin/ai-relay.ts` — the hardcoded
+  `args.provider = "openai"` is replaced with the resolved
+  `parsed.provider`, fixing a latent bug where a non-default provider
+  selected on the CLI would still be passed as `openai` to `loadConfig`.
+
 ## [0.10.0] — 2026-05-13
 
 ### Changed (breaking)

--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -1,14 +1,21 @@
 # ai-relay
 
-Provider-agnostic MCP relay SDK. Embed OpenAI Chat Completions (and any OpenAI-compatible upstream — Azure, vLLM, Ollama, AI Gateway) as MCP tools.
+Provider-agnostic MCP relay SDK. Embed OpenAI Chat Completions (and any OpenAI-compatible upstream — Azure, vLLM, Ollama, AI Gateway) or Anthropic Messages as MCP tools.
 
 ## Install
 
 ```bash
+# OpenAI provider
 npm install ai-relay @modelcontextprotocol/sdk openai
+
+# Anthropic provider
+npm install ai-relay @modelcontextprotocol/sdk @anthropic-ai/sdk
+
+# Both providers (one process per provider; D8)
+npm install ai-relay @modelcontextprotocol/sdk openai @anthropic-ai/sdk
 ```
 
-`@modelcontextprotocol/sdk` and `openai` are peer dependencies — the consumer controls their versions. Requires **Node.js 20+** (or any runtime with `node:async_hooks` compatibility — Bun, Deno, Cloudflare Workers with `nodejs_compat`).
+`@modelcontextprotocol/sdk` is required. `openai` and `@anthropic-ai/sdk` are **optional** peer dependencies — install only the SDK for the provider(s) you use. Requires **Node.js 20+** (or any runtime with `node:async_hooks` compatibility — Bun, Deno, Cloudflare Workers with `nodejs_compat`).
 
 ---
 
@@ -17,7 +24,11 @@ npm install ai-relay @modelcontextprotocol/sdk openai
 **1. One-shot CLI** — `ai-relay-cli <provider> <tool> [flags] [input]`:
 
 ```bash
+# OpenAI
 AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini "ping"
+
+# Anthropic
+AI_RELAY_API_KEY=sk-ant-... npx ai-relay-cli anthropic messages -m claude-sonnet-4-5 "ping"
 ```
 
 **2. stdio MCP server** — `ai-relay <provider>`, register in any MCP host:
@@ -25,16 +36,21 @@ AI_RELAY_API_KEY=sk-... npx ai-relay-cli openai chat-completions -m gpt-4o-mini 
 ```json
 {
   "mcpServers": {
-    "ai-relay": {
+    "ai-relay-openai": {
       "command": "npx",
       "args": ["-y", "ai-relay", "openai", "-m", "gpt-4o-mini"],
       "env": { "AI_RELAY_API_KEY": "sk-..." }
+    },
+    "ai-relay-anthropic": {
+      "command": "npx",
+      "args": ["-y", "ai-relay", "anthropic", "-m", "claude-sonnet-4-5"],
+      "env": { "AI_RELAY_API_KEY": "sk-ant-..." }
     }
   }
 }
 ```
 
-**3. SDK embed** — `registerOpenAIChat(server, config)`:
+**3. SDK embed** — `registerOpenAIChat(server, config)` or `registerAnthropicMessages(server, config)`:
 
 ```ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -47,6 +63,16 @@ registerOpenAIChat(server, {
   model: "gpt-4o-mini",
 });
 await server.connect(new StdioServerTransport());
+```
+
+```ts
+import { registerAnthropicMessages } from "ai-relay/anthropic";
+
+registerAnthropicMessages(server, {
+  apiKey: process.env.AI_RELAY_API_KEY!,
+  model: "claude-sonnet-4-5",
+  // max_tokens defaults to 1024 when omitted (Anthropic requires this field)
+});
 ```
 
 **4. Multi-upstream** — one server, multiple `registerOpenAIChat` calls with distinct `name` values (each call captures its own `model`):
@@ -274,13 +300,42 @@ createOpenAIClient(config): OpenAI;                                       // low
 }
 ```
 
+## Anthropic Messages
+
+The Anthropic provider mirrors the OpenAI provider shape: same caller schema (`{ messages }` only), same result shape (`content` + `structuredContent`), same registrar pattern. Differences are confined to upstream semantics:
+
+- **`max_tokens` is required upstream** — defaults to 1024 when the config omits it.
+- **`temperature` range is 0..1** (OpenAI accepts 0..2).
+- **`system` messages** at the start of the `messages` array are extracted into Anthropic's top-level `system` field; non-leading `system` messages are rejected with `bad_request` (Anthropic has no interleaved-system representation).
+- **`stop` → `stop_sequences`** — a single string is wrapped in an array; empty/whitespace entries are filtered.
+- **`stop_reason` → `finish_reason`** mapping: `end_turn` → `stop`, `max_tokens` → `length`, `stop_sequence` → `stop`, `tool_use` → `tool_calls`, `refusal` → `content_filter` (also sets `isError: true` and `code: "content_policy"`).
+
+### SDK embed
+
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAnthropicMessages } from "ai-relay/anthropic";
+
+const server = new McpServer({ name: "anthropic-relay", version: "0.1.0" });
+registerAnthropicMessages(server, {
+  apiKey: process.env.AI_RELAY_API_KEY!,
+  model: "claude-sonnet-4-5",
+  max_tokens: 4096,
+});
+await server.connect(new StdioServerTransport());
+```
+
+`@anthropic-ai/sdk` is an **optional** peer dependency — install it explicitly when using this provider: `npm install @anthropic-ai/sdk`.
+
 ## Compatibility
 
 | Dependency | Version |
 |---|---|
 | Node.js | 20+ |
 | `@modelcontextprotocol/sdk` | `^1.26` |
-| `openai` | `^6` |
+| `openai` (optional) | `^6` |
+| `@anthropic-ai/sdk` (optional) | `^0.96.0` |
 | `mcp-handler` (optional) | `^1.1` |
 
 ESM-only (`"type": "module"`). Only `node:` import is `node:async_hooks`.

--- a/packages/ai-relay/package.json
+++ b/packages/ai-relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-relay",
-  "version": "0.10.0",
-  "description": "Provider-agnostic MCP relay SDK — embed Chat Completions and (future) Anthropic Messages, Gemini, and unified-gateway tools in any MCP server.",
+  "version": "0.11.0",
+  "description": "Provider-agnostic MCP relay SDK — embed Chat Completions, Anthropic Messages, and (future) Gemini / unified-gateway tools in any MCP server.",
   "license": "MIT",
   "author": "Jimmy Moon <ragingwind@gmail.com>",
   "type": "module",
@@ -15,6 +15,10 @@
     "./openai": {
       "types": "./dist/openai/index.d.ts",
       "import": "./dist/openai/index.js"
+    },
+    "./anthropic": {
+      "types": "./dist/anthropic/index.d.ts",
+      "import": "./dist/anthropic/index.js"
     },
     "./env": {
       "types": "./dist/config.d.ts",
@@ -50,13 +54,25 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
+    "@anthropic-ai/sdk": "^0.96.0",
     "@modelcontextprotocol/sdk": "^1.26",
     "openai": "^6"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "openai": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@anthropic-ai/sdk": "^0.96.0"
   }
 }

--- a/packages/ai-relay/src/anthropic/client.ts
+++ b/packages/ai-relay/src/anthropic/client.ts
@@ -1,0 +1,191 @@
+// Anthropic client factory + per-client request scope.
+//
+// Mirrors the OpenAI client factory. Each call to `createAnthropicClient`
+// produces a fresh `Anthropic` instance and its own `AsyncLocalStorage`
+// scope. There is no module-level singleton.
+//
+// `requestScope` carries an optional captured upstream-error body across
+// the SDK call boundary so the error mapper can surface a redacted
+// snippet on 5xx responses without touching the SDK internals.
+//
+// Streaming calls additionally pass `maxRetries: 0` at the call site to
+// prevent mid-stream replays from emitting duplicated text.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import Anthropic from "@anthropic-ai/sdk";
+import { redactSecret, type VerboseLogger } from "../bin/logger.js";
+
+const UPSTREAM_BODY_MAX_CHARS = 512;
+
+export type RequestScope = AsyncLocalStorage<{ upstreamBody?: string }>;
+
+export interface AnthropicClientConfig {
+  /** Anthropic API key. Required. */
+  apiKey: string;
+  /** Anthropic base URL override. */
+  baseURL?: string;
+  /** Per-request timeout in ms. Default 60_000. */
+  requestTimeoutMs?: number;
+  /** Optional verbose logger. When enabled, emits `anthropic-http-request`
+   *  and `anthropic-http-response` events with the Authorization header
+   *  + x-api-key value redacted. SSE bodies are not consumed; their
+   *  content surfaces via `anthropic-stream-*` events in `messages.ts`. */
+  logger?: VerboseLogger;
+}
+
+export interface CreatedAnthropicClient {
+  client: Anthropic;
+  requestScope: RequestScope;
+}
+
+export function createAnthropicClient(config: AnthropicClientConfig): CreatedAnthropicClient {
+  const requestScope: RequestScope = new AsyncLocalStorage();
+  const baseFetch: typeof fetch = globalThis.fetch.bind(globalThis);
+  const logger = config.logger;
+
+  const captureFetch: typeof fetch = async (input, init) => {
+    if (logger?.enabled) {
+      logRequest(logger, input, init, config.apiKey);
+    }
+    const res = await baseFetch(input, init);
+    if (logger?.enabled) {
+      await logResponse(logger, res, config.apiKey);
+    }
+    if (!res.ok) {
+      const store = requestScope.getStore();
+      if (store) {
+        try {
+          const text = await res.clone().text();
+          if (text) {
+            store.upstreamBody = redact(text, config.apiKey).slice(0, UPSTREAM_BODY_MAX_CHARS);
+          }
+        } catch {
+          /* body unreadable; SDK's own message remains the fallback */
+        }
+      }
+    }
+    return res;
+  };
+
+  const client = new Anthropic({
+    apiKey: config.apiKey,
+    timeout: config.requestTimeoutMs ?? 60_000,
+    fetch: captureFetch,
+    ...(config.baseURL ? { baseURL: config.baseURL } : {}),
+  });
+
+  return { client, requestScope };
+}
+
+function redact(s: string, apiKey: string): string {
+  if (!apiKey) return s;
+  return s.split(apiKey).join("[REDACTED]");
+}
+
+function logRequest(
+  logger: VerboseLogger,
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+  apiKey: string,
+): void {
+  try {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method =
+      init?.method ?? (typeof input !== "string" && !(input instanceof URL) ? input.method : "GET");
+    const headers = collectHeaders(
+      init?.headers ??
+        (typeof input !== "string" && !(input instanceof URL) ? input.headers : undefined),
+      apiKey,
+    );
+    const body = init?.body;
+    const bodyDump = renderBody(body, apiKey);
+    logger.log("anthropic-http-request", { method, url, headers, body: bodyDump });
+  } catch {
+    /* logging never blocks delivery */
+  }
+}
+
+async function logResponse(logger: VerboseLogger, res: Response, apiKey: string): Promise<void> {
+  try {
+    const ct = res.headers.get("content-type") ?? "";
+    let body: unknown;
+    if (ct.includes("text/event-stream")) {
+      body = "<sse stream — see anthropic-stream-* events>";
+    } else {
+      try {
+        const text = await res.clone().text();
+        const redacted = redact(text, apiKey);
+        body = tryParseJson(redacted);
+      } catch {
+        body = "<unreadable response body>";
+      }
+    }
+    logger.log("anthropic-http-response", {
+      status: res.status,
+      statusText: res.statusText,
+      body,
+    });
+  } catch {
+    /* logging never blocks delivery */
+  }
+}
+
+function collectHeaders(h: unknown, apiKey: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (h === null || h === undefined) return out;
+  const apply = (k: string, v: string) => {
+    const lower = k.toLowerCase();
+    if (lower === "authorization") {
+      const bearerMatch = v.match(/^(\s*Bearer\s+)(.+)$/i);
+      if (bearerMatch) {
+        out[k] = `${bearerMatch[1]}${redactSecret(bearerMatch[2])}`;
+      } else {
+        out[k] = redactSecret(v);
+      }
+      return;
+    }
+    if (lower === "x-api-key") {
+      out[k] = redactSecret(v);
+      return;
+    }
+    out[k] = apiKey && v.includes(apiKey) ? v.split(apiKey).join("[REDACTED]") : v;
+  };
+  if (typeof Headers !== "undefined" && h instanceof Headers) {
+    h.forEach((v, k) => {
+      apply(k, v);
+    });
+  } else if (Array.isArray(h)) {
+    for (const entry of h as Array<[string, string]>) {
+      apply(entry[0], entry[1]);
+    }
+  } else if (typeof h === "object") {
+    for (const [k, v] of Object.entries(h as Record<string, unknown>)) apply(k, String(v));
+  }
+  return out;
+}
+
+function renderBody(body: unknown, apiKey: string): unknown {
+  if (body === undefined || body === null) return null;
+  if (typeof body === "string") return tryParseJson(redact(body, apiKey));
+  if (body instanceof ArrayBuffer) return `<ArrayBuffer ${body.byteLength}B>`;
+  if (ArrayBuffer.isView(body)) return `<TypedArray ${(body as ArrayBufferView).byteLength}B>`;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (typeof FormData !== "undefined" && body instanceof FormData) return "<FormData>";
+  if (typeof Blob !== "undefined" && body instanceof Blob) return `<Blob ${body.size}B>`;
+  if (typeof ReadableStream !== "undefined" && body instanceof ReadableStream)
+    return "<ReadableStream>";
+  return "<unknown body>";
+}
+
+function tryParseJson(s: string): unknown {
+  const trimmed = s.trimStart();
+  if (trimmed.length === 0) return s;
+  const first = trimmed[0];
+  if (first !== "{" && first !== "[") return s;
+  try {
+    return JSON.parse(s) as unknown;
+  } catch {
+    return s;
+  }
+}

--- a/packages/ai-relay/src/anthropic/index.ts
+++ b/packages/ai-relay/src/anthropic/index.ts
@@ -1,0 +1,22 @@
+// ai-relay/anthropic — Anthropic Messages provider.
+
+export type { AnthropicClientConfig, CreatedAnthropicClient, RequestScope } from "./client.js";
+export { createAnthropicClient } from "./client.js";
+export type {
+  AnthropicMessagesConfig,
+  AnthropicMessagesHandler,
+  AnthropicMessagesHandlerBundle,
+  AnthropicMessagesInput,
+  AnthropicMessagesResult,
+  AnthropicMessagesSchema,
+  AnthropicMessagesStructured,
+  AnthropicUsage,
+} from "./messages.js";
+export {
+  anthropicMessagesTool,
+  makeAnthropicMessagesHandler,
+  makeAnthropicMessagesSchema,
+  mapAnthropicError,
+  registerAnthropicMessages,
+  registerAnthropicProvider,
+} from "./messages.js";

--- a/packages/ai-relay/src/anthropic/messages.ts
+++ b/packages/ai-relay/src/anthropic/messages.ts
@@ -1,0 +1,557 @@
+// Anthropic Messages MCP tool registrar.
+//
+// `registerAnthropicMessages(server, config)` registers a single MCP tool
+// that streams an Anthropic Messages response and returns it as one
+// `CallToolResult`. The same server may be safely registered against
+// multiple times with different `name` + `apiKey` + `baseURL` —
+// every call produces an independent closure (schema, Anthropic client,
+// per-request scope, AbortController) with NO module-level shared state.
+//
+// Streaming invariants:
+//   - `maxRetries: 0` at the call site (mid-stream replay would duplicate
+//     output).
+//
+// Error result invariants:
+//   - never echo the raw upstream body, prompt, or headers.
+//   - map Anthropic errors to the stable `code` set defined below.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import Anthropic from "@anthropic-ai/sdk";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { dumpMessages, type VerboseLogger } from "../bin/logger.js";
+import type { ToolDescriptor } from "../openai/chat.js";
+import { type CreatedAnthropicClient, createAnthropicClient, type RequestScope } from "./client.js";
+
+const DEFAULT_NAME = "messages";
+const DEFAULT_DESCRIPTION =
+  "Invoke Anthropic Messages and return the accumulated assistant message.";
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_TOKENS = 1024;
+
+// --- config ---------------------------------------------------------------
+
+export interface AnthropicMessagesConfig {
+  /** Registered MCP tool name. Default `"messages"`. Must be unique
+   *  within an MCP server when multiple instances are registered. */
+  name?: string;
+  /** Description override. */
+  description?: string;
+  /** Anthropic API key. Required unless `anthropicClient` is supplied. */
+  apiKey: string;
+  /** Anthropic base URL override. */
+  baseURL?: string;
+  /** Model id forwarded to the upstream Messages endpoint. Required. */
+  model: string;
+  /** Sampling temperature (0..1). When set, forwarded with every call. */
+  temperature?: number;
+  /** Max tokens forwarded to the upstream. Positive integer. Defaults
+   *  to 1024 when omitted (Anthropic requires `max_tokens` per call). */
+  max_tokens?: number;
+  /** Nucleus sampling cutoff (0..1). When set, forwarded with every call. */
+  top_p?: number;
+  /** Stop sequence (single string or array). Translated to
+   *  `stop_sequences` for the upstream call. */
+  stop?: string | string[];
+  /** Per-request Anthropic timeout in ms. Default 60_000. */
+  requestTimeoutMs?: number;
+  /** Inject a pre-built Anthropic client. */
+  anthropicClient?: Anthropic;
+  /** Inject the request scope that pairs with `anthropicClient`. */
+  requestScope?: RequestScope;
+  /** Optional verbose logger. */
+  logger?: VerboseLogger;
+}
+
+// --- input schema ---------------------------------------------------------
+
+export function makeAnthropicMessagesSchema() {
+  return z
+    .object({
+      messages: z
+        .array(
+          z.object({
+            role: z.enum(["system", "user", "assistant"]),
+            content: z.string(),
+          }),
+        )
+        .min(1),
+    })
+    .strict();
+}
+
+export type AnthropicMessagesSchema = ReturnType<typeof makeAnthropicMessagesSchema>;
+export type AnthropicMessagesInput = z.infer<AnthropicMessagesSchema>;
+
+export const anthropicMessagesOutputSchema = z
+  .object({
+    model: z.string(),
+    usage: z
+      .object({
+        prompt_tokens: z.number(),
+        completion_tokens: z.number(),
+        total_tokens: z.number(),
+      })
+      .optional(),
+    finish_reason: z.string().optional(),
+    code: z.string().optional(),
+    retryAfter: z.number().optional(),
+  })
+  .strict();
+
+// --- result shape ---------------------------------------------------------
+
+export type AnthropicUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+export type AnthropicMessagesStructured = {
+  model: string;
+  usage?: AnthropicUsage;
+  finish_reason?: string;
+  code?: string;
+  retryAfter?: number;
+};
+
+export type AnthropicMessagesResult = {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: AnthropicMessagesStructured;
+  isError: boolean;
+};
+
+export type AnthropicMessagesHandler = (
+  rawInput: unknown,
+  extra?: { signal?: AbortSignal },
+) => Promise<AnthropicMessagesResult>;
+
+// --- error mapping --------------------------------------------------------
+
+type MappedError = {
+  code: string;
+  message: string;
+  retryAfter?: number;
+};
+
+export function mapAnthropicError(err: unknown, requestScope?: RequestScope): MappedError {
+  if (err instanceof Anthropic.APIError) {
+    const status = err.status;
+
+    if (status === 401 || status === 403) {
+      return { code: "auth", message: "Authentication failed" };
+    }
+
+    if (status === 429) {
+      const headerVal = err.headers?.get?.("retry-after") ?? "";
+      const parsed = Number(headerVal);
+      const retryAfter = Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+      return retryAfter !== undefined
+        ? { code: "rate_limited", message: "Rate limited by upstream", retryAfter }
+        : { code: "rate_limited", message: "Rate limited by upstream" };
+    }
+
+    if (status === 400) {
+      const errType = err.type;
+      const msg = err.message ?? "";
+      if (errType === "invalid_request_error" && /context/i.test(msg)) {
+        return { code: "context_length", message: "Context length exceeded" };
+      }
+      return { code: "bad_request", message: "Bad request" };
+    }
+
+    if (status === 529) {
+      const body = requestScope?.getStore()?.upstreamBody;
+      return {
+        code: "upstream_error",
+        message: body ? `Upstream overloaded: ${body}` : "Upstream overloaded",
+      };
+    }
+
+    if (typeof status === "number" && status >= 500) {
+      const body = requestScope?.getStore()?.upstreamBody;
+      return {
+        code: "upstream_error",
+        message: body ? `Upstream server error: ${body}` : "Upstream server error",
+      };
+    }
+
+    if (status === undefined) {
+      return { code: "upstream_error", message: "Network or connection error" };
+    }
+
+    return { code: "bad_request", message: "Bad request" };
+  }
+
+  return { code: "upstream_error", message: "Network or unknown error" };
+}
+
+// --- handler factory ------------------------------------------------------
+
+export interface AnthropicMessagesHandlerBundle {
+  schema: AnthropicMessagesSchema;
+  handler: AnthropicMessagesHandler;
+  /** Resolved tool name (`config.name ?? "messages"`). */
+  name: string;
+  /** Resolved description. */
+  description: string;
+}
+
+export function makeAnthropicMessagesHandler(
+  config: AnthropicMessagesConfig,
+): AnthropicMessagesHandlerBundle {
+  if (!config.model || config.model.length === 0) {
+    throw new Error("AnthropicMessagesConfig.model is required");
+  }
+  const name = config.name ?? DEFAULT_NAME;
+  const max_tokens = config.max_tokens ?? DEFAULT_MAX_TOKENS;
+  const appliedMaxTokensDefault = config.max_tokens === undefined;
+  const description = config.description ?? buildDefaultDescription({ ...config, max_tokens });
+  const schema = makeAnthropicMessagesSchema();
+
+  const { client, requestScope } = resolveClient(config);
+  const logger = config.logger;
+
+  if (appliedMaxTokensDefault && logger?.enabled) {
+    logger.log("anthropic-max-tokens-default", {
+      model: config.model,
+      default: DEFAULT_MAX_TOKENS,
+    });
+  }
+
+  const handler: AnthropicMessagesHandler = async (rawInput, extra = {}) => {
+    const input: AnthropicMessagesInput = schema.parse(rawInput);
+
+    const ac = new AbortController();
+    if (extra.signal) {
+      if (extra.signal.aborted) {
+        ac.abort();
+      } else {
+        extra.signal.addEventListener("abort", () => ac.abort(), { once: true });
+      }
+    }
+
+    return requestScope.run({}, () =>
+      runOnce(input.messages, { ...config, max_tokens }, client, requestScope, ac, logger),
+    );
+  };
+
+  return { schema, handler, name, description };
+}
+
+export function registerAnthropicMessages(
+  server: McpServer,
+  config: AnthropicMessagesConfig,
+): void {
+  const { schema, handler, name, description } = makeAnthropicMessagesHandler(config);
+  server.registerTool(
+    name,
+    {
+      description,
+      inputSchema: schema.shape,
+      outputSchema: anthropicMessagesOutputSchema.shape,
+    },
+    handler,
+  );
+}
+
+export function registerAnthropicProvider(
+  server: McpServer,
+  config: AnthropicMessagesConfig,
+): void {
+  registerAnthropicMessages(server, config);
+}
+
+// --- transport-agnostic tool descriptor ----------------------------------
+
+export const anthropicMessagesTool: ToolDescriptor<
+  AnthropicMessagesConfig,
+  AnthropicMessagesHandlerBundle
+> = {
+  provider: "anthropic",
+  name: "messages",
+  makeHandler: makeAnthropicMessagesHandler,
+  desugar: (plain, opts) => {
+    const messages: Array<{ role: "system" | "user"; content: string }> = [];
+    if (opts.system) messages.push({ role: "system", content: opts.system });
+    messages.push({ role: "user", content: plain });
+    return { messages };
+  },
+};
+
+// --- internals ------------------------------------------------------------
+
+function buildDefaultDescription(
+  config: Omit<AnthropicMessagesConfig, "max_tokens"> & { max_tokens: number },
+): string {
+  const hints: string[] = [`model: ${config.model}`, `max_tokens: ${config.max_tokens}`];
+  if (config.temperature !== undefined) hints.push(`temperature: ${config.temperature}`);
+  if (config.top_p !== undefined) hints.push(`top_p: ${config.top_p}`);
+  if (config.stop !== undefined) {
+    hints.push(`stop: ${Array.isArray(config.stop) ? JSON.stringify(config.stop) : config.stop}`);
+  }
+  return `${DEFAULT_DESCRIPTION} (${hints.join(", ")})`;
+}
+
+function resolveClient(config: AnthropicMessagesConfig): CreatedAnthropicClient {
+  if (config.anthropicClient) {
+    return {
+      client: config.anthropicClient,
+      requestScope: config.requestScope ?? new AsyncLocalStorage(),
+    };
+  }
+  return createAnthropicClient({
+    apiKey: config.apiKey,
+    ...(config.baseURL ? { baseURL: config.baseURL } : {}),
+    requestTimeoutMs: config.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ...(config.logger ? { logger: config.logger } : {}),
+  });
+}
+
+type ExtractedMessages = {
+  system?: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+};
+
+// Anthropic places the system prompt in a top-level `system` field. The
+// caller-facing schema accepts a `system` role inside `messages` (parity
+// with OpenAI). Leading consecutive system messages are concatenated; a
+// system message after a user/assistant turn is rejected because Anthropic
+// has no representation for interleaved system content.
+function extractSystem(messages: AnthropicMessagesInput["messages"]): ExtractedMessages {
+  const systemParts: string[] = [];
+  let i = 0;
+  while (i < messages.length && messages[i]?.role === "system") {
+    const m = messages[i];
+    if (m) systemParts.push(m.content);
+    i++;
+  }
+  const rest: Array<{ role: "user" | "assistant"; content: string }> = [];
+  for (; i < messages.length; i++) {
+    const m = messages[i];
+    if (!m) continue;
+    if (m.role === "system") {
+      const err = new Error(
+        "Anthropic does not support system messages interleaved with user/assistant turns; place all system messages at the start",
+      ) as Error & { code?: string };
+      err.code = "bad_request";
+      throw err;
+    }
+    rest.push({ role: m.role, content: m.content });
+  }
+  const out: ExtractedMessages = { messages: rest };
+  if (systemParts.length > 0) out.system = systemParts.join("\n\n");
+  return out;
+}
+
+function translateStop(stop: string | string[] | undefined): string[] | undefined {
+  if (stop === undefined) return undefined;
+  const arr = Array.isArray(stop) ? stop : [stop];
+  const filtered = arr.filter((s) => typeof s === "string" && s.trim().length > 0);
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function mapStopReason(stopReason: string | null | undefined): string | undefined {
+  switch (stopReason) {
+    case "end_turn":
+      return "stop";
+    case "max_tokens":
+      return "length";
+    case "stop_sequence":
+      return "stop";
+    case "tool_use":
+      return "tool_calls";
+    case "refusal":
+      return "content_filter";
+    default:
+      return stopReason ?? undefined;
+  }
+}
+
+async function runOnce(
+  rawMessages: AnthropicMessagesInput["messages"],
+  config: AnthropicMessagesConfig & { max_tokens: number },
+  client: Anthropic,
+  requestScope: RequestScope,
+  ac: AbortController,
+  logger?: VerboseLogger,
+): Promise<AnthropicMessagesResult> {
+  const startedAt = Date.now();
+  const model = config.model;
+
+  let extracted: ExtractedMessages;
+  try {
+    extracted = extractSystem(rawMessages);
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    const code = e.code ?? "bad_request";
+    if (logger?.enabled) {
+      logger.log("anthropic-stream-end", {
+        accumulatedText: "",
+        finish_reason: undefined,
+        usage: undefined,
+        elapsedMs: Date.now() - startedAt,
+        error: { code, message: e.message },
+      });
+    }
+    return {
+      content: [{ type: "text", text: e.message }],
+      structuredContent: { model, code },
+      isError: true,
+    };
+  }
+
+  const stopSequences = translateStop(config.stop);
+
+  if (logger?.enabled) {
+    logger.log("anthropic-stream-start", {
+      model,
+      messages: dumpMessages(rawMessages),
+      ...(extracted.system !== undefined ? { system: extracted.system } : {}),
+      max_tokens: config.max_tokens,
+      temperature: config.temperature,
+      top_p: config.top_p,
+      stop_sequences: stopSequences,
+      maxRetries: 0,
+    });
+    if (ac.signal.aborted) {
+      logger.log("anthropic-cancelled", {
+        reason: ac.signal.reason ?? "aborted",
+        elapsedMs: Date.now() - startedAt,
+      });
+    } else {
+      ac.signal.addEventListener(
+        "abort",
+        () => {
+          logger.log("anthropic-cancelled", {
+            reason: ac.signal.reason ?? "aborted",
+            elapsedMs: Date.now() - startedAt,
+          });
+        },
+        { once: true },
+      );
+    }
+  }
+
+  try {
+    const stream = await client.messages.create(
+      {
+        model,
+        messages: extracted.messages,
+        max_tokens: config.max_tokens,
+        ...(extracted.system !== undefined ? { system: extracted.system } : {}),
+        ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
+        ...(config.top_p !== undefined ? { top_p: config.top_p } : {}),
+        ...(stopSequences !== undefined ? { stop_sequences: stopSequences } : {}),
+        stream: true,
+      },
+      { signal: ac.signal, maxRetries: 0 },
+    );
+
+    let accumulated = "";
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+    let stopReason: string | null | undefined;
+
+    for await (const event of stream) {
+      if (event.type === "message_start") {
+        const u = event.message?.usage;
+        if (u) inputTokens = u.input_tokens ?? inputTokens;
+      } else if (event.type === "content_block_delta") {
+        const delta = event.delta;
+        if (delta && delta.type === "text_delta") {
+          accumulated += delta.text;
+        }
+      } else if (event.type === "message_delta") {
+        if (event.delta?.stop_reason !== undefined) {
+          stopReason = event.delta.stop_reason;
+        }
+        if (event.usage?.output_tokens !== undefined) {
+          outputTokens = event.usage.output_tokens;
+        }
+      }
+    }
+
+    if (stopReason === "refusal") {
+      const usage = buildUsage(inputTokens, outputTokens);
+      const structuredContent: AnthropicMessagesStructured = {
+        model,
+        code: "content_policy",
+        ...(usage ? { usage } : {}),
+        finish_reason: "content_filter",
+      };
+      if (logger?.enabled) {
+        logger.log("anthropic-stream-end", {
+          accumulatedText: accumulated,
+          finish_reason: "content_filter",
+          usage,
+          elapsedMs: Date.now() - startedAt,
+          error: { code: "content_policy", message: "Content policy rejected" },
+        });
+      }
+      return {
+        content: [{ type: "text", text: "Content policy rejected" }],
+        structuredContent,
+        isError: true,
+      };
+    }
+
+    const usage = buildUsage(inputTokens, outputTokens);
+    const finishReason = mapStopReason(stopReason);
+    const structuredContent: AnthropicMessagesStructured = {
+      model,
+      ...(usage ? { usage } : {}),
+      ...(finishReason !== undefined ? { finish_reason: finishReason } : {}),
+    };
+
+    if (logger?.enabled) {
+      logger.log("anthropic-stream-end", {
+        accumulatedText: accumulated,
+        finish_reason: finishReason,
+        usage,
+        elapsedMs: Date.now() - startedAt,
+      });
+    }
+
+    return {
+      content: [{ type: "text", text: accumulated }],
+      structuredContent,
+      isError: false,
+    };
+  } catch (err) {
+    const mapped = mapAnthropicError(err, requestScope);
+    const structuredContent: AnthropicMessagesStructured = {
+      model,
+      code: mapped.code,
+      ...(mapped.retryAfter !== undefined ? { retryAfter: mapped.retryAfter } : {}),
+    };
+    if (logger?.enabled) {
+      logger.log("anthropic-stream-end", {
+        accumulatedText: "",
+        finish_reason: undefined,
+        usage: undefined,
+        elapsedMs: Date.now() - startedAt,
+        error: { code: mapped.code, message: mapped.message },
+      });
+    }
+    return {
+      content: [{ type: "text", text: mapped.message }],
+      structuredContent,
+      isError: true,
+    };
+  }
+}
+
+function buildUsage(
+  inputTokens: number | undefined,
+  outputTokens: number | undefined,
+): AnthropicUsage | undefined {
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const prompt = inputTokens ?? 0;
+  const completion = outputTokens ?? 0;
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+  };
+}

--- a/packages/ai-relay/src/bin/ai-relay.ts
+++ b/packages/ai-relay/src/bin/ai-relay.ts
@@ -5,6 +5,7 @@
 import { realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
+import type { AnthropicProviderConfig, OpenAIProviderConfig, Provider } from "../config.js";
 import { loadConfig } from "../config.js";
 import { VERSION } from "../version.js";
 import { parseEnvFile } from "./env-file.js";
@@ -17,7 +18,7 @@ import {
 } from "./logger.js";
 import { startMcpServer } from "./mcp-server.js";
 import { type ParsedMcpInvocation, parseMcpArgv, UsageError } from "./parse.js";
-import { registry, resolveProvider } from "./registry.js";
+import { providerNames, resolveProvider } from "./registry.js";
 
 export { VERSION };
 
@@ -28,7 +29,7 @@ Intended to be spawned by an MCP host (Claude Desktop, Claude Code, Cursor, …)
 — do not run interactively.
 
 Providers:
-  ${Object.keys(registry).join(", ")}
+  ${providerNames.join(", ")}
 
 Required:
   -m, --model <id>        Upstream model id (or set AI_RELAY_MODEL)
@@ -63,7 +64,7 @@ For one-shot CLI invocation (no MCP server), use \`ai-relay-cli\`.
 const USAGE_NO_PROVIDER = `error: <provider> positional is required
 
 usage: ai-relay <provider> [flags]
-providers: ${Object.keys(registry).join(", ")}
+providers: ${providerNames.join(", ")}
 
 For one-shot CLI invocation, use \`ai-relay-cli\`.
 `;
@@ -112,10 +113,10 @@ export async function main(argv: readonly string[], io: AiRelayIO): Promise<numb
     return 2;
   }
 
-  const providerEntry = resolveProvider(parsed.provider);
+  const providerEntry = await resolveProvider(parsed.provider);
   if (providerEntry === undefined) {
     io.stderr.write(
-      `unknown provider: ${parsed.provider}\nknown providers: ${Object.keys(registry).join(", ")}\n`,
+      `unknown provider: ${parsed.provider}\nknown providers: ${providerNames.join(", ")}\n`,
     );
     return 2;
   }
@@ -140,7 +141,7 @@ export async function main(argv: readonly string[], io: AiRelayIO): Promise<numb
 
   const effectiveEnv = { ...io.env, ...envFileMap };
 
-  const args: Record<string, unknown> = { provider: "openai" };
+  const args: Record<string, unknown> = { provider: parsed.provider as Provider };
   if (parsed.flags["api-key"] !== undefined) args.apiKey = parsed.flags["api-key"];
   if (parsed.flags["base-url"] !== undefined) args.baseURL = parsed.flags["base-url"];
   if (parsed.flags.model !== undefined) args.model = parsed.flags.model;
@@ -150,16 +151,7 @@ export async function main(argv: readonly string[], io: AiRelayIO): Promise<numb
   if (parsed.flags.stop !== undefined) args.stop = parsed.flags.stop;
   if (parsed.flags.timeout !== undefined) args.requestTimeoutMs = parsed.flags.timeout;
 
-  let providerConfig: {
-    apiKey: string;
-    baseURL?: string | undefined;
-    model: string;
-    temperature?: number | undefined;
-    max_tokens?: number | undefined;
-    top_p?: number | undefined;
-    stop?: string | string[] | undefined;
-    requestTimeoutMs?: number | undefined;
-  };
+  let providerConfig: OpenAIProviderConfig | AnthropicProviderConfig;
   try {
     const cfg = loadConfig({ env: effectiveEnv, args });
     const first = cfg.providers[0];

--- a/packages/ai-relay/src/bin/mcp-server.ts
+++ b/packages/ai-relay/src/bin/mcp-server.ts
@@ -4,14 +4,13 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { OpenAIChatConfig } from "../openai/index.js";
 import { dumpMessages, type VerboseLogger } from "./logger.js";
-import type { ProviderEntry } from "./registry.js";
+import type { AnyProviderConfig, ProviderEntry } from "./registry.js";
 
 export interface StartMcpServerOptions {
   provider: string;
   providerEntry: ProviderEntry;
-  config: OpenAIChatConfig;
+  config: AnyProviderConfig;
   version: string;
   logger?: VerboseLogger;
 }
@@ -19,7 +18,9 @@ export interface StartMcpServerOptions {
 export async function startMcpServer(opts: StartMcpServerOptions): Promise<void> {
   const server = new McpServer({ name: "ai-relay", version: opts.version });
   const logger = opts.logger;
-  const configWithLogger: OpenAIChatConfig = logger ? { ...opts.config, logger } : opts.config;
+  const configWithLogger: AnyProviderConfig = logger
+    ? ({ ...opts.config, logger } as AnyProviderConfig)
+    : opts.config;
   opts.providerEntry.registerOnServer(server, configWithLogger);
 
   const transport = new StdioServerTransport();

--- a/packages/ai-relay/src/bin/registry.ts
+++ b/packages/ai-relay/src/bin/registry.ts
@@ -1,37 +1,77 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-  type OpenAIChatConfig,
-  type OpenAIChatHandlerBundle,
-  openAIChatTool,
-  registerOpenAIProvider,
-  type ToolDescriptor,
-} from "../openai/index.js";
+import type { ToolDescriptor } from "../openai/chat.js";
+import type { VerboseLogger } from "./logger.js";
 
-export type AnyTool = ToolDescriptor<OpenAIChatConfig, OpenAIChatHandlerBundle>;
+// Tool config shape accepted by every provider's `makeHandler` /
+// `registerOnServer`. Provider modules validate the precise shape they
+// accept; the bin treats configs uniformly through this surface.
+export interface AnyProviderConfig {
+  name?: string;
+  description?: string;
+  apiKey: string;
+  baseURL?: string;
+  model: string;
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  stop?: string | string[];
+  requestTimeoutMs?: number;
+  logger?: VerboseLogger;
+}
+
+// Tools are typed against their own config shape. The bin treats them
+// uniformly as `ToolDescriptor<AnyProviderConfig, unknown>` since it only
+// invokes `makeHandler` + `desugar` and never touches handler-specific
+// surface.
+export type AnyTool = ToolDescriptor<AnyProviderConfig, unknown>;
 
 export interface ProviderEntry {
   /** Mount all of this provider's API tools on an `McpServer`. */
-  registerOnServer: (server: McpServer, config: OpenAIChatConfig) => void;
+  registerOnServer: (server: McpServer, config: AnyProviderConfig) => void;
   /** CLI one-shot tool descriptors keyed by tool name. */
   tools: Record<string, AnyTool>;
 }
 
-export const registry = {
-  openai: {
-    registerOnServer: registerOpenAIProvider,
-    tools: {
-      "chat-completions": openAIChatTool,
-    },
+export type ProviderName = "openai" | "anthropic";
+
+type Loader = () => Promise<ProviderEntry>;
+
+const loaders: Record<ProviderName, Loader> = {
+  openai: async () => {
+    const mod = await import("../openai/index.js");
+    return {
+      registerOnServer: mod.registerOpenAIProvider as ProviderEntry["registerOnServer"],
+      tools: {
+        "chat-completions": mod.openAIChatTool as AnyTool,
+      },
+    };
   },
-} as const satisfies Record<string, ProviderEntry>;
+  anthropic: async () => {
+    const mod = (await import("../anthropic/index.js")) as {
+      registerAnthropicProvider: ProviderEntry["registerOnServer"];
+      anthropicMessagesTool: AnyTool;
+    };
+    return {
+      registerOnServer: mod.registerAnthropicProvider,
+      tools: {
+        messages: mod.anthropicMessagesTool,
+      },
+    };
+  },
+};
 
-export type Provider = keyof typeof registry;
+export const providerNames: readonly ProviderName[] = Object.keys(loaders) as ProviderName[];
 
-export function resolveProvider(name: string): ProviderEntry | undefined {
-  return (registry as Record<string, ProviderEntry>)[name];
+export async function resolveProvider(name: string): Promise<ProviderEntry | undefined> {
+  const loader = (loaders as Record<string, Loader | undefined>)[name];
+  if (!loader) return undefined;
+  return loader();
 }
 
-export function resolveProviderTool(provider: string, tool: string): AnyTool | undefined {
-  const entry = (registry as Record<string, ProviderEntry>)[provider];
+export async function resolveProviderTool(
+  provider: string,
+  tool: string,
+): Promise<AnyTool | undefined> {
+  const entry = await resolveProvider(provider);
   return entry?.tools[tool];
 }

--- a/packages/ai-relay/src/bin/run.ts
+++ b/packages/ai-relay/src/bin/run.ts
@@ -234,7 +234,8 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
   const result = await bundle.handler(inputObj);
 
   if (result.isError) {
-    verbose.log("openai-error", {
+    verbose.log("tool-error", {
+      provider: parsed.provider,
       code: result.structuredContent.code,
       retryAfter: result.structuredContent.retryAfter,
     });

--- a/packages/ai-relay/src/bin/run.ts
+++ b/packages/ai-relay/src/bin/run.ts
@@ -3,8 +3,8 @@
 
 import { readFile } from "node:fs/promises";
 import type { Readable } from "node:stream";
+import type { AnthropicProviderConfig, OpenAIProviderConfig, Provider } from "../config.js";
 import { loadConfig } from "../config.js";
-import type { OpenAIChatConfig, OpenAIChatHandlerBundle } from "../openai/index.js";
 import { VERSION } from "../version.js";
 import { parseEnvFile } from "./env-file.js";
 import {
@@ -14,9 +14,16 @@ import {
   redactArgv,
   redactSecret,
   snapshotRelayEnv,
+  type VerboseLogger,
 } from "./logger.js";
 import { type ParsedInvocation, parseArgv, UsageError } from "./parse.js";
-import { type AnyTool, registry, resolveProvider, resolveProviderTool } from "./registry.js";
+import {
+  type AnyProviderConfig,
+  type AnyTool,
+  providerNames,
+  resolveProvider,
+  resolveProviderTool,
+} from "./registry.js";
 
 export { VERSION };
 
@@ -26,7 +33,7 @@ Positionals:
   <provider>              Upstream provider (e.g. openai)
   <tool>                  Tool name within the provider (e.g. chat-completions)
 
-Providers: ${Object.keys(registry).join(", ")}
+Providers: ${providerNames.join(", ")}
 
 Inputs (exactly one of):
   positional <input>      JSON object {"messages":[...]} or plain text
@@ -104,14 +111,14 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
   });
   verbose.log("env-snapshot", snapshotRelayEnv(io.env));
 
-  const providerEntry = resolveProvider(parsed.provider);
+  const providerEntry = await resolveProvider(parsed.provider);
   if (!providerEntry) {
     io.stderr.write(
-      `unknown provider: ${parsed.provider}\nknown providers: ${Object.keys(registry).join(", ")}\n`,
+      `unknown provider: ${parsed.provider}\nknown providers: ${providerNames.join(", ")}\n`,
     );
     return 2;
   }
-  const tool = resolveProviderTool(parsed.provider, parsed.tool);
+  const tool = await resolveProviderTool(parsed.provider, parsed.tool);
   if (!tool) {
     io.stderr.write(
       `unknown tool for provider ${parsed.provider}: ${parsed.tool}\nknown tools: ${Object.keys(providerEntry.tools).join(", ")}\n`,
@@ -179,7 +186,7 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
 
   const effectiveEnv = { ...io.env, ...envFileMap };
 
-  const args: Record<string, unknown> = { provider: "openai" };
+  const args: Record<string, unknown> = { provider: parsed.provider as Provider };
   if (parsed.flags["api-key"] !== undefined) args.apiKey = parsed.flags["api-key"];
   if (parsed.flags["base-url"] !== undefined) args.baseURL = parsed.flags["base-url"];
   if (parsed.flags.model !== undefined) args.model = parsed.flags.model;
@@ -189,16 +196,7 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
   if (parsed.flags.stop !== undefined) args.stop = parsed.flags.stop;
   if (parsed.flags.timeout !== undefined) args.requestTimeoutMs = parsed.flags.timeout;
 
-  let providerConfig: {
-    apiKey: string;
-    baseURL?: string | undefined;
-    model: string;
-    temperature?: number | undefined;
-    max_tokens?: number | undefined;
-    top_p?: number | undefined;
-    stop?: string | string[] | undefined;
-    requestTimeoutMs?: number | undefined;
-  };
+  let providerConfig: OpenAIProviderConfig | AnthropicProviderConfig;
   try {
     const cfg = loadConfig({ env: effectiveEnv, args });
     const first = cfg.providers[0];
@@ -220,23 +218,18 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
     requestTimeoutMs: providerConfig.requestTimeoutMs ?? "(default)",
   });
 
-  const toolConfig: OpenAIChatConfig = {
-    apiKey: providerConfig.apiKey,
-    ...(providerConfig.baseURL !== undefined ? { baseURL: providerConfig.baseURL } : {}),
-    model: providerConfig.model,
-    ...(providerConfig.temperature !== undefined
-      ? { temperature: providerConfig.temperature }
-      : {}),
-    ...(providerConfig.max_tokens !== undefined ? { max_tokens: providerConfig.max_tokens } : {}),
-    ...(providerConfig.top_p !== undefined ? { top_p: providerConfig.top_p } : {}),
-    ...(providerConfig.stop !== undefined ? { stop: providerConfig.stop } : {}),
-    ...(providerConfig.requestTimeoutMs !== undefined
-      ? { requestTimeoutMs: providerConfig.requestTimeoutMs }
-      : {}),
-    ...(verbose.enabled ? { logger: verbose } : {}),
-  };
+  const toolConfig = buildToolConfig(parsed.provider as Provider, providerConfig, verbose);
 
-  const bundle: OpenAIChatHandlerBundle = tool.makeHandler(toolConfig);
+  const bundle = tool.makeHandler(toolConfig) as {
+    handler: (
+      rawInput: unknown,
+      extra?: { signal?: AbortSignal },
+    ) => Promise<{
+      content: Array<{ type: "text"; text: string }>;
+      structuredContent: { code?: string; retryAfter?: number };
+      isError: boolean;
+    }>;
+  };
 
   const result = await bundle.handler(inputObj);
 
@@ -298,6 +291,25 @@ function coerceInput(
     throw new UsageError(`tool ${tool.name} does not accept plain text input; pass JSON`);
   }
   return tool.desugar(raw, opts);
+}
+
+function buildToolConfig(
+  _provider: Provider,
+  cfg: OpenAIProviderConfig | AnthropicProviderConfig,
+  verbose: VerboseLogger,
+): AnyProviderConfig {
+  const common = {
+    apiKey: cfg.apiKey,
+    ...(cfg.baseURL !== undefined ? { baseURL: cfg.baseURL } : {}),
+    model: cfg.model,
+    ...(cfg.temperature !== undefined ? { temperature: cfg.temperature } : {}),
+    ...(cfg.max_tokens !== undefined ? { max_tokens: cfg.max_tokens } : {}),
+    ...(cfg.top_p !== undefined ? { top_p: cfg.top_p } : {}),
+    ...(cfg.stop !== undefined ? { stop: cfg.stop } : {}),
+    ...(cfg.requestTimeoutMs !== undefined ? { requestTimeoutMs: cfg.requestTimeoutMs } : {}),
+    ...(verbose.enabled ? { logger: verbose } : {}),
+  };
+  return common as AnyProviderConfig;
 }
 
 type StdinResult = { kind: "tty" } | { kind: "text"; value: string } | { kind: "empty-pipe" };

--- a/packages/ai-relay/src/config.ts
+++ b/packages/ai-relay/src/config.ts
@@ -11,12 +11,12 @@
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 
-export type Provider = "openai";
-export type Capability = "chat";
+export type Provider = "openai" | "anthropic";
+export type Capability = "chat" | "messages";
 
 const stopSchema = z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]);
 
-const providerConfigSchema = z
+const openaiConfigSchema = z
   .object({
     id: z.string().min(1).optional(),
     provider: z.literal("openai"),
@@ -33,12 +33,36 @@ const providerConfigSchema = z
   })
   .strict();
 
+const anthropicConfigSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    provider: z.literal("anthropic"),
+    capability: z.literal("messages").default("messages"),
+    apiKey: z.string().min(1),
+    baseURL: z.string().url().optional(),
+    model: z.string().min(1),
+    temperature: z.number().min(0).max(1).optional(),
+    max_tokens: z.number().int().positive().optional(),
+    top_p: z.number().min(0).max(1).optional(),
+    stop: stopSchema.optional(),
+    requestTimeoutMs: z.number().int().positive().optional(),
+    description: z.string().optional(),
+  })
+  .strict();
+
+const providerConfigSchema = z.discriminatedUnion("provider", [
+  openaiConfigSchema,
+  anthropicConfigSchema,
+]);
+
 const relayConfigSchema = z
   .object({
     providers: z.array(providerConfigSchema).min(1),
   })
   .strict();
 
+export type OpenAIProviderConfig = z.infer<typeof openaiConfigSchema>;
+export type AnthropicProviderConfig = z.infer<typeof anthropicConfigSchema>;
 export type ProviderConfig = z.infer<typeof providerConfigSchema>;
 export type RelayConfig = z.infer<typeof relayConfigSchema>;
 
@@ -104,8 +128,10 @@ function parseStopList(value: string | undefined): string | string[] | undefined
   return parts;
 }
 
-function envOpenAIPartial(env: EnvSource): Partial<ProviderConfig> {
-  const out: Partial<ProviderConfig> = {};
+type EnvPartial = Partial<Record<string, unknown>>;
+
+function envCommonPartial(env: EnvSource): EnvPartial {
+  const out: EnvPartial = {};
   if (env.AI_RELAY_API_KEY) out.apiKey = env.AI_RELAY_API_KEY;
   if (env.AI_RELAY_BASE_URL && env.AI_RELAY_BASE_URL.trim().length > 0) {
     out.baseURL = env.AI_RELAY_BASE_URL;
@@ -113,8 +139,6 @@ function envOpenAIPartial(env: EnvSource): Partial<ProviderConfig> {
   if (env.AI_RELAY_MODEL && env.AI_RELAY_MODEL.length > 0) {
     out.model = env.AI_RELAY_MODEL;
   }
-  const temperature = parseFloatInRange(env.AI_RELAY_TEMPERATURE, 0, 2);
-  if (temperature !== undefined) out.temperature = temperature;
   const maxTokens = parsePositiveInt(env.AI_RELAY_MAX_TOKENS);
   if (maxTokens !== undefined) out.max_tokens = maxTokens;
   const topP = parseFloatInRange(env.AI_RELAY_TOP_P, 0, 1);
@@ -124,6 +148,29 @@ function envOpenAIPartial(env: EnvSource): Partial<ProviderConfig> {
   const timeoutMs = parsePositiveInt(env.AI_RELAY_REQUEST_TIMEOUT_MS);
   if (timeoutMs !== undefined) out.requestTimeoutMs = timeoutMs;
   return out;
+}
+
+function envOpenAIPartial(env: EnvSource): EnvPartial {
+  const out = envCommonPartial(env);
+  const temperature = parseFloatInRange(env.AI_RELAY_TEMPERATURE, 0, 2);
+  if (temperature !== undefined) out.temperature = temperature;
+  return out;
+}
+
+function envAnthropicPartial(env: EnvSource): EnvPartial {
+  const out = envCommonPartial(env);
+  const temperature = parseFloatInRange(env.AI_RELAY_TEMPERATURE, 0, 1);
+  if (temperature !== undefined) out.temperature = temperature;
+  return out;
+}
+
+const envPartialByProvider: Record<Provider, (env: EnvSource) => EnvPartial> = {
+  openai: envOpenAIPartial,
+  anthropic: envAnthropicPartial,
+};
+
+function defaultCapability(provider: Provider): Capability {
+  return provider === "anthropic" ? "messages" : "chat";
 }
 
 function materialiseId(p: ProviderConfig): ProviderConfig {
@@ -139,9 +186,9 @@ function withDefaults(p: ProviderConfig): ProviderConfig {
 }
 
 function buildFromArgsAndEnv(args: ArgsSource, env: EnvSource): RelayConfig {
-  const envPartial = envOpenAIPartial(env);
-  const provider = args.provider ?? "openai";
-  const capability = args.capability ?? "chat";
+  const provider: Provider = args.provider ?? "openai";
+  const envPartial = envPartialByProvider[provider](env);
+  const capability: Capability = args.capability ?? defaultCapability(provider);
   const merged: Record<string, unknown> = {
     provider,
     capability,
@@ -165,7 +212,7 @@ function buildFromArgsAndEnv(args: ArgsSource, env: EnvSource): RelayConfig {
 }
 
 function buildFromEnvOnly(env: EnvSource): RelayConfig {
-  const envPartial = envOpenAIPartial(env);
+  const envPartial = envPartialByProvider.openai(env);
   const merged = {
     provider: "openai" as const,
     capability: "chat" as const,
@@ -219,15 +266,15 @@ function buildFromFile(
   const parsed = relayConfigSchema.safeParse(json);
   if (!parsed.success) throw redactZodError(`Invalid config file ${file}`, parsed.error);
 
-  const envPartial = env ? envOpenAIPartial(env) : {};
   const filled = parsed.data.providers.map((p) => {
+    const envPartial = env ? envPartialByProvider[p.provider](env) : {};
     const withEnv: ProviderConfig = {
       ...p,
       apiKey: p.apiKey,
       ...(p.baseURL
         ? { baseURL: p.baseURL }
         : envPartial.baseURL
-          ? { baseURL: envPartial.baseURL }
+          ? { baseURL: envPartial.baseURL as string }
           : {}),
     };
     const merged = args ? applyArgsOverrides(withEnv, args) : withEnv;

--- a/packages/ai-relay/tests/integration/bin-tarball.test.ts
+++ b/packages/ai-relay/tests/integration/bin-tarball.test.ts
@@ -169,11 +169,15 @@ beforeAll(async () => {
     join(scratchDir, "package.json"),
     JSON.stringify({ name: "bin-tarball-test", private: true, type: "module" }),
   );
-  execFileSync("npm", ["install", "--no-audit", "--no-fund", tarball], {
-    cwd: scratchDir,
-    stdio: "pipe",
-    env: packEnv,
-  });
+  execFileSync(
+    "npm",
+    ["install", "--no-audit", "--no-fund", tarball, "openai@^6", "@anthropic-ai/sdk@^0.96.0"],
+    {
+      cwd: scratchDir,
+      stdio: "pipe",
+      env: packEnv,
+    },
+  );
   mcpBinPath = join(scratchDir, "node_modules", ".bin", "ai-relay");
   cliBinPath = join(scratchDir, "node_modules", ".bin", "ai-relay-cli");
   if (!existsSync(mcpBinPath)) {
@@ -512,12 +516,12 @@ describe("ai-relay bin — installed tarball, MCP stdio mode (openai provider po
   it("C2: unknown provider → exit 2; no upstream call", async () => {
     mock.requests.length = 0;
     const r = await runMcpSession([], {
-      args: ["anthropic"],
+      args: ["gemini"],
       expectStartupFailure: true,
       env: { AI_RELAY_API_KEY: "test-k", AI_RELAY_BASE_URL: mock.baseURL },
     });
     expect(r.status).toBe(2);
-    expect(r.stderr).toContain("unknown provider: anthropic");
+    expect(r.stderr).toContain("unknown provider: gemini");
     expect(mock.requests).toHaveLength(0);
   });
 

--- a/packages/ai-relay/tests/integration/pack-contract.test.ts
+++ b/packages/ai-relay/tests/integration/pack-contract.test.ts
@@ -101,23 +101,30 @@ describe("pack contract — installed-tarball imports", () => {
       join(installDir, "package.json"),
       JSON.stringify({ name: "pack-import-check", private: true, type: "module" }),
     );
-    execFileSync("npm", ["install", "--no-audit", "--no-fund", tarball], {
-      cwd: installDir,
-      stdio: "pipe",
-    });
+    execFileSync(
+      "npm",
+      ["install", "--no-audit", "--no-fund", tarball, "openai@^6", "@anthropic-ai/sdk@^0.96.0"],
+      {
+        cwd: installDir,
+        stdio: "pipe",
+      },
+    );
 
     const script = `
       import * as root from "ai-relay";
       import * as env from "ai-relay/env";
       import * as auth from "ai-relay/auth";
       import * as openai from "ai-relay/openai";
+      import * as anthropic from "ai-relay/anthropic";
       const ok =
         typeof root.verifyBearer === "function" &&
         typeof root.loadConfig === "function" &&
         typeof env.loadConfig === "function" &&
         typeof auth.verifyBearer === "function" &&
         typeof openai.registerOpenAIChat === "function" &&
-        typeof openai.makeOpenAIChatHandler === "function";
+        typeof openai.makeOpenAIChatHandler === "function" &&
+        typeof anthropic.registerAnthropicMessages === "function" &&
+        typeof anthropic.makeAnthropicMessagesHandler === "function";
       console.log(ok ? "EXPORTS_OK" : "EXPORTS_MISSING");
     `;
     const out = execFileSync("node", ["--input-type=module", "-e", script], {
@@ -141,7 +148,16 @@ describe("pack contract — typecheck under bundler + nodenext", () => {
     // ai-relay install as extraneous and prune it.
     execFileSync(
       "npm",
-      ["install", "--no-audit", "--no-fund", "--no-save", tarball, "typescript@^6.0.3"],
+      [
+        "install",
+        "--no-audit",
+        "--no-fund",
+        "--no-save",
+        tarball,
+        "openai@^6",
+        "@anthropic-ai/sdk@^0.96.0",
+        "typescript@^6.0.3",
+      ],
       { cwd: tmp, stdio: "pipe" },
     );
 

--- a/packages/ai-relay/tests/unit/ai-relay.test.ts
+++ b/packages/ai-relay/tests/unit/ai-relay.test.ts
@@ -85,9 +85,9 @@ describe("ai-relay — usage / registry errors", () => {
 
   it("D2: unknown provider → exit 2 + 'unknown provider' on stderr", async () => {
     const cap = makeIO({ AI_RELAY_API_KEY: "k" });
-    const code = await main(["anthropic"], cap.io);
+    const code = await main(["gemini"], cap.io);
     expect(code).toBe(2);
-    expect(cap.stderr.value).toContain("unknown provider: anthropic");
+    expect(cap.stderr.value).toContain("unknown provider: gemini");
     expect(cap.stderr.value).toContain("openai");
   });
 

--- a/packages/ai-relay/tests/unit/anthropic-messages.test.ts
+++ b/packages/ai-relay/tests/unit/anthropic-messages.test.ts
@@ -1,0 +1,763 @@
+// Unit tests for `lib/anthropic/messages.ts` — the framework-agnostic
+// Anthropic Messages registrar. Tests target `makeAnthropicMessagesHandler`
+// (the factory `registerAnthropicMessages` calls internally) with MSW
+// intercepting the upstream HTTP boundary. Each test creates its own
+// handler so there is no module-level shared state to reset.
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  type AnthropicMessagesConfig,
+  type AnthropicMessagesHandlerBundle,
+  type AnthropicMessagesResult,
+  makeAnthropicMessagesHandler,
+} from "../../src/anthropic/messages.js";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const ENDPOINT = "https://api.anthropic.com/v1/messages";
+
+const TEST_API_KEY = "test-anthropic-api-key";
+
+const VALID_MODEL = "claude-sonnet-4-5";
+const VALID_MESSAGES = [{ role: "user" as const, content: "say hi" }];
+
+function makeHandler(
+  overrides: Partial<AnthropicMessagesConfig> = {},
+): AnthropicMessagesHandlerBundle {
+  return makeAnthropicMessagesHandler({
+    apiKey: TEST_API_KEY,
+    model: VALID_MODEL,
+    ...overrides,
+  });
+}
+
+function sseStream(events: Array<{ event: string; data: unknown }>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < events.length) {
+        const e = events[i];
+        if (e) {
+          controller.enqueue(
+            encoder.encode(`event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`),
+          );
+        }
+        i++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function sseResponse(events: Array<{ event: string; data: unknown }>) {
+  return new HttpResponse(sseStream(events), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function defaultOkStream(text = "ok"): Array<{ event: string; data: unknown }> {
+  return [
+    {
+      event: "message_start",
+      data: { type: "message_start", message: { usage: { input_tokens: 5 } } },
+    },
+    {
+      event: "content_block_start",
+      data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+    },
+    {
+      event: "content_block_delta",
+      data: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text },
+      },
+    },
+    { event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+    {
+      event: "message_delta",
+      data: {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 3 },
+      },
+    },
+    { event: "message_stop", data: { type: "message_stop" } },
+  ];
+}
+
+function assertNoSecretLeak(result: AnthropicMessagesResult | unknown): void {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain(TEST_API_KEY);
+}
+
+// =========================================================================
+// A: Input Validation
+// =========================================================================
+
+describe("anthropic messages — input validation", () => {
+  it("P1: accepts a minimal { messages } input", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(defaultOkStream())));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(false);
+  });
+
+  it("D1: rejects unknown extra keys (strict schema)", async () => {
+    const { handler } = makeHandler();
+    await expect(handler({ messages: VALID_MESSAGES, unknown: "x" })).rejects.toThrow();
+  });
+
+  it("D2: rejects role enum value outside {system,user,assistant}", async () => {
+    const { handler } = makeHandler();
+    await expect(
+      handler({ messages: [{ role: "tool", content: "x" }] as unknown }),
+    ).rejects.toThrow();
+  });
+
+  it("D3: rejects empty messages array (min 1)", async () => {
+    const { handler } = makeHandler();
+    await expect(handler({ messages: [] })).rejects.toThrow();
+  });
+});
+
+// =========================================================================
+// B: System extraction
+// =========================================================================
+
+describe("anthropic messages — system extraction from leading messages", () => {
+  it("P1: leading single system message → top-level system", async () => {
+    let body: { system?: string; messages?: unknown[] } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "system", content: "be terse" },
+        { role: "user", content: "hi" },
+      ],
+    });
+    expect(body?.system).toBe("be terse");
+    expect(body?.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("P2: multiple leading system messages joined with \\n\\n", async () => {
+    let body: { system?: string } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "system", content: "A" },
+        { role: "system", content: "B" },
+        { role: "user", content: "hi" },
+      ],
+    });
+    expect(body?.system).toBe("A\n\nB");
+  });
+
+  it("P3: no system messages → request body omits system", async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    expect(body).toBeDefined();
+    expect("system" in (body ?? {})).toBe(false);
+  });
+
+  it("D1: non-leading system message → isError with code bad_request", async () => {
+    const { handler } = makeHandler();
+    const result = await handler({
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "system", content: "interleaved" },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("bad_request");
+    expect(result.content[0]?.text).toMatch(/interleaved/i);
+  });
+});
+
+// =========================================================================
+// C: max_tokens default
+// =========================================================================
+
+describe("anthropic messages — max_tokens default", () => {
+  it("P1: config.max_tokens unset → 1024 applied on upstream call", async () => {
+    let body: { max_tokens?: number } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.max_tokens).toBe(1024);
+  });
+
+  it("P2: config.max_tokens explicit → upstream sees the explicit value", async () => {
+    let body: { max_tokens?: number } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ max_tokens: 2048 });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.max_tokens).toBe(2048);
+  });
+});
+
+// =========================================================================
+// D: Stop translation
+// =========================================================================
+
+describe("anthropic messages — stop → stop_sequences translation", () => {
+  it("P1: config.stop string → stop_sequences: [string]", async () => {
+    let body: { stop_sequences?: unknown } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ stop: "END" });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.stop_sequences).toEqual(["END"]);
+  });
+
+  it("P2: config.stop array → stop_sequences mirrors the array", async () => {
+    let body: { stop_sequences?: unknown } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ stop: ["A", "B"] });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.stop_sequences).toEqual(["A", "B"]);
+  });
+
+  it("N1: config.stop undefined → stop_sequences omitted", async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    expect("stop_sequences" in (body ?? {})).toBe(false);
+  });
+});
+
+// =========================================================================
+// E: Stream accumulation
+// =========================================================================
+
+describe("anthropic messages — stream accumulation", () => {
+  it("P1: multi-chunk text_delta concatenated into accumulated text", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          {
+            event: "message_start",
+            data: { type: "message_start", message: { usage: { input_tokens: 4 } } },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "Hello" },
+            },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: " " },
+            },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "world" },
+            },
+          },
+          {
+            event: "message_delta",
+            data: {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn" },
+              usage: { output_tokens: 2 },
+            },
+          },
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("Hello world");
+    expect(result.structuredContent.model).toBe(VALID_MODEL);
+    assertNoSecretLeak(result);
+  });
+
+  it("N1: thinking_delta events are ignored in accumulated text", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          {
+            event: "message_start",
+            data: { type: "message_start", message: { usage: { input_tokens: 1 } } },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "thinking_delta", thinking: "scratchpad" },
+            },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "visible" },
+            },
+          },
+          {
+            event: "message_delta",
+            data: {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn" },
+              usage: { output_tokens: 1 },
+            },
+          },
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.content[0]?.text).toBe("visible");
+  });
+
+  it("N2: input_json_delta events are ignored in accumulated text", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          {
+            event: "message_start",
+            data: { type: "message_start", message: { usage: { input_tokens: 1 } } },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "input_json_delta", partial_json: '{"x":1}' },
+            },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "ok" },
+            },
+          },
+          {
+            event: "message_delta",
+            data: {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn" },
+              usage: { output_tokens: 1 },
+            },
+          },
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.content[0]?.text).toBe("ok");
+  });
+});
+
+// =========================================================================
+// F: Usage capture
+// =========================================================================
+
+describe("anthropic messages — usage capture", () => {
+  it("P1: combines input_tokens (message_start) + output_tokens (message_delta)", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          {
+            event: "message_start",
+            data: { type: "message_start", message: { usage: { input_tokens: 7 } } },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "x" },
+            },
+          },
+          {
+            event: "message_delta",
+            data: {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn" },
+              usage: { output_tokens: 5 },
+            },
+          },
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.usage).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 5,
+      total_tokens: 12,
+    });
+  });
+
+  it("P2: total_tokens = prompt + completion when both present", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          {
+            event: "message_start",
+            data: { type: "message_start", message: { usage: { input_tokens: 10 } } },
+          },
+          {
+            event: "content_block_delta",
+            data: {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "x" },
+            },
+          },
+          {
+            event: "message_delta",
+            data: {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn" },
+              usage: { output_tokens: 20 },
+            },
+          },
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.usage?.total_tokens).toBe(30);
+  });
+});
+
+// =========================================================================
+// G: finish_reason mapping
+// =========================================================================
+
+describe("anthropic messages — stop_reason → finish_reason mapping", () => {
+  function streamWithStopReason(reason: string): Array<{ event: string; data: unknown }> {
+    return [
+      {
+        event: "message_start",
+        data: { type: "message_start", message: { usage: { input_tokens: 1 } } },
+      },
+      {
+        event: "content_block_delta",
+        data: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "x" } },
+      },
+      {
+        event: "message_delta",
+        data: {
+          type: "message_delta",
+          delta: { stop_reason: reason },
+          usage: { output_tokens: 1 },
+        },
+      },
+    ];
+  }
+
+  it("P1: end_turn → stop", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(streamWithStopReason("end_turn"))));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("stop");
+  });
+
+  it("P2: max_tokens → length", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(streamWithStopReason("max_tokens"))));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("length");
+  });
+
+  it("P3: stop_sequence → stop", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(streamWithStopReason("stop_sequence"))));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("stop");
+  });
+
+  it("P4: tool_use → tool_calls", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(streamWithStopReason("tool_use"))));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("tool_calls");
+  });
+
+  it("P5: refusal handled as isError content_policy", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(streamWithStopReason("refusal"))));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("content_policy");
+    expect(result.structuredContent.finish_reason).toBe("content_filter");
+  });
+});
+
+// =========================================================================
+// H: Error Mapping
+// =========================================================================
+
+describe("anthropic messages — error mapping", () => {
+  it("D1: 401 → code 'auth'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "bad key" } }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("auth");
+    assertNoSecretLeak(result);
+  });
+
+  it("D2: 429 with retry-after header → 'rate_limited' + retryAfter", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: {} }), {
+            status: 429,
+            headers: { "retry-after": "12", "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("rate_limited");
+    expect(result.structuredContent.retryAfter).toBe(12);
+  });
+
+  it("D3: 400 invalid_request_error with 'context' in message → context_length", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: "error",
+              error: { type: "invalid_request_error", message: "context too long for model" },
+            }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("context_length");
+  });
+
+  it("D4: 500 → upstream_error", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: {} }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("D5: 529 overloaded_error → upstream_error", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ type: "error", error: { type: "overloaded_error" } }), {
+            status: 529,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("D6: network error → upstream_error", async () => {
+    server.use(http.post(ENDPOINT, () => HttpResponse.error()));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+});
+
+// =========================================================================
+// I: Cancellation
+// =========================================================================
+
+describe("anthropic messages — cancellation", () => {
+  it("D1: abort mid-stream → isError upstream_error, no thrown error", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                const enc = new TextEncoder();
+                controller.enqueue(
+                  enc.encode(
+                    `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { usage: { input_tokens: 1 } } })}\n\n`,
+                  ),
+                );
+                controller.enqueue(
+                  enc.encode(
+                    `event: content_block_delta\ndata: ${JSON.stringify({
+                      type: "content_block_delta",
+                      index: 0,
+                      delta: { type: "text_delta", text: "partial" },
+                    })}\n\n`,
+                  ),
+                );
+                // intentionally never closes
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      ),
+    );
+    const { handler } = makeHandler();
+    const ac = new AbortController();
+    const promise = handler({ messages: VALID_MESSAGES }, { signal: ac.signal });
+    await Promise.resolve();
+    ac.abort();
+    const result = await promise;
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+});
+
+// =========================================================================
+// J: Multi-registration
+// =========================================================================
+
+describe("anthropic messages — multi-registration closure isolation", () => {
+  it("P1: two handlers with different names + apiKeys route to distinct upstreams", async () => {
+    let authA: string | null = null;
+    let authB: string | null = null;
+    server.use(
+      http.post("https://a.example.com/v1/messages", ({ request }) => {
+        authA = request.headers.get("x-api-key");
+        return sseResponse(defaultOkStream("from-a"));
+      }),
+      http.post("https://b.example.com/v1/messages", ({ request }) => {
+        authB = request.headers.get("x-api-key");
+        return sseResponse(defaultOkStream("from-b"));
+      }),
+    );
+    const a = makeAnthropicMessagesHandler({
+      name: "messages-a",
+      apiKey: "key-a",
+      baseURL: "https://a.example.com",
+      model: VALID_MODEL,
+    });
+    const b = makeAnthropicMessagesHandler({
+      name: "messages-b",
+      apiKey: "key-b",
+      baseURL: "https://b.example.com",
+      model: VALID_MODEL,
+    });
+    const ra = await a.handler({ messages: VALID_MESSAGES });
+    const rb = await b.handler({ messages: VALID_MESSAGES });
+    expect(ra.content[0]?.text).toBe("from-a");
+    expect(rb.content[0]?.text).toBe("from-b");
+    expect(authA).toBe("key-a");
+    expect(authB).toBe("key-b");
+  });
+});
+
+// =========================================================================
+// K: Bundle surface
+// =========================================================================
+
+describe("anthropic messages — handler bundle surface", () => {
+  it("P1: bundle exposes name, description, schema, handler", () => {
+    const bundle = makeHandler();
+    expect(bundle.name).toBe("messages");
+    expect(typeof bundle.description).toBe("string");
+    expect(bundle.description).toContain("model: ");
+    expect(bundle.description).toContain("max_tokens: 1024");
+    expect(typeof bundle.handler).toBe("function");
+  });
+
+  it("P2: explicit name overrides default", () => {
+    const bundle = makeHandler({ name: "claude_messages" });
+    expect(bundle.name).toBe("claude_messages");
+  });
+
+  it("D1: throws when config.model is missing", () => {
+    // @ts-expect-error intentional missing required field
+    expect(() => makeAnthropicMessagesHandler({ apiKey: TEST_API_KEY })).toThrow(/model/i);
+  });
+});

--- a/packages/ai-relay/tests/unit/config.test.ts
+++ b/packages/ai-relay/tests/unit/config.test.ts
@@ -316,6 +316,63 @@ describe("loadConfig — error paths", () => {
   });
 });
 
+describe("loadConfig — anthropic provider", () => {
+  it("P1: args provider=anthropic resolves to capability=messages with default id", () => {
+    const cfg = loadConfig({
+      args: {
+        provider: "anthropic",
+        apiKey: "k",
+        model: "claude-sonnet-4-5",
+        max_tokens: 1024,
+      },
+    });
+    const p = cfg.providers[0];
+    if (!p) throw new Error("provider missing");
+    expect(p.provider).toBe("anthropic");
+    expect(p.capability).toBe("messages");
+    expect(p.model).toBe("claude-sonnet-4-5");
+    expect(p.max_tokens).toBe(1024);
+    expect(p.id).toBe("anthropic_messages");
+  });
+
+  it("P2: env-resolved AI_RELAY_TEMPERATURE=0.5 accepted for anthropic", () => {
+    const cfg = loadConfig({
+      env: {
+        AI_RELAY_API_KEY: "k",
+        AI_RELAY_MODEL: "claude-sonnet-4-5",
+        AI_RELAY_TEMPERATURE: "0.5",
+      },
+      args: { provider: "anthropic" },
+    });
+    expect(cfg.providers[0]?.temperature).toBe(0.5);
+  });
+
+  it("D1: AI_RELAY_TEMPERATURE=1.5 rejected for anthropic (range 0..1)", () => {
+    const err = expectThrow(() =>
+      loadConfig({
+        env: {
+          AI_RELAY_API_KEY: "k",
+          AI_RELAY_MODEL: "claude-sonnet-4-5",
+          AI_RELAY_TEMPERATURE: "1.5",
+        },
+        args: { provider: "anthropic" },
+      }),
+    );
+    expect(err.message).toContain("range");
+  });
+
+  it("N1: AI_RELAY_TEMPERATURE=1.5 accepted for openai (range 0..2 — regression check)", () => {
+    const cfg = loadConfig({
+      env: {
+        AI_RELAY_API_KEY: "k",
+        AI_RELAY_MODEL: "gpt-4o-mini",
+        AI_RELAY_TEMPERATURE: "1.5",
+      },
+    });
+    expect(cfg.providers[0]?.temperature).toBe(1.5);
+  });
+});
+
 describe("loadConfig — secret redaction", () => {
   it("D1: apiKey value never appears in error message", () => {
     const sentinel = "leak-marker-apikey-1234567890";

--- a/packages/ai-relay/tests/unit/multi-registration.test.ts
+++ b/packages/ai-relay/tests/unit/multi-registration.test.ts
@@ -10,6 +10,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { registerAnthropicMessages } from "../../src/anthropic/messages.js";
 import { makeOpenAIChatHandler, registerOpenAIChat } from "../../src/openai/chat.js";
 
 const mswServer = setupServer();
@@ -63,6 +64,25 @@ describe("registerOpenAIChat — multi-registration on one McpServer", () => {
         apiKey: "key-local",
         baseURL: "http://localhost:11434/v1",
         model: "llama3",
+      });
+    }).not.toThrow();
+  });
+
+  it("P2: registers OpenAI Chat + Anthropic Messages on the same server (cross-provider type contract)", () => {
+    // NOTE: This is a unit-level type-system check. Per D8 (doc/ARCHITECTURE.md
+    // §1), deployed processes MUST run a single provider at a time — this
+    // test does NOT condone multi-provider production deployments.
+    const server = new McpServer({ name: "cross-provider-test", version: "0.0.1" });
+    expect(() => {
+      registerOpenAIChat(server, {
+        name: "chat-completions",
+        apiKey: "key-openai",
+        model: VALID_MODEL,
+      });
+      registerAnthropicMessages(server, {
+        name: "messages",
+        apiKey: "key-anthropic",
+        model: "claude-sonnet-4-5",
       });
     }).not.toThrow();
   });

--- a/packages/ai-relay/tests/unit/run.test.ts
+++ b/packages/ai-relay/tests/unit/run.test.ts
@@ -119,6 +119,21 @@ describe("run — usage errors short-circuit", () => {
     expect(cap.stderr.value).toContain("unknown tool for provider openai: messages");
   });
 
+  it("D2c: anthropic + chat-completions cross-product → exit 2", async () => {
+    const cap = makeIO();
+    const code = await run(["anthropic", "chat-completions", "hi"], cap.io);
+    expect(code).toBe(2);
+    expect(cap.stderr.value).toContain("unknown tool for provider anthropic: chat-completions");
+  });
+
+  it("P5: anthropic provider resolves via lazy loader and is listed under known providers", async () => {
+    const cap = makeIO();
+    const code = await run(["anthropic", "unknown-tool", "hi"], cap.io);
+    expect(code).toBe(2);
+    expect(cap.stderr.value).toContain("unknown tool for provider anthropic");
+    expect(cap.stderr.value).toContain("messages");
+  });
+
   it("D3: -h prints usage on stdout, exit 0", async () => {
     const cap = makeIO();
     const code = await run(["-h"], cap.io);

--- a/packages/ai-relay/tests/unit/run.test.ts
+++ b/packages/ai-relay/tests/unit/run.test.ts
@@ -638,7 +638,7 @@ describe("run — verbose stderr", () => {
     expect(cap.stderr.value).toContain('"role"');
   });
 
-  it("D4: upstream error path emits openai-error stage", async () => {
+  it("D4: upstream error path emits tool-error stage with provider field", async () => {
     server.use(
       http.post(ENDPOINT, () =>
         HttpResponse.json({ error: { message: "no auth" } }, { status: 401 }),
@@ -647,7 +647,27 @@ describe("run — verbose stderr", () => {
     const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
     const code = await run(["openai", "chat-completions", "-v", "-m", "gpt-4o-mini", "hi"], cap.io);
     expect(code).toBe(1);
-    expect(cap.stderr.value).toContain("] openai-error:");
+    expect(cap.stderr.value).toContain("] tool-error:");
+    expect(cap.stderr.value).toContain('"provider": "openai"');
+  });
+
+  it("D4b: anthropic upstream error emits tool-error stage with provider=anthropic", async () => {
+    server.use(
+      http.post("https://api.anthropic.com/v1/messages", () =>
+        HttpResponse.json(
+          { error: { type: "authentication_error", message: "no auth" } },
+          { status: 401 },
+        ),
+      ),
+    );
+    const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
+    const code = await run(
+      ["anthropic", "messages", "-v", "-m", "claude-sonnet-4-5", "hi"],
+      cap.io,
+    );
+    expect(code).toBe(1);
+    expect(cap.stderr.value).toContain("] tool-error:");
+    expect(cap.stderr.value).toContain('"provider": "anthropic"');
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,10 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.96.0
+        version: 0.96.0(zod@4.4.3)
 
 packages:
 
@@ -158,6 +162,15 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
+
+  '@anthropic-ai/sdk@0.96.0':
+    resolution: {integrity: sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/runtime-corejs3@7.29.2':
     resolution: {integrity: sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==}
@@ -1111,6 +1124,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
@@ -1407,6 +1423,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -1518,6 +1537,10 @@ packages:
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1814,6 +1837,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -1881,6 +1907,9 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2094,6 +2123,13 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@anthropic-ai/sdk@0.96.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@babel/runtime-corejs3@7.29.2':
     dependencies:
@@ -2714,6 +2750,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@types/diff-match-patch@1.0.36': {}
 
   '@types/estree@1.0.8': {}
@@ -3085,6 +3123,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -3189,6 +3229,11 @@ snapshots:
   jose@6.2.3: {}
 
   js-base64@3.7.8: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -3535,6 +3580,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -3583,6 +3633,8 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
+
+  ts-algebra@2.0.0: {}
 
   tslib@2.8.1:
     optional: true

--- a/tests/runtime-fixtures/README.md
+++ b/tests/runtime-fixtures/README.md
@@ -14,6 +14,22 @@ script.
 | `typecheck-bundler/` | Publish-contract test (`packages/ai-relay/tests/integration/pack-contract.test.ts`) | `ai-relay` types resolve under `moduleResolution: "bundler"` for every documented subpath. |
 | `typecheck-nodenext/` | Publish-contract test | `ai-relay` types resolve under `moduleResolution: "nodenext"` for every documented subpath. |
 
+## Provider SDK dependencies
+
+`smoke-node/` and `smoke-bun/` simulate an **OpenAI consumer**: they declare
+`openai` in their `package.json` `dependencies` so `npm install <tarball>`
+pulls in the SDK alongside `ai-relay` exactly as a real OpenAI consumer
+would. Without this, the optional `peerDependenciesMeta.openai` entry in
+`ai-relay/package.json` leaves the consumer with `ai-relay/dist/openai/chat.js`
+unable to resolve `openai` → `ERR_MODULE_NOT_FOUND`.
+
+When adding a new provider fixture (e.g., `smoke-node-anthropic/`), declare
+the corresponding peer SDK explicitly in its `package.json` so the fixture
+maps to a single consumer shape.
+
+`cjs-require/` only `require()`s the root `ai-relay` entry (not the
+provider subpaths) so it does not need any provider SDK declared.
+
 ## smoke duplication
 
 `smoke-node/smoke.mjs` and `smoke-bun/smoke.mjs` are byte-for-byte

--- a/tests/runtime-fixtures/smoke-bun/package.json
+++ b/tests/runtime-fixtures/smoke-bun/package.json
@@ -2,5 +2,8 @@
   "name": "smoke-bun-fixture",
   "private": true,
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "openai": "^6"
+  }
 }

--- a/tests/runtime-fixtures/smoke-node/package.json
+++ b/tests/runtime-fixtures/smoke-node/package.json
@@ -2,5 +2,8 @@
   "name": "smoke-node-fixture",
   "private": true,
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "openai": "^6"
+  }
 }

--- a/tests/runtime-fixtures/typecheck-bundler/index.ts
+++ b/tests/runtime-fixtures/typecheck-bundler/index.ts
@@ -4,6 +4,8 @@
 // runs `tsc --noEmit`. Exit 0 = subpath types resolve under bundler mode.
 
 import { verifyBearer } from "ai-relay";
+import type { AnthropicMessagesConfig, AnthropicMessagesResult } from "ai-relay/anthropic";
+import { makeAnthropicMessagesHandler, registerAnthropicMessages } from "ai-relay/anthropic";
 import { verifyBearer as verifyBearerSub } from "ai-relay/auth";
 import { loadConfig } from "ai-relay/env";
 import type { OpenAIChatConfig, OpenAIChatResult, ToolDescriptor } from "ai-relay/openai";
@@ -15,6 +17,10 @@ const _cfg: OpenAIChatConfig = { apiKey: "k", model: "gpt-4o-mini" };
 const _handler = makeOpenAIChatHandler(_cfg);
 const _register: typeof registerOpenAIChat = registerOpenAIChat;
 
+const _acfg: AnthropicMessagesConfig = { apiKey: "k", model: "claude-sonnet-4-5" };
+const _ahandler = makeAnthropicMessagesHandler(_acfg);
+const _aregister: typeof registerAnthropicMessages = registerAnthropicMessages;
+
 const _loaded = loadConfig({ env: { AI_RELAY_API_KEY: "x" } });
 const _providers = _loaded.providers.length;
 
@@ -22,6 +28,7 @@ const _providers = _loaded.providers.length;
 // strictness even though this isn't actually verbatim. The cast keeps the
 // types referenced so the typecheck has work to do.
 const _result: OpenAIChatResult | undefined = undefined;
+const _aresult: AnthropicMessagesResult | undefined = undefined;
 const _tool: ToolDescriptor | undefined = undefined;
 
-export { _handler, _ok, _providers, _register, _result, _tool };
+export { _ahandler, _aregister, _aresult, _handler, _ok, _providers, _register, _result, _tool };

--- a/tests/runtime-fixtures/typecheck-nodenext/index.ts
+++ b/tests/runtime-fixtures/typecheck-nodenext/index.ts
@@ -2,6 +2,8 @@
 // `moduleResolution: "nodenext"`. Used by the publish-contract test.
 
 import { verifyBearer } from "ai-relay";
+import type { AnthropicMessagesConfig, AnthropicMessagesResult } from "ai-relay/anthropic";
+import { makeAnthropicMessagesHandler, registerAnthropicMessages } from "ai-relay/anthropic";
 import { verifyBearer as verifyBearerSub } from "ai-relay/auth";
 import { loadConfig } from "ai-relay/env";
 import type { OpenAIChatConfig, OpenAIChatResult, ToolDescriptor } from "ai-relay/openai";
@@ -13,10 +15,15 @@ const _cfg: OpenAIChatConfig = { apiKey: "k", model: "gpt-4o-mini" };
 const _handler = makeOpenAIChatHandler(_cfg);
 const _register: typeof registerOpenAIChat = registerOpenAIChat;
 
+const _acfg: AnthropicMessagesConfig = { apiKey: "k", model: "claude-sonnet-4-5" };
+const _ahandler = makeAnthropicMessagesHandler(_acfg);
+const _aregister: typeof registerAnthropicMessages = registerAnthropicMessages;
+
 const _loaded = loadConfig({ env: { AI_RELAY_API_KEY: "x" } });
 const _providers = _loaded.providers.length;
 
 const _result: OpenAIChatResult | undefined = undefined;
+const _aresult: AnthropicMessagesResult | undefined = undefined;
 const _tool: ToolDescriptor | undefined = undefined;
 
-export { _handler, _ok, _providers, _register, _result, _tool };
+export { _ahandler, _aregister, _aresult, _handler, _ok, _providers, _register, _result, _tool };


### PR DESCRIPTION
Closes #91.

## Summary

Adds **Anthropic Messages API** as the second provider under `ai-relay`. After this PR ships, an operator gains `ai-relay anthropic` (MCP stdio), `ai-relay-cli anthropic messages "..."` (one-shot CLI), and `import { registerAnthropicMessages } from "ai-relay/anthropic"` (SDK embed). The caller-facing input schema is identical to OpenAI Chat (per ADR D10); the Anthropic SDK module performs syntactic translation internally — extracting leading `role: 'system'` messages to Anthropic's top-level `system` param, translating `stop` to `stop_sequences`, applying a default `max_tokens` of 1024.

This PR also validates the multi-provider machinery that #92 (OpenAI Responses) and #93 (Google Gemini) will inherit:

- **Provider-aware config** (`config.ts`) — discriminated union; `envPartialByProvider` map dispatches `AI_RELAY_*` key interpretation per the invocation-derived provider, per ADR D8.
- **Lazy-loading bin registry** (`bin/registry.ts`) — dynamic `import()` per provider; consumers installing only one SDK don't pay a static-import cost on the other.
- **`peerDependenciesMeta`** — both `openai` and `@anthropic-ai/sdk` are now **optional** peers. Existing OpenAI consumers see no install-time change; new Anthropic-only consumers can skip `openai`.

Version bump: `0.10.0` → `0.11.0` (minor, additive — no breaking change for OpenAI consumers).

## Changes

| File | Change |
|---|---|
| `packages/ai-relay/src/anthropic/{client,messages,index}.ts` | **NEW** — Anthropic provider module (~770 LOC) |
| `packages/ai-relay/src/config.ts` | `Provider`/`Capability` widened; `providerConfigSchema` → discriminated union; `envPartialByProvider` map |
| `packages/ai-relay/src/bin/registry.ts` | Static imports → lazy dynamic-import loader; async `resolveProvider`/`resolveProviderTool` |
| `packages/ai-relay/src/bin/{run,ai-relay,mcp-server}.ts` | Adapt to async resolve; fix hardcoded `provider: "openai"` bug in `run.ts:182`; `buildToolConfig` helper |
| `packages/ai-relay/package.json` | `+./anthropic` exports; `+@anthropic-ai/sdk@^0.96` peer; `+peerDependenciesMeta` (both optional); version `0.11.0` |
| `packages/ai-relay/tests/unit/anthropic-messages.test.ts` | **NEW** — 34 cases covering the 31-behavior inventory from plan §6 |
| `packages/ai-relay/tests/unit/{config,multi-registration,run,ai-relay}.test.ts` | +7 cases for provider-aware paths + cross-product validations |
| `packages/ai-relay/tests/integration/{bin-tarball,pack-contract}.test.ts` | Install both peer SDKs; `ai-relay/anthropic` subpath import test |
| `README.md` / `README.ko.md` / `packages/ai-relay/README.md` | Anthropic quick-start sections + Providers table |
| `doc/ARCHITECTURE.md` | §4 `messages` tool block; §6 stack row; §7 per-provider env semantics; new `stop_reason → finish_reason` mapping table |
| `packages/ai-relay/CHANGELOG.md` | `0.11.0` entry |
| `.env.example` | Anthropic env block + per-provider notes |

## Test plan

- [x] `pnpm typecheck` — clean (discriminated union types narrow correctly)
- [x] `pnpm test` — **368 passed / 1 skipped** (327 baseline + **41 new** = 368)
- [x] `pnpm lint` — clean (Biome 64 files, 0 fixes)
- [x] `pnpm build` — `dist/anthropic/{client,messages,index}.js` + `.d.ts` produced
- [x] OpenAI baseline preserved — existing OpenAI tests pass without modification
- [x] Negative-touch — `app/` HTTP server NOT modified (HTTP Anthropic support is a separate follow-up per plan OQ-2)
- [ ] Manual MCP Inspector smoke against a real Anthropic API key — deferred to maintainer pre-merge (no real key in this build environment; logged at `$STATE_DIR/manual-mcp-inspector-anthropic.log` as SKIPPED)
- [ ] Korean mirror parity: `doc/ARCHITECTURE.ko.md`, `doc/DEPLOY.md`, `doc/DEPLOY.ko.md` not updated by the BUILD stage despite the plan listing them. Recoverable as a follow-up commit on this branch if reviewer flags MEDIUM. Other docs (README + README.ko + packages/ai-relay/README + ARCHITECTURE.md EN + CHANGELOG + .env.example) all landed.

## v1 non-goal self-check

Per plan §1b G:

- [x] Multi-provider on a single process forbidden (D8 — enforced by `loadConfig` returning single-provider arrays)
- [x] Extended thinking / reasoning content blocks ignored (`thinking_delta` events dropped silently)
- [x] Tool-use pass-through not implemented (only `finish_reason: "tool_calls"` surfaced; tool call payload not serialized)
- [x] Vision / image input not supported (`messages[].content` is `string` only)
- [x] No `--top-k` CLI flag (Anthropic-specific; deferred per OQ-4)
- [x] HTTP server (`app/`) NOT touched (per OQ-2 — follow-up issue)
- [x] Vertex AI auth path not added (Direct Anthropic API only)

## Forward links

After merge:
- #92 (OpenAI Responses API) can start — inherits lazy-loader pattern; registers `responses` tool under the existing `openai` registry entry
- #93 (Google Gemini provider) can start — adds `google` entry to the lazy loader; same translation pattern from OpenAI-shape input to Gemini `contents`/`parts`

🤖 Implemented via `/dev 91` pipeline.

## Evidence

<details>
<summary>BUILD stage — diff + verify outputs</summary>

**4 commits** on the branch:
- `f248bfb` refactor(sdk): provider-aware foundation
- `6b650ba` feat(sdk): Anthropic Messages module + package.json (0.11.0)
- `f576458` test(sdk): cover Anthropic Messages (+ 34 new cases)
- `8e0d989` docs: document Anthropic Messages

**Plus REVIEW fixups** (per reviewer MEDIUM-1/MEDIUM-2):
- `68d8fc3` fix(bin): rename `openai-error` verbose log key → `tool-error` (+1 test case)
- `d2a6177` docs: Korean mirrors + DEPLOY Anthropic env example

**Verify**:
- `pnpm typecheck` — clean
- `pnpm lint` — clean (Biome 64 files, 0 fixes)
- `pnpm test` — **369 passed / 1 skipped** (327 baseline + 41 anthropic + 1 tool-error rename = 369)
- `pnpm build` — `dist/anthropic/` produced; subpath imports resolve under bundler + nodenext

</details>

<details>
<summary>REVIEW stage — verdict and findings</summary>

**Verdict**: **APPROVED** — 0 CRITICAL / 0 HIGH / 5 MEDIUM / 3 LOW / 2 INFO

Two of the MEDIUM findings were addressed in-PR (commits `68d8fc3` + `d2a6177`); the rest are non-blocking observations.

Notable strengths flagged by the reviewer:
- Clean factory/closure isolation pattern with no module-level state (verified by A18 multi-registration test)
- ADR D8 / D9 / D10 all compliant
- Correct `stop_reason` → `finish_reason` table (5 entries match plan)
- Refusal correctly surfaced as `isError: true` + `code: "content_policy"`
- `maxRetries: 0` on streaming call
- `x-api-key` AND `Authorization` redacted in `captureFetch`
- All 31 plan §6 behaviors mapped to at least one test
- No `as any` / `eslint-disable` / `@ts-ignore` added

</details>

<details>
<summary>VERIFY stage — TIA report</summary>

**TIA scope**: 9 affected specs identified via import-graph analysis
**TIA result**: PASS — **200 / 200 tests in 9.36s**

| Spec | Cases | Purpose |
|---|---|---|
| `anthropic-messages.test.ts` | 34 | New module exhaustive |
| `config.test.ts` | various | Discriminated union + envPartialByProvider |
| `run.test.ts` | various | CLI orchestrator (incl. tool-error rename) |
| `ai-relay.test.ts` | various | Stdio launcher |
| `multi-registration.test.ts` | various | Cross-provider isolation |
| `chat.test.ts` | 48 | OpenAI regression-check (R7) |
| `exports.test.ts` | various | Public API surface |
| `bin-tarball.test.ts` | integration | Published tarball install + run |
| `pack-contract.test.ts` | integration | Subpath imports under bundler + nodenext |

**Plan §6 coverage**: 29 of 31 behaviors fully asserted. X1 (green-path CLI against installed tarball) and X2 (green-path stdio tools/list) flagged as informational partials — exercised at unit level but not as end-to-end happy paths; recommended for a small follow-up, NOT blocking.

**Regression**: R7 (chat.test.ts) PASS — refactored config + registry preserves OpenAI semantics.

**evidence-mode**: none per project CLAUDE.md §3 (no UI, no browser, no `tia-*.png`).

</details>

<details>
<summary>Manual MCP Inspector verification</summary>

**Status**: deferred to maintainer pre-merge. The dev build environment has no real Anthropic API key, so the smoke test against a live upstream cannot run here. Recorded at `$STATE_DIR/manual-mcp-inspector-anthropic.log` as SKIPPED with the procedure for the maintainer to follow:

1. Set `AI_RELAY_API_KEY=<real Anthropic key>`, `AI_RELAY_MODEL=claude-sonnet-4-6`, `AI_RELAY_MAX_TOKENS=512`
2. `pnpm --filter ai-relay build && node packages/ai-relay/dist/bin/ai-relay.js anthropic` (stdio)
3. Connect MCP Inspector via stdio
4. `tools/list` → confirm `messages`
5. `tools/call messages { messages: [{ role: "user", content: "Say exactly: pong" }] }` → confirm `pong` (or close) returned with `structuredContent.usage.total_tokens > 0`

</details>
