### PR TITLE
fix(docs): remove -s/--system flag, sync all docs to implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ working in this repository. **It overrides the global rules at `~/.claude/CLAUDE
 
 ## 1. One-line summary
 
-A relay server that exposes OpenAI Chat Completions as an MCP (Model Context Protocol) tool —
-shipped as a Hono HTTP server packaged as a multi-arch Docker image
-(`ghcr.io/ragingwind/ai-relay`), Bearer authentication, single tool `chat-completions` in v1.
+A relay server that exposes upstream LLM APIs (OpenAI `chat-completions`, Anthropic `messages`)
+as MCP (Model Context Protocol) tools — shipped as a Hono HTTP server packaged as a multi-arch
+Docker image (`ghcr.io/ragingwind/ai-relay`), Bearer authentication.
 
 Full architecture: [`doc/ARCHITECTURE.md`](./doc/ARCHITECTURE.md)
 
@@ -42,7 +42,7 @@ build:    pnpm build         # pnpm -r build (SDK + app)
 typecheck: pnpm typecheck    # tsc --noEmit across SDK + app
 lint:     pnpm lint          # biome check .
 test:     pnpm test          # vitest run
-test:unit: pnpm test:unit    # vitest run packages/ai-relay/tests/unit
+test:unit: pnpm test:unit    # pnpm --filter ai-relay test (unit + integration + cli tests inside packages/ai-relay/)
 test:integration: pnpm test:integration  # vitest run --project integration
 test:runtime: pnpm test:runtime  # pack tarball + run smoke fixtures (Node/Bun/CJS). Catches "consumer install without peer SDK" failures that vitest workspace-resolution masks.
 dev:      pnpm dev           # Hono dev server (port 8787)
@@ -68,7 +68,7 @@ The following items extend or override the global `core.md`.
 - **Never log OpenAI/MCP response bodies via `console`/logs/error messages at default/info levels** — only metadata (model, token counts, latency, status) is allowed at default output.
 - **Exception — `--verbose` debug stream**: when explicitly enabled via `--verbose` flag or `AI_RELAY_VERBOSE=1`, the stderr trace MAY emit full request/response bodies (assistant text, tool arguments, OpenAI HTTP body). Secrets — API keys, bearer tokens, env values matching `*_KEY` / `*_TOKEN`, and the `Authorization` header value — MUST still be redacted via `redactSecret()`. Operators MUST treat the verbose stderr stream as sensitive: never persist it to shared logging infrastructure, never include it in PR comments or issue evidence, never check it into git.
 - Never expose `AI_RELAY_API_KEY` or `AI_RELAY_AUTH_TOKEN` in plain text in code/tests/docs/commits.
-- Never use `===` to compare bearer tokens — always use `timingSafeEqual` from `node:crypto`.
+- Never use `===` to compare bearer tokens — use the constant-time XOR-OR loop in `packages/ai-relay/src/auth.ts` (`verifyBearer`). Do not replace it with `node:crypto.timingSafeEqual` — the manual loop is intentional for Workers portability (`nodejs_compat` not required).
 - Never add features outside v1 scope (Responses API, OAuth, rate limiting, external KV, observability — see [`doc/ARCHITECTURE.md` §11](./doc/ARCHITECTURE.md#11-future-work-v2-backlog)).
 - Never bump only one of `mcp-handler`/`@modelcontextprotocol/sdk` — the two packages are ABI-coupled (`^1.1`, `^1.26`); upgrade them as a pair.
 
@@ -155,13 +155,12 @@ Details: [`doc/ARCHITECTURE.md` §7](./doc/ARCHITECTURE.md#7-environment-variabl
 | Case | Location | Notes |
 |---|---|---|
 | Tool input zod validation | `packages/ai-relay/tests/unit/chat.test.ts` | Enumerate schema-violation cases |
-| `max_tokens` clamp | `packages/ai-relay/tests/unit/chat.test.ts` | Caller value > ceiling case + injected ceiling override |
 | OpenAI error mapping (401/429/400/5xx) | `packages/ai-relay/tests/unit/chat.test.ts` | Forge responses with MSW |
 | `verifyBearer` constant-time comparison | `packages/ai-relay/tests/unit/auth.test.ts` | Length mismatch, single-byte change, NFC vs NFD |
-| `parseEnv` validation + redaction | `packages/ai-relay/tests/unit/env.test.ts` | Failing-key path included; sentinel values never echoed |
+| `parseEnv` validation + redaction | `tests/integration/app-env.test.ts` | App-private `parseEnv`; failing-key path included; sentinel values never echoed |
 | **Multi-registration** (same server, multiple upstreams) | `packages/ai-relay/tests/unit/multi-registration.test.ts` | Distinct names, no cross-talk, independent cancellation |
 | Bearer auth (present/missing/invalid) | `tests/integration/route.test.ts` | Verify 401 + `WWW-Authenticate` header |
-| `tools/list` JSON-RPC | `tests/integration/route.test.ts` | Confirm a single tool is exposed |
+| `tools/list` JSON-RPC | `tests/integration/route.test.ts` | Confirm registered tools are exposed |
 | `tools/call` happy path | `tests/integration/route.test.ts` | Mock OpenAI with MSW |
 | Stream accumulation → single result | `tests/integration/route.test.ts` | MSW SSE response |
 | MCP Inspector manual verification | Manual (not in CI) | Once before each PR — `pnpm dev` + `npx @modelcontextprotocol/inspector` |
@@ -191,7 +190,7 @@ Principle: **mock only the OpenAI HTTP boundary** (MSW). Never mock the `openai`
 - ghcr first-push setup: after the initial `release-app` run, the maintainer must (a) confirm Settings → Actions → Workflow permissions = "Read and write", and (b) Settings → Packages → ai-relay → Change visibility to public (default is private).
 - If you do not wrap the `/api/mcp` handler with `withMcpAuth`, authentication is not applied — verify this when modifying `app/src/index.ts`.
 - Register `AI_RELAY_API_KEY` with **distinct OpenAI project keys** for Production and Preview, and set a **hard usage cap** in the OpenAI dashboard for each project (v1's cost defense).
-- After `pnpm dev`, when connecting MCP Inspector you must enter the **Proxy Session Token** from the mcp-handler startup log.
+- After `pnpm dev`, when connecting MCP Inspector you must enter the **Proxy Session Token** printed by the `npx @modelcontextprotocol/inspector` CLI on startup (not from the mcp-handler/server log).
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -90,9 +90,9 @@ npx ai-relay openai chat-completions -m gpt-4o-mini "ping"
 npx ai-relay openai chat-completions -m gpt-4o-mini \
   '{"messages":[{"role":"user","content":"ping"}]}'
 
-# stdin + 시스템 프롬프트 + 샘플링 오버라이드
+# stdin + 샘플링 오버라이드
 echo "explain TLS in 2 sentences" \
-  | npx ai-relay openai chat-completions -m gpt-4o-mini --temperature 0.2 -s "be terse"
+  | npx ai-relay openai chat-completions -m gpt-4o-mini --temperature 0.2
 
 # Azure OpenAI / vLLM / Ollama / AI Gateway 같은 OpenAI 호환 엔드포인트
 npx ai-relay openai chat-completions -m gpt-4o-mini \

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ npx ai-relay openai chat-completions -m gpt-4o-mini "ping"
 npx ai-relay openai chat-completions -m gpt-4o-mini \
   '{"messages":[{"role":"user","content":"ping"}]}'
 
-# Stdin pipe + system prompt + sampling override
+# Stdin pipe + sampling override
 echo "explain TLS in 2 sentences" \
-  | npx ai-relay openai chat-completions -m gpt-4o-mini --temperature 0.2 -s "be terse"
+  | npx ai-relay openai chat-completions -m gpt-4o-mini --temperature 0.2
 
 # Azure OpenAI / vLLM / Ollama / AI Gateway — any OpenAI-compatible endpoint
 npx ai-relay openai chat-completions -m gpt-4o-mini \

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -2,12 +2,12 @@
 
 > 한국어: [ARCHITECTURE.ko.md](./ARCHITECTURE.ko.md)
 
-A relay server that exposes the OpenAI Chat Completions API as an MCP
-(Model Context Protocol) tool. Shipped as a multi-arch Docker image
-(`ghcr.io/ragingwind/ai-relay`, amd64+arm64) built on a minimal Hono HTTP
-server. A community-supported Vercel recipe lives in `examples/vercel/`.
-When an MCP host such as Claude Code calls in, this server calls OpenAI
-and returns the response back to the host.
+A relay server that exposes upstream LLM APIs (OpenAI Chat Completions,
+Anthropic Messages) as MCP (Model Context Protocol) tools. Shipped as a
+multi-arch Docker image (`ghcr.io/ragingwind/ai-relay`, amd64+arm64) built
+on a minimal Hono HTTP server. A community-supported Vercel recipe lives in
+`examples/vercel/`. When an MCP host such as Claude Code calls in, this
+server calls the configured upstream and returns the response back to the host.
 
 This document is the single source of truth (SSOT) for v1 architecture.
 For background research, tradeoffs, and alternatives considered, see the
@@ -62,7 +62,7 @@ sources in the [Reference index](#reference-index).
 1. The MCP host sends `Authorization: Bearer <AI_RELAY_AUTH_TOKEN>` plus a `tools/call` JSON-RPC message via `POST /api/mcp`.
 2. `withMcpAuth` compares the header token to the `AI_RELAY_AUTH_TOKEN` env var in constant time (timing-safe).
 3. `mcp-handler` parses the JSON-RPC and invokes the `chat-completions` tool handler.
-4. The tool handler validates input with zod → applies the server policy `max_tokens` ceiling → calls the `openai` SDK's `chat.completions.create({ stream: true, ... })` (with an `AbortController` attached).
+4. The tool handler validates input with zod → calls the `openai` SDK's `chat.completions.create({ stream: true, ... })` (with an `AbortController` attached).
 5. The upstream stream is accumulated as an async iterator (`for await (const chunk of stream)`).
 6. The accumulated text and `usage` metadata are serialized as a `CallToolResult`:
    ```ts
@@ -124,7 +124,7 @@ The caller-facing surface is intentionally minimal — `model` and all sampling 
   structuredContent: {
     model: string,
     usage: { prompt_tokens: number, completion_tokens: number, total_tokens: number },
-    finish_reason: "stop" | "length" | "tool_calls" | "content_filter" | "function_call"
+    finish_reason: string
   }
 }
 ```
@@ -220,7 +220,10 @@ mcp-ai-relay/                              # repo root — pnpm workspace orches
 │       └── vercel.json                 # ex-root config (pins maxDuration + region)
 ├── .github/workflows/
 │   ├── ci.yml                          # typecheck + lint + build + test on PR
-│   └── release-app.yml                 # multi-arch buildx → ghcr push on `v*` tags
+│   ├── release-app.yml                 # multi-arch buildx → ghcr push on `v*` tags
+│   ├── docker-smoke.yml                # smoke test against built Docker image
+│   ├── examples-smoke.yml              # smoke test examples/ recipes
+│   └── runtime-matrix.yml             # pack tarball + Node/Bun/CJS smoke matrix
 ├── doc/
 │   ├── ARCHITECTURE.md                 # this document — design SSOT
 │   ├── DEPLOY.md                       # Docker + Vercel runbook
@@ -249,7 +252,7 @@ mcp-ai-relay/                              # repo root — pnpm workspace orches
 | Validation | `zod@^4` |
 | OpenAI SDK | `openai@^6` (optional peer dep) |
 | Anthropic SDK | `@anthropic-ai/sdk@^0.96.0` (optional peer dep) |
-| Runtime | Node.js `20.x` (alpine container; multi-arch amd64+arm64) |
+| Runtime | Node.js `20.x` (Distroless Debian 12 `nonroot` container; multi-arch amd64+arm64) |
 | Language | TypeScript strict, NodeNext ESM, `verbatimModuleSyntax: true` |
 | Package manager | pnpm `^9` (pinned via `packageManager`) |
 | Lint/Format | Biome `^2` |
@@ -320,18 +323,16 @@ Record keys only in `.env.example`; never commit values. Register the secrets vi
 ## 8. Authentication (v1)
 
 ```ts
-// lib/auth.ts (concept)
-import { timingSafeEqual } from "node:crypto";
-
-export function verifyToken(req: Request, bearerToken: string | undefined) {
-  if (!bearerToken) return undefined;            // unauthenticated
-  const expected = process.env.AI_RELAY_AUTH_TOKEN;
-  if (!expected) return undefined;                // fail-closed
-  const a = Buffer.from(bearerToken);
+// packages/ai-relay/src/auth.ts (concept)
+export function verifyBearer(token: string, expected: string): boolean {
+  if (token.length !== expected.length) return false;
+  // Manual XOR-OR loop instead of node:crypto.timingSafeEqual for
+  // Workers compatibility (nodejs_compat flag not required).
+  const a = Buffer.from(token);
   const b = Buffer.from(expected);
-  if (a.length !== b.length) return undefined;
-  if (!timingSafeEqual(a, b)) return undefined;
-  return { clientId: "shared-secret", scopes: ["openai:chat"] };
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  return diff === 0;
 }
 ```
 
@@ -345,12 +346,12 @@ On unauthenticated requests, `mcp-handler` automatically responds with 401 + `WW
 ## 9. Security — v1 minimum set
 
 - Never echo `AI_RELAY_API_KEY` in responses, logs, or error messages.
-- Always compare bearer tokens with `timingSafeEqual`.
+- Compare bearer tokens in constant time (XOR-OR accumulator — see `packages/ai-relay/src/auth.ts`). Do not use `===`.
 - All tool inputs must be strictly validated with zod (use `.strict()`).
-- `max_tokens` accepts the caller's value but is clamped to the server ceiling.
+- `max_tokens` is forwarded as-is — no server-side ceiling is applied.
 - `console` logs may include only metadata (model, token counts, latency, status). **Never log prompt/response bodies at default/info levels.**
 - **`--verbose` carve-out**: when explicitly enabled via `--verbose` flag or `AI_RELAY_VERBOSE=1`, the stderr trace MAY emit full request/response bodies (tool arguments, accumulated assistant text, OpenAI HTTP body). Secrets — API keys, bearer tokens, `Authorization` header values, and env vars whose names match `*_KEY`/`*_TOKEN` — remain redacted via `redactSecret()`. The verbose stream is operator-only diagnostic output: never persist it to shared logging, PR comments, or git. See [CLAUDE.md §4](../CLAUDE.md#4-coding-conventions-repo-specific) for the operational policy.
-- Container images run as a non-root `app` user (uid 1001); orchestrators should not override with root.
+- Container images run as the distroless `nonroot` user (uid 65532); orchestrators should not override with root.
 - The published image is private by default — flip to public via Settings → Packages → ai-relay only when ready.
 
 ### Not included in v1 (intentional)
@@ -368,7 +369,7 @@ These items are listed as v2 candidates in §11.
 
 | Layer | Tools | Scope |
 |---|---|---|
-| Unit (SDK) | vitest + msw, run inside `packages/ai-relay/` | `verifyBearer`, `parseEnv`, `registerOpenAIChat` factory — input validation, max_tokens clamp, error mapping |
+| Unit (SDK) | vitest + msw, run inside `packages/ai-relay/` | `verifyBearer`, `registerOpenAIChat` factory, `registerAnthropicMessages` factory — input validation, error mapping |
 | Multi-registration | vitest + msw, real `McpServer` | Same server registered against multiple times with different `name` + `apiKey` + `baseURL` — each handler routes to its own upstream with no cross-talk |
 | Integration | vitest, Hono `app.fetch(request)` invoked directly with Web `Request`/`Response` | Bearer auth (present/missing/invalid), MCP `tools/list` and `tools/call` JSON-RPC flows, `/healthz` liveness, `AI_RELAY_PORT` validation |
 | Manual E2E | MCP Inspector | Locally run `pnpm dev` → `npx @modelcontextprotocol/inspector` → Streamable HTTP, connect to `http://localhost:8787/api/mcp` |
@@ -398,7 +399,7 @@ These policies govern how the SDK expands beyond a single provider. They are loa
 
 `AI_RELAY_*` env keys retain stable names regardless of which provider is in use. Their meaning is **derived from the provider passed at invocation**:
 
-- `ai-relay openai`     → `AI_RELAY_API_KEY` is the OpenAI key, `AI_RELAY_MODEL` is an OpenAI model id (`gpt-5-mini`).
+- `ai-relay openai`     → `AI_RELAY_API_KEY` is the OpenAI key, `AI_RELAY_MODEL` is an OpenAI model id (`gpt-4o-mini`).
 - `ai-relay anthropic`  → same keys, interpreted as Anthropic (`claude-sonnet-4-6`, …).
 - `ai-relay google`     → same keys, interpreted as Gemini (`gemini-2.5-pro`).
 

--- a/doc/QA-MCP-INSPECTOR.md
+++ b/doc/QA-MCP-INSPECTOR.md
@@ -47,11 +47,11 @@ C5** — the three scenarios assertable from a client. Prints an evidence-record
 block ready to paste into the PR. Costs ~$0.0001 per run (one `gpt-4o-mini`
 call).
 
-Inputs (env-only — `verify.mjs` does not parse flags):
+Inputs (env or flag — flag wins):
 
-| env | default | purpose |
-|---|---|---|
-| `MCP_URL`      | `http://localhost:8787/api/mcp` | endpoint (matches Hono `AI_RELAY_PORT` default) |
+| env | flag | default | purpose |
+|---|---|---|---|
+| `MCP_URL` | `--url=<url>` | `http://localhost:8787/api/mcp` | endpoint (matches Hono `AI_RELAY_PORT` default) |
 
 The model used for the C2 happy-path call is whatever `AI_RELAY_MODEL` is set
 to on the running server (the caller schema is `{ messages }` only).
@@ -114,9 +114,9 @@ AI_RELAY_VERBOSE=1 npx @modelcontextprotocol/inspector --cli \
 ```
 
 Secrets (`AI_RELAY_API_KEY`, `--api-key` value) appear only as
-`***redacted(Nchars)***`; OpenAI / MCP response bodies are summarised by
-character count + finish reason. The response body itself never reaches
-stderr.
+`***redacted(Nchars)***`. The full assistant response text is emitted in
+the `openai-stream-end` event — treat the verbose stream as sensitive and
+never persist it to shared logs, PR comments, or git.
 
 ## A. Preparation
 
@@ -182,7 +182,7 @@ upstreams on one server).
 |---|---|---|---|
 | **C1** | Tool list | In Inspector, switch to **Tools** tab | Single tool `chat-completions` is listed. Its input schema is `{ messages: Array<{role, content}> }` only (no `model` / `temperature` / `max_tokens` / `top_p` / `stop` fields) — `.strict()`. |
 | **C2** | Happy path | Click **Run Tool** on `chat-completions`. Inputs: `messages: [{role: "user", content: "ping"}]` (only field accepted). | Response contains accumulated text in `result.content[0].text`. `result.structuredContent.model` matches the server's `AI_RELAY_MODEL`. `result.structuredContent.usage.total_tokens > 0`. `result.isError` is `false`. |
-| **C4** | Server-side sampling override | **Stop** the dev server. Restart with `AI_RELAY_MAX_TOKENS=64 AI_RELAY_TEMPERATURE=0.1 pnpm dev`. Re-run C2. | Response succeeds. Server stderr verbose log (`pnpm dev -v` or `AI_RELAY_VERBOSE=1`) shows `max_tokens: 64`, `temperature: 0.1` in the `openai-request` payload. Caller did not send these fields. |
+| **C4** | Server-side sampling override | **Stop** the dev server. Restart with `AI_RELAY_MAX_TOKENS=64 AI_RELAY_TEMPERATURE=0.1 pnpm dev`. Re-run C2. | Response succeeds. Server stderr verbose log (`pnpm dev -v` or `AI_RELAY_VERBOSE=1`) shows `max_tokens: 64`, `temperature: 0.1` in the `openai-http-request` payload. Caller did not send these fields. |
 | **C5** | Bearer rejection | In Inspector, **Disconnect**, change the Header to `Authorization: Bearer wrong-token`, **Connect** | Connection fails with HTTP 401 + `WWW-Authenticate: Bearer` header. Reconnect with the correct token to continue. |
 | **C6** | Cancellation (manual) | Run C2 with a long prompt (e.g., "Write a 500-word essay about sourdough"). Mid-stream, **Disconnect** in the Inspector | Server logs show the SDK call aborted; OpenAI usage page (refreshed in ~1 minute) does NOT show full output cost. (Imprecise visual confirmation — manual observation only.) |
 | **C7** | Multi-registration *(SDK consumers only)* | On a server that registered `registerOpenAIChat` against two distinct names (e.g. `chat-completions` + `azure_chat` with different `apiKey` + `baseURL` + `model`), open **Tools** then run each one with `{ messages: [...] }`. | `tools/list` returns both entries. Each `tools/call` answers from its own upstream with its own captured `model` (verify via `structuredContent.model` in each response). |
@@ -223,7 +223,7 @@ metadata only per `CLAUDE.md` §4).
 
 ## E. After production deploy
 
-After running [`doc/DEPLOY.md` §3.5 verification checklist](./DEPLOY.md#35-verification-checklist),
+After running [`doc/DEPLOY.md` §3.4 verification checklist](./DEPLOY.md#34-verification-checklist),
 re-run **C1, C2, C5** against the production URL
 (`https://<project>.vercel.app/api/mcp`) using the **production**
 `AI_RELAY_AUTH_TOKEN` and the prod-issued `AI_RELAY_API_KEY`.
@@ -252,5 +252,5 @@ production).
 - [`CLAUDE.md` §3](../CLAUDE.md#3-verify-commands) — evidence policy (`evidence-mode: none`)
 - [`CLAUDE.md` §7](../CLAUDE.md#7-testing--what-goes-where) — test matrix (last row is this procedure)
 - [`CLAUDE.md` §9](../CLAUDE.md#9-frequently-forgotten-items) — Proxy Session Token
-- [`doc/DEPLOY.md` §3](./DEPLOY.md#3-vercel-deployment) — Vercel deployment (this procedure is referenced from §3.5)
-- [`doc/DEPLOY.md` §4](./DEPLOY.md#4-docker-self-hosted) — Docker deployment (smoke flow uses `pnpm inspect`)
+- [`doc/DEPLOY.md` §3](./DEPLOY.md#3-docker-canonical) — Docker deployment (smoke flow uses `pnpm inspect`)
+- [`doc/DEPLOY.md` §4](./DEPLOY.md#4-vercel-community-supported) — Vercel deployment (this procedure is referenced from §3.4)

--- a/packages/ai-relay/COMPATIBILITY.md
+++ b/packages/ai-relay/COMPATIBILITY.md
@@ -30,8 +30,10 @@ Last updated: see `git log -1 --format=%ad -- COMPATIBILITY.md`.
 |---|---|---|
 | `ai-relay` | `dist/index.js` | `verifyBearer`, `loadConfig`, types |
 | `ai-relay/openai` | `dist/openai/index.js` | `registerOpenAIChat`, `makeOpenAIChatHandler`, `mapOpenAIError`, `createOpenAIClient`, `openAIChatTool` + types |
+| `ai-relay/anthropic` | `dist/anthropic/index.js` | `registerAnthropicMessages`, `makeAnthropicMessagesHandler`, `mapAnthropicError`, `createAnthropicClient`, `anthropicMessagesTool` + types |
 | `ai-relay/env` | `dist/config.js` | `loadConfig` + config types |
 | `ai-relay/auth` | `dist/auth.js` | `verifyBearer` |
+| `ai-relay/logger` | `dist/logger.js` | `createLogger`, logger types |
 
 The root `ai-relay` is intentionally a thin re-export of the common surface.
 Heavier provider-specific code lives under its own subpath.

--- a/packages/ai-relay/README.md
+++ b/packages/ai-relay/README.md
@@ -99,7 +99,6 @@ Prints a single tool result as JSON on stdout, exits. Input is a positional argu
 
 ```bash
 ai-relay openai chat-completions -m gpt-4o-mini "ping"
-ai-relay openai chat-completions --model gpt-4o-mini -s "be terse" "explain TLS"
 ai-relay openai chat-completions -m gpt-4o --temperature 0.2 \
   '{"messages":[{"role":"user","content":"ping"}]}'
 ai-relay openai chat-completions -m gpt-4o-mini --base-url https://my-azure.openai.azure.com/v1 "ping"
@@ -111,7 +110,6 @@ echo '{"messages":[…]}' | ai-relay openai chat-completions -m gpt-4o-mini
 | Flag | Purpose |
 |---|---|
 | `-m, --model <id>` | Model id (e.g. `gpt-4o-mini`) — required (flag or `AI_RELAY_MODEL`) |
-| `-s, --system <text>` | System message prepended to plain-text input |
 | `--api-key <key>` | Override `AI_RELAY_API_KEY` |
 | `--base-url <url>` | Override `AI_RELAY_BASE_URL` |
 | `--max-tokens <n>` | Forwarded upstream as `max_tokens` (or `AI_RELAY_MAX_TOKENS`) |
@@ -122,7 +120,7 @@ echo '{"messages":[…]}' | ai-relay openai chat-completions -m gpt-4o-mini
 | `--env <path>` | Load `AI_RELAY_*` from a dotenv file |
 | `-v, --verbose` | Trace stages to stderr (also: `AI_RELAY_VERBOSE=1`) |
 
-Verbose mode prints `argv`, `parsed-flags`, `loaded-config`, `openai-request`, `result`, etc. to stderr. Secrets are length-redacted; response body text never leaks to stderr.
+Verbose mode prints `argv`, `parsed-flags`, `loaded-config`, `openai-http-request`, `openai-stream-start`, `result`, etc. to stderr. Secrets are redacted; the full assistant response text is included in the `openai-stream-end` event — treat this stream as sensitive.
 
 ---
 
@@ -336,7 +334,6 @@ await server.connect(new StdioServerTransport());
 | `@modelcontextprotocol/sdk` | `^1.26` |
 | `openai` (optional) | `^6` |
 | `@anthropic-ai/sdk` (optional) | `^0.96.0` |
-| `mcp-handler` (optional) | `^1.1` |
 
 ESM-only (`"type": "module"`). Only `node:` import is `node:async_hooks`.
 

--- a/packages/ai-relay/src/anthropic/messages.ts
+++ b/packages/ai-relay/src/anthropic/messages.ts
@@ -271,12 +271,7 @@ export const anthropicMessagesTool: ToolDescriptor<
   provider: "anthropic",
   name: "messages",
   makeHandler: makeAnthropicMessagesHandler,
-  desugar: (plain, opts) => {
-    const messages: Array<{ role: "system" | "user"; content: string }> = [];
-    if (opts.system) messages.push({ role: "system", content: opts.system });
-    messages.push({ role: "user", content: plain });
-    return { messages };
-  },
+  desugar: (plain) => ({ messages: [{ role: "user", content: plain }] }),
 };
 
 // --- internals ------------------------------------------------------------

--- a/packages/ai-relay/src/bin/parse.ts
+++ b/packages/ai-relay/src/bin/parse.ts
@@ -2,7 +2,7 @@
 //
 // Surface: `ai-relay <provider> <tool> [flags] [input]`
 //
-// Long flags: --system -s, --model -m, --api-key, --base-url,
+// Long flags: --model -m, --api-key, --base-url,
 //             --max-tokens, --temperature, --top-p, --stop,
 //             --timeout, --env, --verbose -v,
 //             --help -h, --version -V.
@@ -17,7 +17,6 @@ export class UsageError extends Error {
 }
 
 export interface ParsedFlags {
-  system?: string;
   model?: string;
   "api-key"?: string;
   "base-url"?: string;
@@ -40,7 +39,6 @@ export interface ParsedInvocation {
 }
 
 const VALUE_FLAGS = new Set([
-  "system",
   "model",
   "api-key",
   "base-url",
@@ -55,7 +53,6 @@ const INTEGER_FLAGS = new Set(["max-tokens", "timeout"]);
 const FLOAT_FLAGS = new Set(["temperature", "top-p"]);
 const STRING_ARRAY_FLAGS = new Set(["stop"]);
 const SHORT_TO_LONG: Record<string, string> = {
-  s: "system",
   m: "model",
   h: "help",
   V: "version",
@@ -388,7 +385,6 @@ export function parseMcpArgv(argv: readonly string[]): ParsedMcpInvocation {
 
 export function countPositionals(argv: readonly string[]): number {
   const ALL_VALUE_FLAGS = new Set([
-    "system",
     "model",
     "api-key",
     "base-url",
@@ -399,7 +395,7 @@ export function countPositionals(argv: readonly string[]): number {
     "timeout",
     "env",
   ]);
-  const VALUE_SHORTS = new Set(["s", "m"]);
+  const VALUE_SHORTS = new Set(["m"]);
   let count = 0;
   let pastDash = false;
   for (let i = 0; i < argv.length; i++) {

--- a/packages/ai-relay/src/bin/run.ts
+++ b/packages/ai-relay/src/bin/run.ts
@@ -47,7 +47,6 @@ Required:
   -m, --model <id>        Upstream model id (or set AI_RELAY_MODEL)
 
 Flags:
-  -s, --system <text>     System message prepended to plain-text input
       --api-key <key>     Upstream API key (overrides AI_RELAY_API_KEY)
       --base-url <url>    Upstream base URL (overrides AI_RELAY_BASE_URL)
       --max-tokens <n>    Max tokens forwarded upstream (or AI_RELAY_MAX_TOKENS)
@@ -62,7 +61,6 @@ Flags:
 
 Examples:
   ai-relay openai chat-completions -m gpt-4o-mini "ping"
-  ai-relay openai chat-completions --model gpt-4o-mini -s "be terse" "explain TLS"
   ai-relay openai chat-completions -m gpt-4o-mini --temperature 0.2 "ping"
   AI_RELAY_MODEL=gpt-4o-mini ai-relay openai chat-completions "ping"
   echo '{"messages":[…]}' | ai-relay openai chat-completions -m gpt-4o-mini
@@ -153,9 +151,7 @@ export async function run(argv: readonly string[], io: RunIO): Promise<number> {
 
   let inputObj: Record<string, unknown>;
   try {
-    inputObj = coerceInput(rawInput, tool, {
-      ...(parsed.flags.system !== undefined ? { system: parsed.flags.system } : {}),
-    });
+    inputObj = coerceInput(rawInput, tool);
   } catch (e) {
     io.stderr.write(`${(e as Error).message}\n`);
     return 2;
@@ -266,11 +262,7 @@ function isJsonInput(raw: string): boolean {
   return first === "{" || first === "[";
 }
 
-function coerceInput(
-  raw: string,
-  tool: AnyTool,
-  opts: { system?: string },
-): Record<string, unknown> {
+function coerceInput(raw: string, tool: AnyTool): Record<string, unknown> {
   const trimmed = raw.trimStart();
   const first = trimmed[0];
   if (first === "{" || first === "[") {
@@ -291,7 +283,7 @@ function coerceInput(
   if (!tool.desugar) {
     throw new UsageError(`tool ${tool.name} does not accept plain text input; pass JSON`);
   }
-  return tool.desugar(raw, opts);
+  return tool.desugar(raw);
 }
 
 function buildToolConfig(

--- a/packages/ai-relay/src/openai/chat.ts
+++ b/packages/ai-relay/src/openai/chat.ts
@@ -253,19 +253,14 @@ export interface ToolDescriptor<C = unknown, B = unknown> {
   /** Make a handler bundle (schema + handler + names) for one config. */
   makeHandler: (config: C) => B;
   /** Optional CLI sugar: turn plain text into a JSON object the schema accepts. */
-  desugar?: (plain: string, opts: { system?: string }) => Record<string, unknown>;
+  desugar?: (plain: string) => Record<string, unknown>;
 }
 
 export const openAIChatTool: ToolDescriptor<OpenAIChatConfig, OpenAIChatHandlerBundle> = {
   provider: "openai",
   name: "chat-completions",
   makeHandler: makeOpenAIChatHandler,
-  desugar: (plain, opts) => {
-    const messages: Array<{ role: "system" | "user"; content: string }> = [];
-    if (opts.system) messages.push({ role: "system", content: opts.system });
-    messages.push({ role: "user", content: plain });
-    return { messages };
-  },
+  desugar: (plain) => ({ messages: [{ role: "user", content: plain }] }),
 };
 
 // --- internals ------------------------------------------------------------

--- a/packages/ai-relay/tests/unit/cli.test.ts
+++ b/packages/ai-relay/tests/unit/cli.test.ts
@@ -37,24 +37,7 @@ describe("parseArgv — basic shape", () => {
     expect(out.flags.model).toBe("gpt-4o-mini");
   });
 
-  it("P6: --system value preserved verbatim and supports multi-word", () => {
-    const out = parseArgv(["openai", "chat-completions", "-s", "be terse and concise", "hi"]);
-    expect(out.flags.system).toBe("be terse and concise");
-  });
-
-  it("P7: long --system also accepted", () => {
-    const out = parseArgv(["openai", "chat-completions", "--system", "be terse", "hi"]);
-    expect(out.flags.system).toBe("be terse");
-  });
-
-  it("P8: --key=value and --key value are equivalent", () => {
-    const a = parseArgv(["openai", "chat-completions", "--system=be terse", "hi"]);
-    const b = parseArgv(["openai", "chat-completions", "--system", "be terse", "hi"]);
-    expect(a.flags.system).toBe("be terse");
-    expect(b.flags.system).toBe("be terse");
-  });
-
-  it("P9: numeric flags (--max-tokens, --timeout) parse to integers", () => {
+  it("P6: numeric flags (--max-tokens, --timeout) parse to integers", () => {
     const out = parseArgv([
       "openai",
       "chat-completions",
@@ -87,10 +70,9 @@ describe("parseArgv — basic shape", () => {
     expect(out.flags["base-url"]).toBe("https://example.test/v1");
   });
 
-  it("P12: -m and -s combine cleanly", () => {
-    const out = parseArgv(["openai", "chat-completions", "-m", "gpt-4o", "-s", "be terse", "hi"]);
+  it("P12: -m sets model", () => {
+    const out = parseArgv(["openai", "chat-completions", "-m", "gpt-4o", "hi"]);
     expect(out.flags.model).toBe("gpt-4o");
-    expect(out.flags.system).toBe("be terse");
     expect(out.positional).toBe("hi");
   });
 });

--- a/packages/ai-relay/tests/unit/openai-tool-desugar.test.ts
+++ b/packages/ai-relay/tests/unit/openai-tool-desugar.test.ts
@@ -2,23 +2,14 @@ import { describe, expect, it } from "vitest";
 import { makeOpenAIChatSchema, openAIChatTool } from "../../src/openai/index.js";
 
 describe("openAIChatTool.desugar — plain-text → input JSON", () => {
-  it("P1: bare string with no opts builds a single user message", () => {
-    expect(openAIChatTool.desugar?.("hi", {})).toEqual({
+  it("P1: bare string builds a single user message", () => {
+    expect(openAIChatTool.desugar?.("hi")).toEqual({
       messages: [{ role: "user", content: "hi" }],
     });
   });
 
-  it("P2: system option is prepended", () => {
-    expect(openAIChatTool.desugar?.("hi", { system: "be terse" })).toEqual({
-      messages: [
-        { role: "system", content: "be terse" },
-        { role: "user", content: "hi" },
-      ],
-    });
-  });
-
-  it("P3: desugar result passes the messages-only schema", () => {
-    const desugared = openAIChatTool.desugar?.("hi", {});
+  it("P2: desugar result passes the messages-only schema", () => {
+    const desugared = openAIChatTool.desugar?.("hi");
     expect(desugared).toBeDefined();
     const schema = makeOpenAIChatSchema();
     const parsed = schema.parse(desugared);

--- a/packages/ai-relay/tests/unit/run.test.ts
+++ b/packages/ai-relay/tests/unit/run.test.ts
@@ -228,7 +228,6 @@ describe("run — input handling", () => {
       "input JSON for chat-completions must be an object, not an array",
     );
   });
-
 });
 
 describe("run — model resolution", () => {

--- a/packages/ai-relay/tests/unit/run.test.ts
+++ b/packages/ai-relay/tests/unit/run.test.ts
@@ -229,25 +229,6 @@ describe("run — input handling", () => {
     );
   });
 
-  it("P3: --system + plain text → system prepended", async () => {
-    let captured: { messages?: { role: string; content: string }[] } | undefined;
-    server.use(
-      http.post(ENDPOINT, async ({ request }) => {
-        captured = (await request.json()) as typeof captured;
-        return happyResponse();
-      }),
-    );
-    const cap = makeIO({ env: { AI_RELAY_API_KEY: "k" } });
-    const code = await run(
-      ["openai", "chat-completions", "-m", "gpt-4o-mini", "-s", "be terse", "hi"],
-      cap.io,
-    );
-    expect(code).toBe(0);
-    expect(captured?.messages).toEqual([
-      { role: "system", content: "be terse" },
-      { role: "user", content: "hi" },
-    ]);
-  });
 });
 
 describe("run — model resolution", () => {


### PR DESCRIPTION
## Summary

- **Remove `-s`/`--system` CLI flag** — stripped from source, tests, and all docs
- **Fix 20+ doc/code discrepancies** found in a comprehensive audit of README, ARCHITECTURE.md, CLAUDE.md, QA-MCP-INSPECTOR.md, and COMPATIBILITY.md

## Code changes

| File | Change |
|---|---|
| `parse.ts` | Remove `system` from `VALUE_FLAGS`, `SHORT_TO_LONG`, `countPositionals`, `ParsedFlags` |
| `run.ts` | Remove `-s` from USAGE/examples; simplify `coerceInput` signature |
| `chat.ts` / `messages.ts` | Simplify `desugar` to `(plain: string)` |
| `cli.test.ts` | Remove P6/P7/P8 (`--system`) tests |
| `openai-tool-desugar.test.ts` | Remove P2 (`system option`) test |
| `run.test.ts` | Remove P3 (`--system + plain text`) test |

## Doc fixes

| Finding | Fix |
|---|---|
| C-1: `max_tokens` ceiling claimed in 3 places but removed from code | Remove all ceiling references; fix request flow step 4 |
| C-2: CLAUDE.md mandated `timingSafeEqual` but code uses XOR-OR loop | Document XOR-OR with Workers-compat rationale |
| C-3: `env.test.ts` path nonexistent | Fix to `tests/integration/app-env.test.ts` |
| H-1: Summary described single `chat-completions` tool only | Update to include Anthropic `messages` tool |
| H-2/H-3: Broken anchors in QA-MCP-INSPECTOR.md | Fix DEPLOY.md section references |
| H-4/H-5: `openai-request` event name nonexistent | Fix to `openai-http-request` / `openai-stream-start` |
| H-6: Verbose claimed response body never reaches stderr | Correct: full text emitted in `openai-stream-end` |
| H-7: Testing table referenced `parseEnv` in SDK (doesn't exist) | Fix to app-level `app-env.test.ts` |
| H-8: `ai-relay/anthropic` and `ai-relay/logger` missing from COMPATIBILITY.md | Add both subpaths |
| M-1: `gpt-5-mini` typo | Fix to `gpt-4o-mini` |
| M-2: Runtime described as "alpine container" | Fix to "Distroless Debian 12" |
| M-3: Container uid claimed as 1001 (`app`) | Fix to 65532 (`nonroot`) |
| M-6: `verify.mjs --url=` flag undocumented | Document it |
| M-7: `test:unit` described as unit-only | Correct: runs unit + integration + CLI tests |
| M-8: `mcp-handler` listed as optional SDK peer dep | Remove — not declared in SDK `package.json` |
| M-9/L-4: Intros described OpenAI-only | Update to mention both providers |
| M-10: 3 workflow files missing from directory listing | Add `docker-smoke.yml`, `examples-smoke.yml`, `runtime-matrix.yml` |
| L-5: Auth pseudocode used wrong path + `timingSafeEqual` | Replace with actual XOR-OR implementation |
| L-7: Proxy Session Token credited to mcp-handler | Fix: it's printed by the Inspector CLI |

## Test output

```
Test Files  19 passed | 1 skipped (20)
      Tests  367 passed | 1 skipped (368)
```

## MCP Inspector verification

N/A — no runtime behavior changed (doc + `-s` flag removal only).

## v1 non-goal self-check

- [ ] No Responses API tools added
- [ ] No Embeddings / image tools added
- [ ] No OAuth 2.1 authentication added
- [ ] No rate limiting added
- [ ] No daily token / dollar budget counters added
- [ ] No external observability added
- [ ] No progress notifications added
- [ ] No SSE transport / Redis added