### PR TITLE
feat(sdk): Google Gemini provider — adds ./google subpath

### DIFF
--- a/packages/ai-relay/package.json
+++ b/packages/ai-relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-relay",
   "version": "0.11.0",
-  "description": "Provider-agnostic MCP relay SDK — embed Chat Completions, Anthropic Messages, and (future) Gemini / unified-gateway tools in any MCP server.",
+  "description": "Provider-agnostic MCP relay SDK — embed Chat Completions, Anthropic Messages, Google Gemini, and (future) unified-gateway tools in any MCP server.",
   "license": "MIT",
   "author": "Jimmy Moon <ragingwind@gmail.com>",
   "type": "module",
@@ -19,6 +19,10 @@
     "./anthropic": {
       "types": "./dist/anthropic/index.d.ts",
       "import": "./dist/anthropic/index.js"
+    },
+    "./google": {
+      "types": "./dist/google/index.d.ts",
+      "import": "./dist/google/index.js"
     },
     "./env": {
       "types": "./dist/config.d.ts",
@@ -54,11 +58,15 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.96.0",
+    "@google/genai": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.26",
     "openai": "^6"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@google/genai": {
       "optional": true
     },
     "openai": {
@@ -72,6 +80,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.96.0"
+    "@anthropic-ai/sdk": "^0.96.0",
+    "@google/genai": "^2.5.0"
   }
 }

--- a/packages/ai-relay/src/bin/registry.ts
+++ b/packages/ai-relay/src/bin/registry.ts
@@ -33,7 +33,7 @@ export interface ProviderEntry {
   tools: Record<string, AnyTool>;
 }
 
-export type ProviderName = "openai" | "anthropic";
+export type ProviderName = "openai" | "anthropic" | "google";
 
 type Loader = () => Promise<ProviderEntry>;
 
@@ -57,6 +57,18 @@ const loaders: Record<ProviderName, Loader> = {
       registerOnServer: mod.registerAnthropicProvider,
       tools: {
         messages: mod.anthropicMessagesTool,
+      },
+    };
+  },
+  google: async () => {
+    const mod = (await import("../google/index.js")) as {
+      registerGoogleProvider: ProviderEntry["registerOnServer"];
+      googleGenerateContentTool: AnyTool;
+    };
+    return {
+      registerOnServer: mod.registerGoogleProvider,
+      tools: {
+        "generate-content": mod.googleGenerateContentTool,
       },
     };
   },

--- a/packages/ai-relay/src/google/client.ts
+++ b/packages/ai-relay/src/google/client.ts
@@ -1,0 +1,35 @@
+// Google Gemini client factory. Mirrors the OpenAI/Anthropic factories.
+//
+// Each call to `createGoogleClient` produces a fresh `GoogleGenAI` instance.
+// `@google/genai` v2 does not expose a custom-fetch / fetchImplementation
+// hook on the public `GoogleGenAIOptions` surface, so upstream-error body
+// capture is not wired here today (the `mapGoogleError` mapper extracts the
+// SDK's stringified-JSON `ApiError.message` directly).
+
+import { GoogleGenAI } from "@google/genai";
+
+export interface GoogleClientConfig {
+  /** Gemini API key. Required. */
+  apiKey: string;
+  /** Override the Gemini base URL (e.g. for self-hosted gateway / mock). */
+  baseURL?: string;
+  /** Per-request timeout in ms. Default 60_000. */
+  requestTimeoutMs?: number;
+}
+
+export interface CreatedGoogleClient {
+  client: GoogleGenAI;
+}
+
+export function createGoogleClient(config: GoogleClientConfig): CreatedGoogleClient {
+  const httpOptions: Record<string, unknown> = {};
+  if (config.baseURL) httpOptions.baseUrl = config.baseURL;
+  if (config.requestTimeoutMs !== undefined) httpOptions.timeout = config.requestTimeoutMs;
+
+  const client = new GoogleGenAI({
+    apiKey: config.apiKey,
+    ...(Object.keys(httpOptions).length > 0 ? { httpOptions } : {}),
+  });
+
+  return { client };
+}

--- a/packages/ai-relay/src/google/client.ts
+++ b/packages/ai-relay/src/google/client.ts
@@ -22,13 +22,15 @@ export interface CreatedGoogleClient {
 }
 
 export function createGoogleClient(config: GoogleClientConfig): CreatedGoogleClient {
-  const httpOptions: Record<string, unknown> = {};
+  const httpOptions: Record<string, unknown> = {
+    retryOptions: { attempts: 1 },
+  };
   if (config.baseURL) httpOptions.baseUrl = config.baseURL;
   if (config.requestTimeoutMs !== undefined) httpOptions.timeout = config.requestTimeoutMs;
 
   const client = new GoogleGenAI({
     apiKey: config.apiKey,
-    ...(Object.keys(httpOptions).length > 0 ? { httpOptions } : {}),
+    httpOptions,
   });
 
   return { client };

--- a/packages/ai-relay/src/google/generate-content.ts
+++ b/packages/ai-relay/src/google/generate-content.ts
@@ -137,9 +137,6 @@ export function mapGoogleError(err: unknown): MappedError {
 
     if (status === 400) {
       const body = err.message ?? "";
-      // Gemini wraps the API JSON body in `error.message`. Detect the
-      // `INVALID_ARGUMENT` status + "context" hint without parsing the
-      // unstructured string strictly.
       const isInvalidArgument =
         /"status"\s*:\s*"INVALID_ARGUMENT"/i.test(body) || /INVALID_ARGUMENT/.test(body);
       if (isInvalidArgument && /context/i.test(body)) {
@@ -155,8 +152,33 @@ export function mapGoogleError(err: unknown): MappedError {
     return { code: "bad_request", message: "Bad request" };
   }
 
-  // Aborted requests surface as DOMException("AbortError") or TypeError
-  // ("fetch failed") from undici. Both fall through to upstream_error.
+  // With retryOptions set, @google/genai's apiCall throws plain Error /
+  // AbortError with statusText embedded in the message. Status code and
+  // response body are not retained, so 400-context_length cannot be
+  // distinguished from generic 400.
+  if (err instanceof Error) {
+    const msg = err.message;
+    if (msg.includes("Too Many Requests")) {
+      return { code: "rate_limited", message: "Rate limited by upstream" };
+    }
+    if (msg.includes("Unauthorized") || msg.includes("Forbidden")) {
+      return { code: "auth", message: "Authentication failed" };
+    }
+    if (msg.includes("Bad Request") || msg.includes("INVALID_ARGUMENT")) {
+      return { code: "bad_request", message: "Bad request" };
+    }
+    if (
+      msg.includes("Internal Server Error") ||
+      msg.includes("Service Unavailable") ||
+      msg.includes("Bad Gateway") ||
+      msg.includes("Gateway Timeout") ||
+      msg.includes("Request Timeout") ||
+      msg.includes("Retryable HTTP Error")
+    ) {
+      return { code: "upstream_error", message: "Upstream server error" };
+    }
+  }
+
   return { code: "upstream_error", message: "Network or unknown error" };
 }
 

--- a/packages/ai-relay/src/google/generate-content.ts
+++ b/packages/ai-relay/src/google/generate-content.ts
@@ -1,0 +1,511 @@
+// Google Gemini Generate-Content MCP tool registrar.
+//
+// `registerGoogleGenerateContent(server, config)` registers a single MCP
+// tool that streams a Gemini `generateContentStream` response and returns
+// the accumulated text as one `CallToolResult`. The same server may be
+// registered against multiple times with different `name` + `apiKey` +
+// `baseURL` — every call produces an independent closure with NO
+// module-level shared state.
+//
+// Error result invariants:
+//   - never echo the raw upstream body, prompt, or headers.
+//   - map Gemini errors (`ApiError`) to the stable `code` set defined below.
+
+import { ApiError, type GoogleGenAI } from "@google/genai";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { VerboseLogger } from "../bin/logger.js";
+import type { ToolDescriptor } from "../openai/chat.js";
+import { type CreatedGoogleClient, createGoogleClient } from "./client.js";
+
+const DEFAULT_NAME = "generate-content";
+const DEFAULT_DESCRIPTION =
+  "Invoke Google Gemini generate-content and return the accumulated assistant message.";
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+// --- config ---------------------------------------------------------------
+
+export interface GoogleGenerateContentConfig {
+  /** Registered MCP tool name. Default `"generate-content"`. */
+  name?: string;
+  /** Description override. */
+  description?: string;
+  /** Gemini API key. Required unless `googleClient` is supplied. */
+  apiKey: string;
+  /** Gemini base URL override. */
+  baseURL?: string;
+  /** Model id forwarded to the upstream. Required. */
+  model: string;
+  /** Sampling temperature. When set, forwarded with every call. */
+  temperature?: number;
+  /** Max tokens — forwarded as `maxOutputTokens`. */
+  max_tokens?: number;
+  /** Nucleus sampling cutoff — forwarded as `topP`. */
+  top_p?: number;
+  /** Stop sequence (string, comma-separated string, or array). */
+  stop?: string | string[];
+  /** Per-request timeout in ms. Default 60_000. */
+  requestTimeoutMs?: number;
+  /** Inject a pre-built GoogleGenAI client. */
+  googleClient?: GoogleGenAI;
+  /** Optional verbose logger. */
+  logger?: VerboseLogger;
+}
+
+// --- input schema ---------------------------------------------------------
+
+export function makeGoogleGenerateContentSchema() {
+  return z
+    .object({
+      messages: z
+        .array(
+          z.object({
+            role: z.enum(["system", "user", "assistant"]),
+            content: z.string(),
+          }),
+        )
+        .min(1),
+    })
+    .strict();
+}
+
+export type GoogleGenerateContentSchema = ReturnType<typeof makeGoogleGenerateContentSchema>;
+export type GoogleGenerateContentInput = z.infer<GoogleGenerateContentSchema>;
+
+export const googleGenerateContentOutputSchema = z
+  .object({
+    model: z.string(),
+    usage: z
+      .object({
+        prompt_tokens: z.number(),
+        completion_tokens: z.number(),
+        total_tokens: z.number(),
+      })
+      .optional(),
+    finish_reason: z.string().optional(),
+    code: z.string().optional(),
+    retryAfter: z.number().optional(),
+  })
+  .strict();
+
+// --- result shape ---------------------------------------------------------
+
+export type GoogleUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+export type GoogleGenerateContentStructured = {
+  model: string;
+  usage?: GoogleUsage;
+  finish_reason?: string;
+  code?: string;
+  retryAfter?: number;
+};
+
+export type GoogleGenerateContentResult = {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: GoogleGenerateContentStructured;
+  isError: boolean;
+};
+
+export type GoogleGenerateContentHandler = (
+  rawInput: unknown,
+  extra?: { signal?: AbortSignal },
+) => Promise<GoogleGenerateContentResult>;
+
+// --- error mapping --------------------------------------------------------
+
+type MappedError = {
+  code: string;
+  message: string;
+  retryAfter?: number;
+};
+
+export function mapGoogleError(err: unknown): MappedError {
+  if (err instanceof ApiError) {
+    const status = err.status;
+
+    if (status === 401 || status === 403) {
+      return { code: "auth", message: "Authentication failed" };
+    }
+
+    if (status === 429) {
+      return { code: "rate_limited", message: "Rate limited by upstream" };
+    }
+
+    if (status === 400) {
+      const body = err.message ?? "";
+      // Gemini wraps the API JSON body in `error.message`. Detect the
+      // `INVALID_ARGUMENT` status + "context" hint without parsing the
+      // unstructured string strictly.
+      const isInvalidArgument =
+        /"status"\s*:\s*"INVALID_ARGUMENT"/i.test(body) || /INVALID_ARGUMENT/.test(body);
+      if (isInvalidArgument && /context/i.test(body)) {
+        return { code: "context_length", message: "Context length exceeded" };
+      }
+      return { code: "bad_request", message: "Bad request" };
+    }
+
+    if (typeof status === "number" && status >= 500) {
+      return { code: "upstream_error", message: "Upstream server error" };
+    }
+
+    return { code: "bad_request", message: "Bad request" };
+  }
+
+  // Aborted requests surface as DOMException("AbortError") or TypeError
+  // ("fetch failed") from undici. Both fall through to upstream_error.
+  return { code: "upstream_error", message: "Network or unknown error" };
+}
+
+// --- handler factory ------------------------------------------------------
+
+export interface GoogleGenerateContentHandlerBundle {
+  schema: GoogleGenerateContentSchema;
+  handler: GoogleGenerateContentHandler;
+  /** Resolved tool name (`config.name ?? "generate-content"`). */
+  name: string;
+  /** Resolved description. */
+  description: string;
+}
+
+export function makeGoogleGenerateContentHandler(
+  config: GoogleGenerateContentConfig,
+): GoogleGenerateContentHandlerBundle {
+  if (!config.model || config.model.length === 0) {
+    throw new Error("GoogleGenerateContentConfig.model is required");
+  }
+  const name = config.name ?? DEFAULT_NAME;
+  const description = config.description ?? buildDefaultDescription(config);
+  const schema = makeGoogleGenerateContentSchema();
+
+  const { client } = resolveClient(config);
+  const logger = config.logger;
+
+  const handler: GoogleGenerateContentHandler = async (rawInput, extra = {}) => {
+    const input: GoogleGenerateContentInput = schema.parse(rawInput);
+
+    const ac = new AbortController();
+    if (extra.signal) {
+      if (extra.signal.aborted) {
+        ac.abort();
+      } else {
+        extra.signal.addEventListener("abort", () => ac.abort(), { once: true });
+      }
+    }
+
+    return runOnce(input.messages, config, client, ac, logger);
+  };
+
+  return { schema, handler, name, description };
+}
+
+export function registerGoogleGenerateContent(
+  server: McpServer,
+  config: GoogleGenerateContentConfig,
+): void {
+  const { schema, handler, name, description } = makeGoogleGenerateContentHandler(config);
+  server.registerTool(
+    name,
+    {
+      description,
+      inputSchema: schema.shape,
+      outputSchema: googleGenerateContentOutputSchema.shape,
+    },
+    handler,
+  );
+}
+
+export function registerGoogleProvider(
+  server: McpServer,
+  config: GoogleGenerateContentConfig,
+): void {
+  registerGoogleGenerateContent(server, config);
+}
+
+// --- transport-agnostic tool descriptor ----------------------------------
+
+export const googleGenerateContentTool: ToolDescriptor<
+  GoogleGenerateContentConfig,
+  GoogleGenerateContentHandlerBundle
+> = {
+  provider: "google",
+  name: "generate-content",
+  makeHandler: makeGoogleGenerateContentHandler,
+  desugar: (plain) => ({ messages: [{ role: "user", content: plain }] }),
+};
+
+// --- internals ------------------------------------------------------------
+
+function buildDefaultDescription(config: GoogleGenerateContentConfig): string {
+  const hints: string[] = [`model: ${config.model}`];
+  if (config.temperature !== undefined) hints.push(`temperature: ${config.temperature}`);
+  if (config.max_tokens !== undefined) hints.push(`max_tokens: ${config.max_tokens}`);
+  if (config.top_p !== undefined) hints.push(`top_p: ${config.top_p}`);
+  if (config.stop !== undefined) {
+    hints.push(`stop: ${Array.isArray(config.stop) ? JSON.stringify(config.stop) : config.stop}`);
+  }
+  return `${DEFAULT_DESCRIPTION} (${hints.join(", ")})`;
+}
+
+function resolveClient(config: GoogleGenerateContentConfig): CreatedGoogleClient {
+  if (config.googleClient) {
+    return { client: config.googleClient };
+  }
+  return createGoogleClient({
+    apiKey: config.apiKey,
+    ...(config.baseURL ? { baseURL: config.baseURL } : {}),
+    requestTimeoutMs: config.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+}
+
+type GoogleContent = { role: "user" | "model"; parts: Array<{ text: string }> };
+
+type TranslatedMessages = {
+  systemInstruction?: string;
+  contents: GoogleContent[];
+};
+
+// Gemini places the system prompt in a top-level `systemInstruction` field.
+// The caller-facing schema accepts a `system` role (parity with OpenAI).
+// Leading consecutive system messages are concatenated; a system message
+// after a user/assistant turn is rejected because Gemini has no
+// representation for interleaved system content.
+function translateMessages(messages: GoogleGenerateContentInput["messages"]): TranslatedMessages {
+  const systemParts: string[] = [];
+  let i = 0;
+  while (i < messages.length && messages[i]?.role === "system") {
+    const m = messages[i];
+    if (m) systemParts.push(m.content);
+    i++;
+  }
+
+  const contents: GoogleContent[] = [];
+  for (; i < messages.length; i++) {
+    const m = messages[i];
+    if (!m) continue;
+    if (m.role === "system") {
+      const err = new Error(
+        "Gemini does not support system messages interleaved with user/assistant turns; place all system messages at the start",
+      ) as Error & { code?: string };
+      err.code = "bad_request";
+      throw err;
+    }
+    const role: "user" | "model" = m.role === "assistant" ? "model" : "user";
+    const last = contents[contents.length - 1];
+    if (last && last.role === role) {
+      last.parts.push({ text: m.content });
+    } else {
+      contents.push({ role, parts: [{ text: m.content }] });
+    }
+  }
+
+  const out: TranslatedMessages = { contents };
+  if (systemParts.length > 0) out.systemInstruction = systemParts.join("\n\n");
+  return out;
+}
+
+function translateStop(stop: string | string[] | undefined): string[] | undefined {
+  if (stop === undefined) return undefined;
+  const arr = Array.isArray(stop) ? stop : stop.includes(",") ? stop.split(",") : [stop];
+  const filtered = arr.map((s) => s.trim()).filter((s) => s.length > 0);
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function mapFinishReason(reason: string | undefined): {
+  finish_reason?: string;
+  isContentPolicy: boolean;
+} {
+  if (!reason) return { isContentPolicy: false };
+  if (reason === "SAFETY" || reason === "RECITATION") {
+    return { isContentPolicy: true };
+  }
+  switch (reason) {
+    case "STOP":
+      return { finish_reason: "stop", isContentPolicy: false };
+    case "MAX_TOKENS":
+      return { finish_reason: "length", isContentPolicy: false };
+    default:
+      return { finish_reason: reason.toLowerCase(), isContentPolicy: false };
+  }
+}
+
+type GeminiUsageMetadata = {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  totalTokenCount?: number;
+};
+
+async function runOnce(
+  rawMessages: GoogleGenerateContentInput["messages"],
+  config: GoogleGenerateContentConfig,
+  client: GoogleGenAI,
+  ac: AbortController,
+  logger?: VerboseLogger,
+): Promise<GoogleGenerateContentResult> {
+  const startedAt = Date.now();
+  const model = config.model;
+
+  let translated: TranslatedMessages;
+  try {
+    translated = translateMessages(rawMessages);
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    const code = e.code ?? "bad_request";
+    if (logger?.enabled) {
+      logger.log("google-stream-end", {
+        accumulatedText: "",
+        finish_reason: undefined,
+        usage: undefined,
+        elapsedMs: Date.now() - startedAt,
+        error: { code, message: e.message },
+      });
+    }
+    return {
+      content: [{ type: "text", text: e.message }],
+      structuredContent: { model, code },
+      isError: true,
+    };
+  }
+
+  const stopSequences = translateStop(config.stop);
+
+  const generationConfig: Record<string, unknown> = {};
+  if (config.temperature !== undefined) generationConfig.temperature = config.temperature;
+  if (config.top_p !== undefined) generationConfig.topP = config.top_p;
+  if (config.max_tokens !== undefined) generationConfig.maxOutputTokens = config.max_tokens;
+  if (stopSequences !== undefined) generationConfig.stopSequences = stopSequences;
+
+  if (logger?.enabled) {
+    logger.log("google-stream-start", {
+      model,
+      contents: translated.contents,
+      ...(translated.systemInstruction !== undefined
+        ? { systemInstruction: translated.systemInstruction }
+        : {}),
+      generationConfig,
+    });
+  }
+
+  try {
+    const stream = await client.models.generateContentStream({
+      model,
+      contents: translated.contents,
+      config: {
+        ...(translated.systemInstruction !== undefined
+          ? { systemInstruction: translated.systemInstruction }
+          : {}),
+        ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
+        ...(config.top_p !== undefined ? { topP: config.top_p } : {}),
+        ...(config.max_tokens !== undefined ? { maxOutputTokens: config.max_tokens } : {}),
+        ...(stopSequences !== undefined ? { stopSequences } : {}),
+        abortSignal: ac.signal,
+      },
+    });
+
+    let accumulated = "";
+    let lastUsage: GeminiUsageMetadata | undefined;
+    let lastFinishReason: string | undefined;
+
+    for await (const chunk of stream) {
+      const cand = chunk.candidates?.[0];
+      const text = cand?.content?.parts?.[0]?.text ?? "";
+      accumulated += text;
+      if (cand?.finishReason) {
+        lastFinishReason = cand.finishReason;
+      }
+      if (chunk.usageMetadata) {
+        lastUsage = chunk.usageMetadata as GeminiUsageMetadata;
+      }
+    }
+
+    const mapped = mapFinishReason(lastFinishReason);
+    const usage = buildUsage(lastUsage);
+
+    if (mapped.isContentPolicy) {
+      const structuredContent: GoogleGenerateContentStructured = {
+        model,
+        code: "content_policy",
+        ...(usage ? { usage } : {}),
+        finish_reason: "content_filter",
+      };
+      if (logger?.enabled) {
+        logger.log("google-stream-end", {
+          accumulatedText: accumulated,
+          finish_reason: "content_filter",
+          usage,
+          elapsedMs: Date.now() - startedAt,
+          error: { code: "content_policy", message: "Content policy rejected" },
+        });
+      }
+      return {
+        content: [{ type: "text", text: "Content policy rejected" }],
+        structuredContent,
+        isError: true,
+      };
+    }
+
+    const structuredContent: GoogleGenerateContentStructured = {
+      model,
+      ...(usage ? { usage } : {}),
+      ...(mapped.finish_reason !== undefined ? { finish_reason: mapped.finish_reason } : {}),
+    };
+
+    if (logger?.enabled) {
+      logger.log("google-stream-end", {
+        accumulatedText: accumulated,
+        finish_reason: mapped.finish_reason,
+        usage,
+        elapsedMs: Date.now() - startedAt,
+      });
+    }
+
+    return {
+      content: [{ type: "text", text: accumulated }],
+      structuredContent,
+      isError: false,
+    };
+  } catch (err) {
+    const mapped = mapGoogleError(err);
+    const structuredContent: GoogleGenerateContentStructured = {
+      model,
+      code: mapped.code,
+      ...(mapped.retryAfter !== undefined ? { retryAfter: mapped.retryAfter } : {}),
+    };
+    if (logger?.enabled) {
+      logger.log("google-stream-end", {
+        accumulatedText: "",
+        finish_reason: undefined,
+        usage: undefined,
+        elapsedMs: Date.now() - startedAt,
+        error: { code: mapped.code, message: mapped.message },
+      });
+    }
+    return {
+      content: [{ type: "text", text: mapped.message }],
+      structuredContent,
+      isError: true,
+    };
+  }
+}
+
+function buildUsage(usage: GeminiUsageMetadata | undefined): GoogleUsage | undefined {
+  if (!usage) return undefined;
+  if (
+    usage.promptTokenCount === undefined &&
+    usage.candidatesTokenCount === undefined &&
+    usage.totalTokenCount === undefined
+  ) {
+    return undefined;
+  }
+  const prompt = usage.promptTokenCount ?? 0;
+  const completion = usage.candidatesTokenCount ?? 0;
+  const total = usage.totalTokenCount ?? prompt + completion;
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: total,
+  };
+}

--- a/packages/ai-relay/src/google/index.ts
+++ b/packages/ai-relay/src/google/index.ts
@@ -1,0 +1,22 @@
+// ai-relay/google — Google Gemini provider.
+
+export type { CreatedGoogleClient, GoogleClientConfig } from "./client.js";
+export { createGoogleClient } from "./client.js";
+export type {
+  GoogleGenerateContentConfig,
+  GoogleGenerateContentHandler,
+  GoogleGenerateContentHandlerBundle,
+  GoogleGenerateContentInput,
+  GoogleGenerateContentResult,
+  GoogleGenerateContentSchema,
+  GoogleGenerateContentStructured,
+  GoogleUsage,
+} from "./generate-content.js";
+export {
+  googleGenerateContentTool,
+  makeGoogleGenerateContentHandler,
+  makeGoogleGenerateContentSchema,
+  mapGoogleError,
+  registerGoogleGenerateContent,
+  registerGoogleProvider,
+} from "./generate-content.js";

--- a/packages/ai-relay/tests/integration/pack-contract.test.ts
+++ b/packages/ai-relay/tests/integration/pack-contract.test.ts
@@ -103,7 +103,15 @@ describe("pack contract — installed-tarball imports", () => {
     );
     execFileSync(
       "npm",
-      ["install", "--no-audit", "--no-fund", tarball, "openai@^6", "@anthropic-ai/sdk@^0.96.0"],
+      [
+        "install",
+        "--no-audit",
+        "--no-fund",
+        tarball,
+        "openai@^6",
+        "@anthropic-ai/sdk@^0.96.0",
+        "@google/genai@^2.0.0",
+      ],
       {
         cwd: installDir,
         stdio: "pipe",
@@ -116,6 +124,7 @@ describe("pack contract — installed-tarball imports", () => {
       import * as auth from "ai-relay/auth";
       import * as openai from "ai-relay/openai";
       import * as anthropic from "ai-relay/anthropic";
+      import * as google from "ai-relay/google";
       const ok =
         typeof root.verifyBearer === "function" &&
         typeof root.loadConfig === "function" &&
@@ -124,7 +133,9 @@ describe("pack contract — installed-tarball imports", () => {
         typeof openai.registerOpenAIChat === "function" &&
         typeof openai.makeOpenAIChatHandler === "function" &&
         typeof anthropic.registerAnthropicMessages === "function" &&
-        typeof anthropic.makeAnthropicMessagesHandler === "function";
+        typeof anthropic.makeAnthropicMessagesHandler === "function" &&
+        typeof google.registerGoogleGenerateContent === "function" &&
+        typeof google.makeGoogleGenerateContentHandler === "function";
       console.log(ok ? "EXPORTS_OK" : "EXPORTS_MISSING");
     `;
     const out = execFileSync("node", ["--input-type=module", "-e", script], {
@@ -156,6 +167,7 @@ describe("pack contract — typecheck under bundler + nodenext", () => {
         tarball,
         "openai@^6",
         "@anthropic-ai/sdk@^0.96.0",
+        "@google/genai@^2.0.0",
         "typescript@^6.0.3",
       ],
       { cwd: tmp, stdio: "pipe" },

--- a/packages/ai-relay/tests/unit/google-generate-content.test.ts
+++ b/packages/ai-relay/tests/unit/google-generate-content.test.ts
@@ -457,7 +457,7 @@ describe("google generate-content — error mapping", () => {
     expect(result.structuredContent.code).toBe("rate_limited");
   });
 
-  it("D4: 400 INVALID_ARGUMENT containing 'context' → context_length", async () => {
+  it("D4: 400 INVALID_ARGUMENT containing 'context' → bad_request (Path B fallback; body inaccessible under pRetry)", async () => {
     server.use(
       http.post(
         ENDPOINT,
@@ -476,7 +476,7 @@ describe("google generate-content — error mapping", () => {
     );
     const { handler } = makeHandler();
     const result = await handler({ messages: VALID_MESSAGES });
-    expect(result.structuredContent.code).toBe("context_length");
+    expect(result.structuredContent.code).toBe("bad_request");
   });
 
   it("D5: 400 without 'context' → bad_request", async () => {
@@ -517,6 +517,24 @@ describe("google generate-content — error mapping", () => {
     server.use(http.post(ENDPOINT, () => HttpResponse.error()));
     const { handler } = makeHandler();
     const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("D-retry: does not retry on 5xx — exactly 1 request made", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post(ENDPOINT, () => {
+        requestCount++;
+        return new HttpResponse(
+          JSON.stringify({ error: { message: "Service Unavailable", code: 503 } }),
+          { status: 503, headers: { "content-type": "application/json" } },
+        );
+      }),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(requestCount).toBe(1);
     expect(result.isError).toBe(true);
     expect(result.structuredContent.code).toBe("upstream_error");
   });

--- a/packages/ai-relay/tests/unit/google-generate-content.test.ts
+++ b/packages/ai-relay/tests/unit/google-generate-content.test.ts
@@ -1,0 +1,677 @@
+// Unit tests for `src/google/generate-content.ts` — the framework-agnostic
+// Google Gemini Generate-Content registrar. Tests target
+// `makeGoogleGenerateContentHandler` with MSW intercepting the
+// generativelanguage.googleapis.com boundary. Each test creates its own
+// handler so there is no module-level shared state to reset.
+
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  type GoogleGenerateContentConfig,
+  type GoogleGenerateContentHandlerBundle,
+  type GoogleGenerateContentResult,
+  makeGoogleGenerateContentHandler,
+} from "../../src/google/generate-content.js";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const VALID_MODEL = "gemini-2.0-flash";
+// Streaming endpoint matched by the SDK (URL contains the model id).
+const ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${VALID_MODEL}:streamGenerateContent`;
+
+const TEST_API_KEY = "test-google-api-key";
+
+const VALID_MESSAGES = [{ role: "user" as const, content: "say hi" }];
+
+function makeHandler(
+  overrides: Partial<GoogleGenerateContentConfig> = {},
+): GoogleGenerateContentHandlerBundle {
+  return makeGoogleGenerateContentHandler({
+    apiKey: TEST_API_KEY,
+    model: VALID_MODEL,
+    ...overrides,
+  });
+}
+
+// Build an SSE stream of Gemini chunks. The SDK accepts `alt=sse` and parses
+// each `data: { ... }` line as one `GenerateContentResponse`.
+function sseStream(chunks: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunks[i])}\r\n\r\n`));
+        i++;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function sseResponse(chunks: unknown[]) {
+  return new HttpResponse(sseStream(chunks), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function textChunk(text: string, opts: { finishReason?: string; usage?: unknown } = {}) {
+  const chunk: Record<string, unknown> = {
+    candidates: [
+      {
+        content: { role: "model", parts: [{ text }] },
+        ...(opts.finishReason ? { finishReason: opts.finishReason } : {}),
+      },
+    ],
+  };
+  if (opts.usage) chunk.usageMetadata = opts.usage;
+  return chunk;
+}
+
+function defaultOkStream(text = "ok"): unknown[] {
+  return [
+    textChunk(text, {
+      finishReason: "STOP",
+      usage: { promptTokenCount: 5, candidatesTokenCount: 3, totalTokenCount: 8 },
+    }),
+  ];
+}
+
+function assertNoSecretLeak(result: GoogleGenerateContentResult | unknown): void {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain(TEST_API_KEY);
+}
+
+// =========================================================================
+// A: Input Validation (S1)
+// =========================================================================
+
+describe("google generate-content — input validation", () => {
+  it("P1: accepts a minimal { messages } input", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(defaultOkStream())));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(false);
+  });
+
+  it("D1: rejects unknown extra keys (strict schema)", async () => {
+    const { handler } = makeHandler();
+    await expect(handler({ messages: VALID_MESSAGES, unknown: "x" })).rejects.toThrow();
+  });
+
+  it("D2: rejects role enum value outside {system,user,assistant}", async () => {
+    const { handler } = makeHandler();
+    await expect(
+      handler({ messages: [{ role: "tool", content: "x" }] as unknown }),
+    ).rejects.toThrow();
+  });
+
+  it("D3: rejects empty messages array (min 1)", async () => {
+    const { handler } = makeHandler();
+    await expect(handler({ messages: [] })).rejects.toThrow();
+  });
+});
+
+// =========================================================================
+// B: System instruction extraction (S2)
+// =========================================================================
+
+describe("google generate-content — system instruction extraction", () => {
+  it("P1: leading single system message → systemInstruction.parts[0].text", async () => {
+    let body: { systemInstruction?: { parts?: Array<{ text?: string }> } } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "system", content: "be terse" },
+        { role: "user", content: "hi" },
+      ],
+    });
+    expect(body?.systemInstruction?.parts?.[0]?.text).toBe("be terse");
+  });
+
+  it("P2: multiple leading system messages joined with \\n\\n", async () => {
+    let body: { systemInstruction?: { parts?: Array<{ text?: string }> } } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "system", content: "A" },
+        { role: "system", content: "B" },
+        { role: "user", content: "hi" },
+      ],
+    });
+    expect(body?.systemInstruction?.parts?.[0]?.text).toBe("A\n\nB");
+  });
+
+  it("P3: no system messages → request body omits systemInstruction", async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    expect(body).toBeDefined();
+    expect("systemInstruction" in (body ?? {})).toBe(false);
+  });
+
+  it("D1: non-leading system message → isError with code bad_request", async () => {
+    const { handler } = makeHandler();
+    const result = await handler({
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "system", content: "interleaved" },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("bad_request");
+    expect(result.content[0]?.text).toMatch(/interleaved|system/i);
+  });
+});
+
+// =========================================================================
+// C: Role translation (S3) — assistant → model in contents[]
+// =========================================================================
+
+describe("google generate-content — role translation", () => {
+  it("P1: assistant → model in contents[]", async () => {
+    let body: { contents?: Array<{ role?: string; parts?: Array<{ text?: string }> }> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+        { role: "user", content: "again" },
+      ],
+    });
+    expect(body?.contents?.map((c) => c.role)).toEqual(["user", "model", "user"]);
+  });
+
+  it("P2: user role passed through unchanged in contents[]", async () => {
+    let body: { contents?: Array<{ role?: string }> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.contents?.[0]?.role).toBe("user");
+  });
+});
+
+// =========================================================================
+// D: Consecutive same-role merging (S4)
+// =========================================================================
+
+describe("google generate-content — consecutive same-role merging", () => {
+  it("P1: consecutive user messages merged into one Content with multiple parts", async () => {
+    let body: { contents?: Array<{ role?: string; parts?: Array<{ text?: string }> }> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "user", content: "first" },
+        { role: "user", content: "second" },
+      ],
+    });
+    expect(body?.contents).toHaveLength(1);
+    expect(body?.contents?.[0]?.role).toBe("user");
+    expect(body?.contents?.[0]?.parts?.map((p) => p.text)).toEqual(["first", "second"]);
+  });
+
+  it("P2: consecutive assistant messages merged (after assistant→model translation)", async () => {
+    let body: { contents?: Array<{ role?: string; parts?: Array<{ text?: string }> }> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "a" },
+        { role: "assistant", content: "b" },
+        { role: "user", content: "k" },
+      ],
+    });
+    expect(body?.contents).toHaveLength(3);
+    expect(body?.contents?.[1]?.role).toBe("model");
+    expect(body?.contents?.[1]?.parts?.map((p) => p.text)).toEqual(["a", "b"]);
+  });
+
+  it("N1: alternating roles produce one Content per message", async () => {
+    let body: { contents?: Array<{ role?: string; parts?: Array<{ text?: string }> }> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({
+      messages: [
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "m1" },
+        { role: "user", content: "u2" },
+      ],
+    });
+    expect(body?.contents).toHaveLength(3);
+  });
+});
+
+// =========================================================================
+// E: Stream accumulation + usage (S5)
+// =========================================================================
+
+describe("google generate-content — stream accumulation", () => {
+  it("P1: multi-chunk text concatenated into accumulated text", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          textChunk("Hello"),
+          textChunk(" "),
+          textChunk("world", {
+            finishReason: "STOP",
+            usage: { promptTokenCount: 4, candidatesTokenCount: 2, totalTokenCount: 6 },
+          }),
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(false);
+    expect(result.content[0]?.text).toBe("Hello world");
+    expect(result.structuredContent.model).toBe(VALID_MODEL);
+    assertNoSecretLeak(result);
+  });
+
+  it("P2: usageMetadata mapped to prompt/completion/total_tokens", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          textChunk("x", {
+            finishReason: "STOP",
+            usage: { promptTokenCount: 7, candidatesTokenCount: 5, totalTokenCount: 12 },
+          }),
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.usage).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 5,
+      total_tokens: 12,
+    });
+  });
+
+  it("N1: chunk with missing text part contributes empty string", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([
+          { candidates: [{ content: { role: "model", parts: [] } }] },
+          textChunk("visible", { finishReason: "STOP" }),
+        ]),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.content[0]?.text).toBe("visible");
+  });
+});
+
+// =========================================================================
+// F: Finish reason mapping (S6, S7)
+// =========================================================================
+
+describe("google generate-content — finishReason mapping", () => {
+  it("P1: STOP → finish_reason 'stop'", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse([textChunk("x", { finishReason: "STOP" })])));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("stop");
+    expect(result.isError).toBe(false);
+  });
+
+  it("P2: MAX_TOKENS → finish_reason 'length'", async () => {
+    server.use(
+      http.post(ENDPOINT, () => sseResponse([textChunk("x", { finishReason: "MAX_TOKENS" })])),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("length");
+  });
+
+  it("P3: SAFETY → isError content_policy", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse([textChunk("", { finishReason: "SAFETY" })])));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("content_policy");
+  });
+
+  it("P4: RECITATION → isError content_policy", async () => {
+    server.use(
+      http.post(ENDPOINT, () => sseResponse([textChunk("", { finishReason: "RECITATION" })])),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("content_policy");
+  });
+
+  it("P5: other reasons pass through lowercased", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse([textChunk("x", { finishReason: "OTHER" })])));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.finish_reason).toBe("other");
+  });
+});
+
+// =========================================================================
+// G: Error Mapping (S8)
+// =========================================================================
+
+describe("google generate-content — error mapping", () => {
+  it("D1: 401 → code 'auth'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "bad key", code: 401 } }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("auth");
+    assertNoSecretLeak(result);
+  });
+
+  it("D2: 403 → code 'auth'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "forbidden", code: 403 } }), {
+            status: 403,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("auth");
+  });
+
+  it("D3: 429 → 'rate_limited'", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "rate", code: 429 } }), {
+            status: 429,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("rate_limited");
+  });
+
+  it("D4: 400 INVALID_ARGUMENT containing 'context' → context_length", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              error: {
+                message: "The input context is too long for the model.",
+                code: 400,
+                status: "INVALID_ARGUMENT",
+              },
+            }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("context_length");
+  });
+
+  it("D5: 400 without 'context' → bad_request", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              error: { message: "malformed payload", code: 400, status: "INVALID_ARGUMENT" },
+            }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("bad_request");
+  });
+
+  it("D6: 500 → upstream_error", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(JSON.stringify({ error: { message: "boom", code: 500 } }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+
+  it("D7: network error → upstream_error", async () => {
+    server.use(http.post(ENDPOINT, () => HttpResponse.error()));
+    const { handler } = makeHandler();
+    const result = await handler({ messages: VALID_MESSAGES });
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+});
+
+// =========================================================================
+// H: Cancellation (S9)
+// =========================================================================
+
+describe("google generate-content — cancellation", () => {
+  it("D1: abort mid-stream → isError upstream_error", async () => {
+    server.use(
+      http.post(
+        ENDPOINT,
+        () =>
+          new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                const enc = new TextEncoder();
+                controller.enqueue(
+                  enc.encode(`data: ${JSON.stringify(textChunk("partial"))}\r\n\r\n`),
+                );
+                // intentionally never closes
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      ),
+    );
+    const { handler } = makeHandler();
+    const ac = new AbortController();
+    const promise = handler({ messages: VALID_MESSAGES }, { signal: ac.signal });
+    await Promise.resolve();
+    ac.abort();
+    const result = await promise;
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.code).toBe("upstream_error");
+  });
+});
+
+// =========================================================================
+// I: Sampling params forwarding (S10)
+// =========================================================================
+
+describe("google generate-content — sampling params forwarding", () => {
+  it("P1: temperature forwarded under generationConfig", async () => {
+    let body: { generationConfig?: Record<string, unknown> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ temperature: 0.4 });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.generationConfig?.temperature).toBe(0.4);
+  });
+
+  it("P2: top_p forwarded as topP under generationConfig", async () => {
+    let body: { generationConfig?: Record<string, unknown> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ top_p: 0.9 });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.generationConfig?.topP).toBe(0.9);
+  });
+
+  it("P3: max_tokens forwarded as maxOutputTokens under generationConfig", async () => {
+    let body: { generationConfig?: Record<string, unknown> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ max_tokens: 256 });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.generationConfig?.maxOutputTokens).toBe(256);
+  });
+
+  it("P4: undefined params omitted from generationConfig", async () => {
+    let body: { generationConfig?: Record<string, unknown> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    const gc = body?.generationConfig ?? {};
+    expect("temperature" in gc).toBe(false);
+    expect("topP" in gc).toBe(false);
+    expect("maxOutputTokens" in gc).toBe(false);
+  });
+});
+
+// =========================================================================
+// J: Stop coercion (S11)
+// =========================================================================
+
+describe("google generate-content — stop coercion to stopSequences", () => {
+  it("P1: stop string 'END' → stopSequences: ['END']", async () => {
+    let body: { generationConfig?: { stopSequences?: unknown } } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ stop: "END" });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.generationConfig?.stopSequences).toEqual(["END"]);
+  });
+
+  it("P2: comma-separated string 'A,B' → stopSequences: ['A','B']", async () => {
+    let body: { generationConfig?: { stopSequences?: unknown } } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ stop: "A,B" });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.generationConfig?.stopSequences).toEqual(["A", "B"]);
+  });
+
+  it("P3: array passed through verbatim", async () => {
+    let body: { generationConfig?: { stopSequences?: unknown } } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler({ stop: ["X", "Y"] });
+    await handler({ messages: VALID_MESSAGES });
+    expect(body?.generationConfig?.stopSequences).toEqual(["X", "Y"]);
+  });
+
+  it("N1: undefined stop → stopSequences omitted", async () => {
+    let body: { generationConfig?: Record<string, unknown> } | undefined;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return sseResponse(defaultOkStream());
+      }),
+    );
+    const { handler } = makeHandler();
+    await handler({ messages: VALID_MESSAGES });
+    expect("stopSequences" in (body?.generationConfig ?? {})).toBe(false);
+  });
+});

--- a/packages/ai-relay/tests/unit/multi-registration.test.ts
+++ b/packages/ai-relay/tests/unit/multi-registration.test.ts
@@ -11,6 +11,10 @@ import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { registerAnthropicMessages } from "../../src/anthropic/messages.js";
+import {
+  makeGoogleGenerateContentHandler,
+  registerGoogleGenerateContent,
+} from "../../src/google/generate-content.js";
 import { makeOpenAIChatHandler, registerOpenAIChat } from "../../src/openai/chat.js";
 import { makeOpenAIResponsesHandler, registerOpenAIResponses } from "../../src/openai/responses.js";
 
@@ -110,6 +114,27 @@ describe("registerOpenAIChat — multi-registration on one McpServer", () => {
         name: "messages",
         apiKey: "key-anthropic",
         model: "claude-sonnet-4-5",
+      });
+    }).not.toThrow();
+  });
+
+  it("P3: registers OpenAI + Anthropic + Google on the same server (three-provider type contract)", () => {
+    const server = new McpServer({ name: "three-provider-test", version: "0.0.1" });
+    expect(() => {
+      registerOpenAIChat(server, {
+        name: "chat-completions",
+        apiKey: "key-openai",
+        model: VALID_MODEL,
+      });
+      registerAnthropicMessages(server, {
+        name: "messages",
+        apiKey: "key-anthropic",
+        model: "claude-sonnet-4-5",
+      });
+      registerGoogleGenerateContent(server, {
+        name: "generate-content",
+        apiKey: "key-google",
+        model: "gemini-2.0-flash",
       });
     }).not.toThrow();
   });
@@ -315,5 +340,75 @@ describe("registerOpenAIChat + registerOpenAIResponses — provider-one API-many
     expect(responsesResult.content[0]?.text).toBe("from-responses");
     expect(chatHits).toBe(1);
     expect(responsesHits).toBe(1);
+  });
+});
+
+describe("makeGoogleGenerateContentHandler — closure isolation across handlers", () => {
+  it("P1: each Google handler routes to its own API key (closure isolation)", async () => {
+    const enc = new TextEncoder();
+    const chunkOk = (text: string): unknown => ({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+    });
+    const sseFor = (text: string) =>
+      new HttpResponse(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(enc.encode(`data: ${JSON.stringify(chunkOk(text))}\r\n\r\n`));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+
+    const seenKeys: string[] = [];
+    const captureKey = (request: Request) => {
+      const url = new URL(request.url);
+      const key = url.searchParams.get("key") ?? request.headers.get("x-goog-api-key") ?? "";
+      if (key) seenKeys.push(key);
+    };
+
+    mswServer.use(
+      http.post(
+        "https://gemini-a.example.com/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+        ({ request }) => {
+          captureKey(request);
+          return sseFor("from-a");
+        },
+      ),
+      http.post(
+        "https://gemini-b.example.com/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+        ({ request }) => {
+          captureKey(request);
+          return sseFor("from-b");
+        },
+      ),
+    );
+
+    const a = makeGoogleGenerateContentHandler({
+      apiKey: "key-google-a",
+      baseURL: "https://gemini-a.example.com/",
+      model: "gemini-2.0-flash",
+    });
+    const b = makeGoogleGenerateContentHandler({
+      apiKey: "key-google-b",
+      baseURL: "https://gemini-b.example.com/",
+      model: "gemini-2.0-flash",
+    });
+
+    const ra = await a.handler({ messages: VALID_MESSAGES });
+    const rb = await b.handler({ messages: VALID_MESSAGES });
+
+    expect(ra.isError).toBe(false);
+    expect(rb.isError).toBe(false);
+    expect(ra.content[0]?.text).toBe("from-a");
+    expect(rb.content[0]?.text).toBe("from-b");
+    expect(seenKeys).toContain("key-google-a");
+    expect(seenKeys).toContain("key-google-b");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.96.0
         version: 0.96.0(zod@4.4.3)
+      '@google/genai':
+        specifier: ^2.5.0
+        version: 2.5.0(@modelcontextprotocol/sdk@1.26.0(zod@4.4.3))
 
 packages:
 
@@ -736,6 +739,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google/genai@2.5.0':
+    resolution: {integrity: sha512-qDi3LLh9I3llJK0f9uV8kZ8EdT9oHPxGJJ9yOJ/i5YXYrVwRCs8jHo9x4e99uOeKYDvD3TZwT70p/H/LS3BixQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -963,6 +975,36 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
   '@redis/bloom@1.2.0':
     resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
     peerDependencies:
@@ -1136,6 +1178,9 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
 
@@ -1175,6 +1220,10 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   agents@0.0.113:
     resolution: {integrity: sha512-PnUjSwFGYMcOWTcewo4NJZqN8gU2u1LFD17OhOzc83LZHa01P2o/qjLOVT338jWPzkPalXTj0RO19s0Lgyl6Ig==}
     peerDependencies:
@@ -1213,12 +1262,21 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1306,6 +1364,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1337,6 +1399,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1420,6 +1485,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1438,9 +1506,17 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1457,6 +1533,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
@@ -1476,6 +1560,14 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1503,6 +1595,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1538,6 +1634,9 @@ packages:
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
@@ -1556,9 +1655,18 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1643,6 +1751,15 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1684,6 +1801,10 @@ packages:
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1728,6 +1849,10 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  protobufjs@7.6.0:
+    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1758,6 +1883,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
@@ -1769,6 +1898,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2018,6 +2150,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2431,6 +2567,19 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@google/genai@2.5.0(@modelcontextprotocol/sdk@1.26.0(zod@4.4.3))':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.0
+      ws: 8.18.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:
       hono: 4.12.15
@@ -2645,6 +2794,28 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@redis/bloom@1.2.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
@@ -2760,6 +2931,8 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/retry@0.12.0': {}
+
   '@types/set-cookie-parser@2.4.10':
     dependencies:
       '@types/node': 25.6.0
@@ -2812,6 +2985,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  agent-base@7.1.4: {}
+
   agents@0.0.113(@cloudflare/workers-types@4.20260507.1):
     dependencies:
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
@@ -2856,6 +3031,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
   blake3-wasm@2.1.5: {}
 
   body-parser@2.2.2:
@@ -2871,6 +3050,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bytes@3.1.2: {}
 
@@ -2941,6 +3122,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2960,6 +3143,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -3121,6 +3308,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-sha256@1.3.0: {}
@@ -3137,6 +3326,11 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -3148,6 +3342,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -3156,6 +3354,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generic-pool@3.9.0: {}
 
@@ -3183,6 +3397,19 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graphql@16.14.0: {}
@@ -3208,6 +3435,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -3230,6 +3464,10 @@ snapshots:
 
   js-base64@3.7.8: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -3247,7 +3485,20 @@ snapshots:
       chalk: 5.6.2
       diff-match-patch: 1.0.5
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   kleur@4.1.5: {}
+
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -3334,6 +3585,14 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -3362,6 +3621,11 @@ snapshots:
       zod: 4.4.3
 
   outvariant@1.4.3: {}
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   parseurl@1.3.3: {}
 
@@ -3396,6 +3660,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  protobufjs@7.6.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.6.0
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3428,6 +3707,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry@0.13.1: {}
 
   rettime@0.11.11: {}
 
@@ -3471,6 +3752,8 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
@@ -3735,6 +4018,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:

--- a/tests/runtime-fixtures/typecheck-bundler/index.ts
+++ b/tests/runtime-fixtures/typecheck-bundler/index.ts
@@ -8,6 +8,8 @@ import type { AnthropicMessagesConfig, AnthropicMessagesResult } from "ai-relay/
 import { makeAnthropicMessagesHandler, registerAnthropicMessages } from "ai-relay/anthropic";
 import { verifyBearer as verifyBearerSub } from "ai-relay/auth";
 import { loadConfig } from "ai-relay/env";
+import type { GoogleGenerateContentConfig, GoogleGenerateContentResult } from "ai-relay/google";
+import { makeGoogleGenerateContentHandler, registerGoogleGenerateContent } from "ai-relay/google";
 import type { OpenAIChatConfig, OpenAIChatResult, ToolDescriptor } from "ai-relay/openai";
 import { makeOpenAIChatHandler, registerOpenAIChat } from "ai-relay/openai";
 
@@ -21,6 +23,10 @@ const _acfg: AnthropicMessagesConfig = { apiKey: "k", model: "claude-sonnet-4-5"
 const _ahandler = makeAnthropicMessagesHandler(_acfg);
 const _aregister: typeof registerAnthropicMessages = registerAnthropicMessages;
 
+const _gcfg: GoogleGenerateContentConfig = { apiKey: "k", model: "gemini-2.0-flash" };
+const _ghandler = makeGoogleGenerateContentHandler(_gcfg);
+const _gregister: typeof registerGoogleGenerateContent = registerGoogleGenerateContent;
+
 const _loaded = loadConfig({ env: { AI_RELAY_API_KEY: "x" } });
 const _providers = _loaded.providers.length;
 
@@ -29,6 +35,20 @@ const _providers = _loaded.providers.length;
 // types referenced so the typecheck has work to do.
 const _result: OpenAIChatResult | undefined = undefined;
 const _aresult: AnthropicMessagesResult | undefined = undefined;
+const _gresult: GoogleGenerateContentResult | undefined = undefined;
 const _tool: ToolDescriptor | undefined = undefined;
 
-export { _ahandler, _aregister, _aresult, _handler, _ok, _providers, _register, _result, _tool };
+export {
+  _ahandler,
+  _aregister,
+  _aresult,
+  _ghandler,
+  _gregister,
+  _gresult,
+  _handler,
+  _ok,
+  _providers,
+  _register,
+  _result,
+  _tool,
+};

--- a/tests/runtime-fixtures/typecheck-nodenext/index.ts
+++ b/tests/runtime-fixtures/typecheck-nodenext/index.ts
@@ -6,6 +6,8 @@ import type { AnthropicMessagesConfig, AnthropicMessagesResult } from "ai-relay/
 import { makeAnthropicMessagesHandler, registerAnthropicMessages } from "ai-relay/anthropic";
 import { verifyBearer as verifyBearerSub } from "ai-relay/auth";
 import { loadConfig } from "ai-relay/env";
+import type { GoogleGenerateContentConfig, GoogleGenerateContentResult } from "ai-relay/google";
+import { makeGoogleGenerateContentHandler, registerGoogleGenerateContent } from "ai-relay/google";
 import type { OpenAIChatConfig, OpenAIChatResult, ToolDescriptor } from "ai-relay/openai";
 import { makeOpenAIChatHandler, registerOpenAIChat } from "ai-relay/openai";
 
@@ -19,11 +21,29 @@ const _acfg: AnthropicMessagesConfig = { apiKey: "k", model: "claude-sonnet-4-5"
 const _ahandler = makeAnthropicMessagesHandler(_acfg);
 const _aregister: typeof registerAnthropicMessages = registerAnthropicMessages;
 
+const _gcfg: GoogleGenerateContentConfig = { apiKey: "k", model: "gemini-2.0-flash" };
+const _ghandler = makeGoogleGenerateContentHandler(_gcfg);
+const _gregister: typeof registerGoogleGenerateContent = registerGoogleGenerateContent;
+
 const _loaded = loadConfig({ env: { AI_RELAY_API_KEY: "x" } });
 const _providers = _loaded.providers.length;
 
 const _result: OpenAIChatResult | undefined = undefined;
 const _aresult: AnthropicMessagesResult | undefined = undefined;
+const _gresult: GoogleGenerateContentResult | undefined = undefined;
 const _tool: ToolDescriptor | undefined = undefined;
 
-export { _ahandler, _aregister, _aresult, _handler, _ok, _providers, _register, _result, _tool };
+export {
+  _ahandler,
+  _aregister,
+  _aresult,
+  _ghandler,
+  _gregister,
+  _gresult,
+  _handler,
+  _ok,
+  _providers,
+  _register,
+  _result,
+  _tool,
+};


### PR DESCRIPTION
Closes #93.

## Summary

Adds Google Gemini as the third provider in the `ai-relay` SDK, following the two-provider pattern established by OpenAI and Anthropic. The new `./google` subpath exposes `registerGoogleGenerateContent`, `makeGoogleGenerateContentHandler`, and `googleGenerateContentTool` — enabling both MCP-host integration (`ai-relay google`) and one-shot CLI dispatch (`ai-relay google generate-content`).

The implementation validates the multi-provider architecture with Gemini's structurally divergent schema: `contents`/`parts` vs the canonical `{ messages }` input. Translation covers system instruction extraction, `assistant→model` role mapping, and consecutive same-role merging (which Gemini rejects). `SAFETY`/`RECITATION` finish reasons surface as `content_policy` errors inside 200 OK responses rather than as HTTP errors — a Gemini-specific path not present in the OpenAI or Anthropic providers.

`@google/genai ^2.0.0` is added as an optional peer dependency. Consumers who only use the `./openai` or `./anthropic` subpaths are unaffected — the peer dep is not required unless `ai-relay/google` is imported.

**Note on retry behavior**: `@google/genai` v2 activates `pRetry` when `retryOptions` is set in `httpOptions`, which changes `ApiError({ status })` into a plain `Error` with statusText — losing the HTTP status code. `retryOptions: { attempts: 1 }` disables this wrapper (1 = original request only). `mapGoogleError` includes dual-path handling: Path A for `ApiError` (future SDK changes) and Path B for pRetry-wrapped message strings.

## Changes

| File | Change |
|---|---|
| `packages/ai-relay/src/google/client.ts` | New — `createGoogleClient` factory with `retryOptions: { attempts: 1 }` |
| `packages/ai-relay/src/google/generate-content.ts` | New — handler, registrar, ToolDescriptor, dual-path error mapper |
| `packages/ai-relay/src/google/index.ts` | New — re-exports for `./google` subpath |
| `packages/ai-relay/src/bin/registry.ts` | Add `"google"` to `ProviderName`, add `google` loader entry |
| `packages/ai-relay/package.json` | Add `./google` exports, `@google/genai ^2.0.0` optional peer dep |
| `packages/ai-relay/tests/unit/google-generate-content.test.ts` | New — 38 MSW-mocked unit tests (21 behaviors + D-retry) |
| `packages/ai-relay/tests/unit/multi-registration.test.ts` | Add 3-provider + Google closure-isolation tests |
| `packages/ai-relay/tests/integration/pack-contract.test.ts` | Validate `./google` subpath under installed-tarball |
| `tests/runtime-fixtures/typecheck-bundler/index.ts` | Exercise `./google` under `moduleResolution=bundler` |
| `tests/runtime-fixtures/typecheck-nodenext/index.ts` | Exercise `./google` under `moduleResolution=nodenext` |
| `pnpm-lock.yaml` | Updated for `@google/genai` dev dep |

## Test plan

- [x] `pnpm test:unit` — **353/353 passed** (unit + integration, all new specs)
  - 38 new tests in `google-generate-content.test.ts` (including D-retry)
  - Google multi-registration + closure-isolation in `multi-registration.test.ts`
  - Pack-contract A2/A3/A4 cover the new `./google` subpath
- [x] Full regression `pnpm test` — **407/407 active tests PASS** (1 pre-existing docker skip, unrelated)
- [x] `pnpm build` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm lint` — 0 errors on new/modified files
- [x] Code review — APPROVED (0 CRITICAL, 0 HIGH; 4 MEDIUM non-blocking, 2 LOW, 1 INFO)
- [ ] MCP Inspector manual verification — `ai-relay google generate-content` with live `AI_RELAY_API_KEY` (post-merge)

## MCP Inspector verification

> N/A for CI — requires a live Gemini API key. Manual checklist to tick before merging:
> - [ ] C1: `generate-content` tool appears in `tools/list`
> - [ ] C2: Happy-path call returns non-empty `content[0].text`
> - [ ] C3: `structuredContent.model` matches `AI_RELAY_MODEL`
> - [ ] C4: `structuredContent.usage` populated
> - [ ] C5: `isError: false` on success
> - [ ] C6: Bearer auth enforced (401 without token)

## v1 non-goal self-check

- [x] No Responses API tools
- [x] No embeddings / image tools
- [x] No OAuth 2.1 authentication
- [x] No rate limiting
- [x] No token/dollar budget counters
- [x] No external observability
- [x] No progress notifications
- [x] No tool/function-calling pass-through

<details>
<summary>Review verdict (APPROVED)</summary>

0 CRITICAL, 0 HIGH. H1 (pRetry status erasure) resolved in commit 57715cb.
Non-blocking: 4 MEDIUM (context_length fallback documented, promptFeedback.blockReason unhandled, JSDoc default note, logger asymmetry), 2 LOW, 1 INFO.

</details>

<details>
<summary>TIA — 55 affected tests / 407 full suite</summary>

| Spec | Tests | Result |
|------|-------|--------|
| `tests/unit/google-generate-content.test.ts` | 38 | ✅ PASS |
| `tests/unit/multi-registration.test.ts` | 8 | ✅ PASS |
| `tests/integration/pack-contract.test.ts` | 6 | ✅ PASS |
| `tests/unit/exports.test.ts` (transitive) | 3 | ✅ PASS |

Full regression: 407/407 active tests PASS.

</details>

🤖 Implemented via `/dev 93` pipeline.
